### PR TITLE
ci: Upload component using a Github OIDC Token

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   upload_components:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,4 +20,3 @@ jobs:
         with:
           components: "esp-openclaw-node:components/esp-openclaw-node"
           namespace: "espressif"
-          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
This MR updates upload of the component to use GitHub OIDC Token instead of the ESP Component Registry API Token

<img width="1517" height="137" alt="image" src="https://github.com/user-attachments/assets/f241ece0-7f48-4576-89ef-f9a678d82064" />

</br>

* Closes PACMAN-1277