### PR TITLE
feat(room-node): ambient wake, double-buffered panel, safe area, and on-device diagnostics

### DIFF
--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
@@ -33,7 +33,13 @@ The first setup-code handshake stores two role-keyed device tokens against one h
 
 WakeNet remains active while playback is running and consumes the AEC-cleaned capture stream. A wake starts one client-owned WebRTC Talk session; the media peer connects directly to the configured provider while OpenClaw owns provider credentials and agent delegation. Calls close after the configured maximum lifetime, and another wake can start a new call.
 
-Canvas mode uses a separate 410x502 LVGL screen at 80% brightness. Hiding it returns to the status screen and the normal AMOLED-off idle policy. Talk state changes do not replace active Canvas content; a small status pill appears in the top-right corner until Talk returns to idle.
+Canvas mode uses a separate 410x502 LVGL screen at 80% brightness. Hiding it returns to the status screen; a user-initiated exit leaves a readable hint rather than dropping straight to the AMOLED-off idle policy. Talk state changes do not replace active Canvas content; a small status pill appears at the top-center until Talk returns to idle.
+
+**Safe area.** The glass has large rounded corners, so laid-out content (A2UI, placeholder, test card) is inset 32 px — the same idea as Apple's safe area. Presented images are intentionally full-bleed, like wallpaper.
+
+**On-device controls.** Tapping the screen or pressing the BOOT button cycles status, a safe-area test card, and a solid fill. The test card draws a border exactly on the safe-area inset with markers at its corners; the solid fill has no content variation, so together they separate panel/transfer artifacts from rendering artifacts without a serial console. The PWR button is hardware power management and is not GPIO-visible.
+
+**Display buffers.** LVGL renders into two internal DMA-capable chunk buffers owned by this example rather than the BSP default. The BSP buffer comes from the default heap and lands in PSRAM, which this QSPI panel cannot DMA from; esp_lcd then bounce-buffers every flush through a fresh internal allocation that fails once Wi-Fi/TLS and audio claim internal RAM, silently dropping flushes. Two buffers also keep the renderer off memory the panel is still transmitting.
 
 ## Canvas commands
 

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
@@ -2,7 +2,7 @@
 
 This example turns the watch-shaped Waveshare development board into a USB-powered, always-on OpenClaw room node. The straps are irrelevant; the firmware runs continuously with the AMOLED fully dark while idle.
 
-It uses the maintained Waveshare BSP, the board's ES7210 microphone codec and ES8311 speaker codec, a 24 kHz stereo I2S path, Espressif's AEC capture source, and Espressif WebRTC. The AEC source's AFE pipeline loads WakeNet 9 (**Hi ESP**, `wn9_hiesp`) internally, but esp_capture does not yet surface its detections, and a second esp-sr WakeNet instance aborts inside the closed library on hardware — so ambient wake is currently disabled; start Talk with the console `wake` command (or wire AFE wake events through esp_capture, the tracked follow-up). Gateway `voicewake.changed` events are observed, but an arbitrary text trigger cannot replace a compiled local WakeNet model.
+It uses the maintained Waveshare BSP, the board's ES7210 microphone codec and ES8311 speaker codec, a 24 kHz stereo I2S path, Espressif's AEC capture source, and Espressif WebRTC. Ambient **Hi ESP** wake works through the WakeNet 9 (`wn9_hiesp`) instance already owned by the AFE; the firmware never creates the second esp-sr WakeNet instance that aborts inside the closed library on this hardware. Because esp_capture 1.0.2 does not expose AFE wake events, this example vendors its AEC source compilation unit and private-header closure in `main/`, adding the wake callback locally. That callback should move upstream and the vendored files should be dropped once esp_capture exposes detections. Gateway `voicewake.changed` events are observed, but an arbitrary text trigger cannot replace a compiled local WakeNet model.
 
 ## Build and provision
 
@@ -21,7 +21,7 @@ openclaw> gateway setup-code <code from `openclaw qr --voice-node --setup-code-o
 openclaw> status
 ```
 
-Wi-Fi credentials and the paired gateway session persist in NVS, so re-pairing to a different gateway later is one `gateway setup-code` away — no rebuild. `wake` simulates the wake phrase for a Talk smoke test without speaking.
+Wi-Fi credentials and the paired gateway session persist in NVS, so re-pairing to a different gateway later is one `gateway setup-code` away — no rebuild. The console `wake` command remains available to simulate the wake phrase for a Talk smoke test without speaking.
 
 Kconfig provisioning still works for fleet builds: `idf.py menuconfig` under **OpenClaw room node** can bake Wi-Fi credentials and a setup code; baked Wi-Fi credentials seed NVS only while no console-set credentials exist. Leave provider/model/voice empty to use the Gateway Talk configuration, or set a model such as `gpt-live-1-codex` when the Gateway's OpenAI provider has access. GPT-Live also needs the Gateway HTTPS origin that corresponds to the setup code's `wss://` endpoint; this field is intentionally empty by default because its one-use Talk credential and SDP must not silently cross the LAN over plaintext HTTP.
 

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/CMakeLists.txt
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
     SRCS
         "main.c"
+        "room_aec_src.c"
         "room_canvas.c"
         "room_canvas_node_cmd.c"
         "room_media.c"

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_mem.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_mem.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#pragma once
+
+#include "esp_gmf_oal_mem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**
+ * @brief  Memory management functions
+ *
+ * @note  These functions are wrappers around the GMF OAL memory management functions
+ *        They provide a consistent interface for memory allocation and deallocation
+ */
+
+#define capture_malloc(size)       esp_gmf_oal_malloc(size)
+#define capture_free(ptr)          esp_gmf_oal_free(ptr)
+#define capture_calloc(n, size)    esp_gmf_oal_calloc(n, size)
+#define capture_realloc(ptr, size) esp_gmf_oal_realloc(ptr, size)
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_os.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_os.h
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "capture_mem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**
+ * @brief  Event group handle type
+ */
+typedef void *capture_event_grp_handle_t;
+
+/**
+ * @brief  Maximum lock time value (infinite wait)
+ */
+#define CAPTURE_MAX_LOCK_TIME 0xFFFFFFFF
+
+/**
+ * @brief  Convert milliseconds to FreeRTOS ticks
+ */
+#define CAPTURE_TIME_TO_TICKS(ms) (ms == CAPTURE_MAX_LOCK_TIME ? portMAX_DELAY : ms / portTICK_PERIOD_MS)
+
+/**
+ * @brief  Event group management functions
+ *
+ * @note  These functions provide a wrapper around FreeRTOS event group functions
+ *        for event synchronization and signaling
+ */
+#define capture_event_group_create(event_group)         *event_group = (capture_event_grp_handle_t)xEventGroupCreate()
+#define capture_event_group_set_bits(event_group, bits) xEventGroupSetBits((EventGroupHandle_t)event_group, bits)
+#define capture_event_group_clr_bits(event_group, bits) xEventGroupClearBits((EventGroupHandle_t)event_group, bits)
+
+/**
+ * @brief  Wait for bits (in milliseconds) to be set in an event group
+ */
+#define capture_event_group_wait_bits(event_group, bits, timeout) \
+    (uint32_t) xEventGroupWaitBits((EventGroupHandle_t)event_group, bits, false, true, CAPTURE_TIME_TO_TICKS(timeout))
+
+#define capture_event_group_destroy(event_group) vEventGroupDelete((EventGroupHandle_t)event_group)
+
+/**
+ * @brief  Mutex handle type
+ */
+typedef void *capture_mutex_handle_t;
+
+/**
+ * @brief  Mutex management functions
+ *
+ * @note  These functions provide a wrapper around FreeRTOS recursive mutex functions
+ */
+#define capture_mutex_create(mutex) *mutex = (capture_mutex_handle_t)xSemaphoreCreateRecursiveMutex()
+
+#define capture_mutex_lock(mutex, timeout) \
+    xSemaphoreTakeRecursive((SemaphoreHandle_t)mutex, CAPTURE_TIME_TO_TICKS(timeout))
+
+#define capture_mutex_unlock(mutex) xSemaphoreGiveRecursive((SemaphoreHandle_t)mutex)
+
+#define capture_mutex_destroy(mutex) vSemaphoreDelete((SemaphoreHandle_t)mutex)
+
+/**
+ * @brief  Sleep for specified milliseconds
+ */
+#define capture_sleep(ms) vTaskDelay(ms / portTICK_PERIOD_MS)
+
+/**
+ * @brief  Semaphore handle type
+ */
+typedef void *capture_sema_handle_t;
+
+/**
+ * @brief  Semaphore management functions
+ *
+ * @note  These functions provide a wrapper around FreeRTOS counting semaphore functions
+ */
+#define capture_sema_create(sema) *sema = (capture_sema_handle_t)xSemaphoreCreateCounting(1, 0)
+
+#define capture_sema_lock(sema, timeout) \
+    xSemaphoreTake((SemaphoreHandle_t)sema, CAPTURE_TIME_TO_TICKS(timeout));
+
+#define capture_sema_unlock(sema) xSemaphoreGive((SemaphoreHandle_t)sema)
+
+#define capture_sema_destroy(sema) vSemaphoreDelete((SemaphoreHandle_t)sema)
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_thread.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_thread.h
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#pragma once
+
+#include "esp_capture.h"
+#include "capture_os.h"
+#include "esp_attr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**
+ * @brief  Default scheduler for capture
+ */
+#define CAPTURE_DEFAULT_SCHEDULER() {                     \
+    .priority = 5, .stack_size = 4096, .stack_in_ext = 1, \
+}
+
+/**
+ * @brief  Thread handle type
+ */
+typedef void *capture_thread_handle_t;
+
+/**
+ * @brief  Capture synchronized call argument
+ */
+typedef struct {
+    int                    ret;                 /*!< Function return value */
+    int                    (*body)(void *arg);  /*!< Function body */
+    void                  *arg;                 /*!< Function argument */
+    capture_sema_handle_t  sema;                /*!< Lock to wait for function return */
+} capture_thread_sync_run_arg_t;
+
+/**
+ * @brief  Define for running a function in another thread and wait for its return
+ *
+ * @note  This define specially for some API must run on RAM stack but the running task is on PSRAM
+ *        Running task may need huge stack, if user not want to change the whole task stack into PSRAM
+ *        Can run the special API in RAM stack, wait for finished and continue with left part
+ */
+#define CAPTURE_RUN_SYNC_IN_RAM(name, body_func, arg_info, ret, _stack_size)                     \
+    do {                                                                                         \
+        esp_capture_thread_schedule_cfg_t cur_cfg = CAPTURE_DEFAULT_SCHEDULER();                 \
+        capture_thread_get_scheduler_cfg(NULL, &cur_cfg);                                        \
+        if (capture_thread_is_stack_in_ram()) {                                                  \
+            ret = body_func(arg_info);                                                           \
+            break;                                                                               \
+        }                                                                                        \
+        capture_thread_sync_run_arg_t _arg = {                                                   \
+            .body = body_func,                                                                   \
+            .arg = arg_info,                                                                     \
+        };                                                                                       \
+        capture_sema_create(&_arg.sema);                                                         \
+        if (_arg.sema == NULL) {                                                                 \
+            ret = ESP_CAPTURE_ERR_NO_RESOURCES;                                                  \
+            break;                                                                               \
+        }                                                                                        \
+        cur_cfg.stack_in_ext = false;                                                            \
+        cur_cfg.stack_size = _stack_size;                                                        \
+        capture_thread_handle_t _sync_thread = NULL;                                             \
+        capture_thread_create(&_sync_thread, name, &cur_cfg, capture_thread_run_in_ram, &_arg);  \
+        if (_sync_thread) {                                                                      \
+            capture_sema_lock(_arg.sema, CAPTURE_MAX_LOCK_TIME);                                 \
+            ret = _arg.ret;                                                                      \
+        } else {                                                                                 \
+            ret = ESP_CAPTURE_ERR_NO_RESOURCES;                                                  \
+        }                                                                                        \
+        capture_sema_destroy(_arg.sema);                                                         \
+    } while (0);
+
+/**
+ * @brief  Helper function for synchronized function call
+ *
+ * @param[in]  arg  Pointer to `capture_thread_sync_run_arg_t`
+ */
+IRAM_ATTR void capture_thread_run_in_ram(void *arg);
+
+/**
+ * @brief  Check whether thread stack is in ram
+ *
+ * @return
+ *       - true   Thread stack is in internal ram
+ *       - false  Thread stack is in PSRAM
+ */
+bool capture_thread_is_stack_in_ram(void);
+
+/**
+ * @brief  Set thread scheduler callback
+ *
+ * @param[in]  thread_scheduler  Thread scheduler callback function
+ */
+void capture_thread_set_scheduler(esp_capture_thread_scheduler_cb_t thread_scheduler);
+
+/**
+ * @brief  Get thread scheduler callback
+ *
+ * @return
+ */
+esp_capture_thread_scheduler_cb_t capture_thread_get_scheduler(void);
+
+/**
+ * @brief  Create a thread using the scheduler
+ *
+ * @param[out]  handle  Pointer to store the thread handle
+ * @param[in]   name    Thread name
+ * @param[in]   body    Thread function
+ * @param[in]   arg     Thread function argument
+ *
+ * @return
+ *       - 0       Thread created successfully
+ *       - Others  Failed to create thread
+ */
+int capture_thread_create_from_scheduler(capture_thread_handle_t *handle, const char *name,
+                                         void (*body)(void *arg), void *arg);
+
+/**
+ * @brief  Get scheduler configuration for created thread
+ *
+ * @param[in]   name  Thread name
+ * @param[out]  cfg   Thread scheduler configuration
+ */
+void capture_thread_get_scheduler_cfg(const char *name, esp_capture_thread_schedule_cfg_t *cfg);
+
+/**
+ * @brief  Create a thread using schedule configuration
+ *
+ * @param[out]  handle  Pointer to store the thread handle
+ * @param[in]   name    Thread name
+ * @param[in]   cfg     Scheduler configuration
+ * @param[in]   body    Thread function
+ * @param[in]   arg     Thread function argument
+ *
+ * @return
+ *       - 0       Thread created successfully
+ *       - Others  Failed to create thread
+ */
+int capture_thread_create(capture_thread_handle_t *handle, const char *name, esp_capture_thread_schedule_cfg_t *cfg,
+                          void (*body)(void *arg), void *arg);
+
+/**
+ * @brief  Destroy a thread
+ *
+ * @param[in]  thread  Thread handle
+ */
+void capture_thread_destroy(capture_thread_handle_t thread);
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_utils.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/capture_utils.h
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#pragma once
+
+#include "esp_capture_types.h"
+#include "capture_os.h"
+#include "capture_thread.h"
+#include "capture_mem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+#define CAPTURE_CHECK_MEM(ptr, reason) if (ptr == NULL) {  \
+    ESP_LOGE(TAG, "No enough memory for" reason);          \
+}
+
+#define CAPTURE_CHECK_MEM_RET(ptr, reason, ret) if (ptr == NULL) {  \
+    ESP_LOGE(TAG, "No enough memory for" reason);                   \
+    return ret;                                                     \
+}
+
+#define CAPTURE_VERIFY_PTR(ptr, reason) if ((ptr) == NULL) {  \
+    ESP_LOGE(TAG, "Invalid argument for" reason);             \
+}
+
+#define CAPTURE_VERIFY_PTR_RET(ptr, reason) if ((ptr) == NULL) {  \
+    ESP_LOGE(TAG, "Invalid argument of" reason);                  \
+    return ESP_CAPTURE_ERR_INVALID_ARG;                           \
+}
+
+#define CAPTURE_LOG_ON_ERR(ret, reason, ...) if (ret != ESP_CAPTURE_ERR_OK) {  \
+    ESP_LOGE(TAG, reason, ##__VA_ARGS__);                                      \
+}
+
+#define CAPTURE_SAFE_FREE(ptr) if (ptr) {  \
+    capture_free(ptr);                     \
+}
+
+#define CAPTURE_BREAK_SET_RETURN(ret, ret_val) {  \
+    ret = ret_val;                                \
+    break;                                        \
+}
+
+#define CAPTURE_BREAK_ON_ERR(statement) if ((statement) != 0) {  \
+    break;                                                       \
+}
+
+#define CAPTURE_RETURN_ON_FAIL(ret) if (ret != 0) {  \
+    return ret;                                      \
+}
+
+#define CAPTURE_SAFE_STR(str) ((str) ? (str) : "")
+
+#define CAPTURE_ELEMS(array) (sizeof(array) / sizeof(array[0]))
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -6,6 +6,7 @@
 #include "esp_console.h"
 #include "esp_event.h"
 #include "esp_check.h"
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_openclaw_node.h"
@@ -16,6 +17,8 @@
 #include "esp_peer_default.h"
 #include "esp_webrtc.h"
 #include "esp_capture.h"
+#include "driver/gpio.h"
+#include "freertos/idf_additions.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/timers.h"
@@ -49,6 +52,50 @@ typedef struct {
 } talk_teardown_request_t;
 
 static void start_operator_task(void *arg);
+static void start_talk_once(void);
+static TaskHandle_t talk_start_worker;
+
+/*
+ * The Talk starter is a persistent worker created at boot, when internal RAM
+ * is plentiful: creating an 8 KiB-stack task at wake time fails under load
+ * and surfaced as an on-screen "No memory" error.
+ */
+/*
+ * The BOOT side button (GPIO0, strapping pin, pressed = low) cycles the debug
+ * views like a status-screen tap. The PWR button is wired to hardware power
+ * management and is not GPIO-visible.
+ */
+static void boot_button_task(void *arg)
+{
+    (void)arg;
+    gpio_config_t io = {
+        .pin_bit_mask = 1ULL << GPIO_NUM_0,
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+    };
+    if (gpio_config(&io) != ESP_OK) {
+        vTaskDelete(NULL);
+        return;
+    }
+    bool was_pressed = false;
+    for (;;) {
+        bool pressed = gpio_get_level(GPIO_NUM_0) == 0;
+        if (pressed && !was_pressed) {
+            room_canvas_debug_toggle();
+        }
+        was_pressed = pressed;
+        vTaskDelay(pdMS_TO_TICKS(60));
+    }
+}
+
+static void talk_start_worker_task(void *arg)
+{
+    (void)arg;
+    for (;;) {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        start_talk_once();
+    }
+}
 
 static char *gateway_http_base_from_uri(const char *gateway_uri)
 {
@@ -273,6 +320,7 @@ static void talk_teardown_task(void *arg)
         }
         xTimerStop(talk_timeout_timer, portMAX_DELAY);
         esp_webrtc_close(request.session);
+        (void)room_media_set_ambient_wake(true);
         room_ui_set(
             request.failed ? ROOM_UI_ERROR : ROOM_UI_IDLE,
             request.failed ? "Talk failed" : NULL);
@@ -320,9 +368,8 @@ static int webrtc_event(esp_webrtc_event_t *event, void *ctx)
     return 0;
 }
 
-static void start_talk_task(void *arg)
+static void start_talk_once(void)
 {
-    (void)arg;
     esp_peer_default_cfg_t peer = {
         .agent_recv_timeout = 500,
         .ice_use_lite_mode = true,
@@ -360,7 +407,6 @@ static void start_talk_task(void *arg)
         talk_starting = false;
         xSemaphoreGive(state_lock);
         room_ui_set(ROOM_UI_ERROR, "WebRTC open");
-        vTaskDelete(NULL);
         return;
     }
     esp_webrtc_media_provider_t media = {0};
@@ -373,7 +419,6 @@ static void start_talk_task(void *arg)
         talk_starting = false;
         xSemaphoreGive(state_lock);
         room_ui_set(ROOM_UI_ERROR, "WebRTC start");
-        vTaskDelete(NULL);
         return;
     }
 
@@ -385,18 +430,17 @@ static void start_talk_task(void *arg)
     xSemaphoreGive(state_lock);
     if (!publish) {
         esp_webrtc_close(session);
-        vTaskDelete(NULL);
         return;
     }
+    /* Talk owns the capture pipeline for the call; ambient scanning resumes at teardown. */
+    (void)room_media_set_ambient_wake(false);
     if (esp_webrtc_start(session) != 0) {
         request_talk_teardown(session, true);
-        vTaskDelete(NULL);
         return;
     }
     if (xTimerStart(talk_timeout_timer, 0) != pdPASS) {
         request_talk_teardown(session, true);
     }
-    vTaskDelete(NULL);
 }
 
 static void on_wake(const char *wake_word, void *ctx)
@@ -413,12 +457,7 @@ static void on_wake(const char *wake_word, void *ctx)
         return;
     }
     room_ui_set(ROOM_UI_CONNECTING, wake_word);
-    if (xTaskCreate(start_talk_task, "start_talk", 8192, NULL, 7, NULL) != pdPASS) {
-        xSemaphoreTake(state_lock, portMAX_DELAY);
-        talk_starting = false;
-        xSemaphoreGive(state_lock);
-        room_ui_set(ROOM_UI_ERROR, "No memory");
-    }
+    xTaskNotifyGive(talk_start_worker);
 }
 
 static void operator_gateway_event(
@@ -707,6 +746,17 @@ void app_main(void)
         state_lock != NULL && talk_teardown_queue != NULL && talk_timeout_timer != NULL
             ? ESP_OK
             : ESP_ERR_NO_MEM);
+    /* Supervisor stacks live in PSRAM; internal RAM is reserved for DMA and the
+     * network/audio task stacks that genuinely require it. */
+    BaseType_t starter_task = xTaskCreateWithCaps(
+        talk_start_worker_task,
+        "talk_start",
+        8192,
+        NULL,
+        7,
+        &talk_start_worker,
+        MALLOC_CAP_SPIRAM);
+    ESP_ERROR_CHECK(starter_task == pdPASS ? ESP_OK : ESP_ERR_NO_MEM);
     BaseType_t teardown_task = xTaskCreate(
         talk_teardown_task,
         "talk_teardown",
@@ -745,6 +795,16 @@ void app_main(void)
 
     ESP_ERROR_CHECK(start_node_client());
     ESP_ERROR_CHECK(esp_openclaw_node_example_repl_start(node_client));
+    if (xTaskCreateWithCaps(
+            boot_button_task,
+            "boot_btn",
+            2560,
+            NULL,
+            4,
+            NULL,
+            MALLOC_CAP_SPIRAM) != pdPASS) {
+        ESP_LOGW(TAG, "BOOT button task unavailable");
+    }
     ESP_ERROR_CHECK(register_wake_console_command());
 
     esp_err_t connect_err = request_node_connection();
@@ -757,5 +817,10 @@ void app_main(void)
         ESP_LOGE(TAG, "node connect request failed: %s", esp_err_to_name(connect_err));
         room_ui_set(ROOM_UI_ERROR, "Node connect");
     }
-    ESP_LOGI(TAG, "room node ready; canvas commands become available after pairing");
+    ESP_LOGI(
+        TAG,
+        "room node ready; internal heap free=%u largest=%u, psram free=%u",
+        (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+        (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+        (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
 }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/msg_q.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/msg_q.h
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  /* __cplusplus */
+
+/**
+ * @brief  Message queue handle
+ */
+typedef struct msg_q_t *msg_q_handle_t;
+
+/**
+ * @brief  Create message queue
+ *
+ * @param[in]   msg_number  The maximum number of messages in the queue
+ * @param[out]  msg_size    Message size
+ *
+ * @return
+ *       - NULL    No resource to create message queue
+ *       - Others  Message queue handle
+ */
+msg_q_handle_t msg_q_create(int msg_number, int msg_size);
+
+/**
+ * @brief  Send message to queue
+ *
+ * @param[in]  q     Message queue handle
+ * @param[in]  msg   Message to be inserted into queue
+ * @param[in]  size  Message size, need not larger than msg_size when created
+ *
+ * @return
+ *       - 0   On success
+ *       - -1  On failure
+ */
+int msg_q_send(msg_q_handle_t q, void *msg, int size);
+
+/**
+ * @brief  Receive message from queue
+ *
+ * @param[in]   q        Message queue handle
+ * @param[out]  msg      Message to be inserted into queue
+ * @param[in]   size     Message size, need not larger than msg_size when created
+ * @param[in]   no_wait  If true, return immediately if no message in queue
+ *
+ * @return
+ *       - 0   On success
+ *       - -1  On failure
+ *       - 1   If no message in queue and no_wait is true
+ */
+int msg_q_recv(msg_q_handle_t q, void *msg, int size, bool no_wait);
+
+/**
+ * @brief  Get items number in message queue
+ *
+ * @param[in]  q  Message queue handle
+ *
+ * @return
+ *       - 0       No message in queue
+ *       - Others  Current queued items number
+ */
+int msg_q_number(msg_q_handle_t q);
+
+/**
+ * @brief  Wakeup message queue
+ *
+ * @param[in]  q  Message queue handle
+ *
+ * @return
+ *       - 0   On success
+ *       - -1  On failure
+ */
+int msg_q_wakeup(msg_q_handle_t q);
+
+/**
+ * @brief  Destroy message queue
+ *
+ * @param[in]  q  Message queue handle
+ */
+void msg_q_destroy(msg_q_handle_t q);
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_aec_src.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_aec_src.c
@@ -1,0 +1,730 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO., LTD
+ * SPDX-License-Identifier: LicenseRef-Espressif-Modified-MIT
+ *
+ * See LICENSE file for details.
+ */
+
+/*
+ * Copied from espressif/esp_capture v1.0.2 because upstream does not surface
+ * AFE wake events. The wake callback should be upstreamed and this copy
+ * dropped once esp_capture exposes those detections.
+ */
+
+#include <sdkconfig.h>
+#include <string.h>
+#if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4 || CONFIG_IDF_TARGET_ESP32S31
+#include "esp_capture_types.h"
+#include "esp_capture_audio_src_if.h"
+#include "esp_codec_dev.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "esp_aec.h"
+#include "esp_gmf_data_queue.h"
+#include "capture_utils.h"
+#include "esp_afe_sr_iface.h"
+#include "esp_vadn_iface.h"
+#include "esp_afe_sr_models.h"
+#include "esp_vad.h"
+#include "msg_q.h"
+#include "room_aec_src.h"
+
+#define TAG  "AUD_AEC_SRC"
+
+#define VAD_CACHE_BLOCK   (3)
+#define VAD_SILENT_BLOCK  (20)
+#define DUMP_STOP_IDX     (2)
+#define AFE_RUN_STACK     (8192)
+#define WAKE_DEBOUNCE_US  (2 * 1000 * 1000)
+#define VALID_ON_VAD      // Turn on to not send data if VAD not active or else send silent data
+// #define DUMP_AFE_DATA  // Enable this define to allow dump AFE input and output to file
+#define WAIT_STATE_TIMEOUT(state) do {                    \
+    int _wait_time_out = 1000;                            \
+    while (state) {                                       \
+        capture_sleep(10);                                \
+        _wait_time_out -= 10;                             \
+        if (_wait_time_out == 0) {                        \
+            ESP_LOGE(TAG, "Wait for" #state "timeout");   \
+            break;                                        \
+        }                                                 \
+    }                                                     \
+} while (0);
+
+typedef enum {
+    VAD_CHECKING_DETECTING,
+    VAD_CHECKING_STARTED,
+    VAD_CHECKING_ENDED,
+} vad_checking_state_t;
+
+typedef struct {
+    esp_vadn_iface_t     *vadnet;
+    model_iface_data_t   *vad_model;
+    uint8_t              *vad_working_buf;
+    uint8_t               vad_channel;
+    uint8_t               vad_filled_block;
+    uint8_t               silent_block;
+    esp_gmf_data_queue_t *in_q;
+    msg_q_handle_t        vad_q;
+    uint8_t               vad_duration;
+    vad_checking_state_t  vad_state;
+    bool                  dev_src_running;
+} audio_aec_vad_res_t;
+
+typedef struct {
+    esp_capture_audio_src_if_t  base;
+    const char                 *mic_layout;
+    uint8_t                     channel;
+    uint8_t                     channel_mask;
+    bool                        data_on_vad;
+    esp_codec_dev_handle_t      handle;
+    esp_capture_audio_info_t    info;
+    uint64_t                    samples;
+    uint8_t                    *cached_frame;
+    int                         cached_read_pos;
+    int                         cache_size;
+    int                         cache_fill;
+    uint8_t                     start        : 1;
+    uint8_t                     open         : 1;
+    uint8_t                     in_quit      : 1;
+    uint8_t                     in_error     : 1;
+    uint8_t                     stopping     : 1;
+    bool                        wait_feeding : 1;
+    const esp_afe_sr_iface_t   *afe_handle;
+    esp_afe_sr_data_t          *afe_data;
+    srmodel_list_t             *models;
+    audio_aec_vad_res_t        *vad_res;
+    void                      (*wake_cb)(void *ctx);
+    void                       *wake_ctx;
+} audio_aec_src_t;
+
+static int64_t last_wake_callback_us;
+
+static int open_afe_in_ram(void *arg)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)arg;
+    esp_capture_err_t ret = ESP_CAPTURE_ERR_OK;
+    do {
+        src->models = esp_srmodel_init("model");
+        if (src->models == NULL) {
+            ESP_LOGW(TAG, "No model to load");
+        }
+        afe_config_t *afe_config = afe_config_init(src->mic_layout, src->models, AFE_TYPE_SR, AFE_MODE_LOW_COST);
+        if (afe_config == NULL) {
+            ESP_LOGE(TAG, "Failed to create AFE config");
+            ret = ESP_CAPTURE_ERR_NO_MEM;
+            break;
+        }
+        // When data_on_vad turn on VAD process before AFE disable it
+        if (src->data_on_vad) {
+            afe_config->vad_init = false;
+        }
+        src->afe_handle = esp_afe_handle_from_config(afe_config);
+        if (src->afe_handle == NULL) {
+            ESP_LOGE(TAG, "Failed to create AFE handle");
+            ret = ESP_CAPTURE_ERR_NOT_SUPPORTED;
+            afe_config_free(afe_config);
+            break;
+        }
+        src->afe_data = src->afe_handle->create_from_config(afe_config);
+        afe_config_free(afe_config);
+        if (src->afe_data == NULL) {
+            ESP_LOGE(TAG, "Failed to create AFE data");
+            ret = ESP_CAPTURE_ERR_NOT_SUPPORTED;
+            break;
+        }
+    } while (0);
+    return ret;
+}
+
+static esp_capture_err_t open_afe(audio_aec_src_t *src)
+{
+    esp_capture_err_t ret = ESP_CAPTURE_ERR_OK;
+    CAPTURE_RUN_SYNC_IN_RAM("afe_open", open_afe_in_ram, src, ret, AFE_RUN_STACK);
+    return ret;
+}
+
+static esp_capture_err_t audio_aec_src_open(esp_capture_audio_src_if_t *h)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)h;
+    if (src->handle == NULL) {
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    src->samples = 0;
+    src->open = true;
+    return ESP_CAPTURE_ERR_OK;
+}
+
+static esp_capture_err_t audio_aec_src_get_support_codecs(esp_capture_audio_src_if_t *src, const esp_capture_format_id_t **codecs, uint8_t *num)
+{
+    static esp_capture_format_id_t support_codecs[] = {ESP_CAPTURE_FMT_ID_PCM};
+    *codecs = support_codecs;
+    *num = 1;
+    return ESP_CAPTURE_ERR_OK;
+}
+
+static esp_capture_err_t audio_aec_src_negotiate_caps(esp_capture_audio_src_if_t *h, esp_capture_audio_info_t *in_cap, esp_capture_audio_info_t *out_caps)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)h;
+    // Only support 1 channel 16bits PCM
+    if (in_cap->format_id != ESP_CAPTURE_FMT_ID_PCM) {
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    if (in_cap->sample_rate == 8000) {
+        out_caps->sample_rate = 8000;
+    } else {
+        out_caps->sample_rate = 16000;
+    }
+    out_caps->channel = 1;
+    out_caps->bits_per_sample = 16;
+    out_caps->format_id = ESP_CAPTURE_FMT_ID_PCM;
+    src->info = *out_caps;
+    return ESP_CAPTURE_ERR_OK;
+}
+
+static uint8_t get_src_channel(audio_aec_src_t *src)
+{
+    uint8_t ch = src->channel;
+    if (src->channel_mask) {
+        ch = __builtin_popcount(src->channel_mask);
+    }
+    return ch;
+}
+
+static void dump_data(uint8_t type, void *data, int size)
+{
+#ifdef DUMP_AFE_DATA
+    static FILE *fp[DUMP_STOP_IDX];
+    static uint8_t dump_count = 0;
+    if (type == DUMP_STOP_IDX) {
+        for (int i = 0; i < DUMP_STOP_IDX; i++) {
+            if (fp[i]) {
+                fclose(fp[i]);
+                fp[i] = NULL;
+            }
+        }
+        dump_count++;
+        if (dump_count > 9) {
+            dump_count = 0;
+        }
+        return;
+    }
+    if (size == 0) {
+        return;
+    }
+    if (fp[type] == NULL) {
+        char *pre_name[] = {"feed", "fetch"};
+        char file_name[20];
+        snprintf(file_name, sizeof(file_name), "/sdcard/%s%d.bin", pre_name[type], dump_count);
+        fp[type] = fopen(file_name, "wb");
+        if (fp[type]) {
+            ESP_LOGI(TAG, "dump to %s", file_name);
+        }
+    }
+    if (fp[type]) {
+        fwrite(data, size, 1, fp[type]);
+    }
+#endif
+}
+
+static inline void audio_aec_fill_vad_working_buf(audio_aec_src_t *src, uint8_t *feed_data, int feed_size)
+{
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    uint8_t src_channel = get_src_channel(src);
+    int16_t *src_pcm = (int16_t *)feed_data;
+    int16_t *dst_pcm = (int16_t *)vad_res->vad_working_buf;
+    int16_t *end = (int16_t *)(feed_data + feed_size);
+    src_pcm += vad_res->vad_channel;
+    while (src_pcm < end) {
+        *(dst_pcm++) = *src_pcm;
+        src_pcm += src_channel;
+    }
+}
+
+static int audio_aec_feed_data(audio_aec_src_t *src, uint8_t *feed_data, int feed_size)
+{
+    int ret = src->afe_handle->feed(src->afe_data, (int16_t *)feed_data);
+    dump_data(0, feed_data, feed_size);
+    return ret;
+}
+
+static int audio_aec_read_by_vad(audio_aec_src_t *src, int read_size)
+{
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    int ret = 0;
+    uint8_t *feed_data = NULL;
+    if (vad_res->vad_state == VAD_CHECKING_STARTED) {
+        if (vad_res->vad_filled_block > 0) {
+            // Send vad detection cache firstly
+            esp_gmf_data_queue_acquire_read(vad_res->in_q, (void **)&feed_data, &read_size, ESP_GMF_DATA_QUEUE_WAIT_FOREVER);
+            if (feed_data == NULL) {
+                ESP_LOGE(TAG, "Fail to get from dev src queue on %d", __LINE__);
+                return -1;
+            }
+            ret = audio_aec_feed_data(src, feed_data, read_size);
+            if (ret < 0) {
+                ESP_LOGE(TAG, "Fail to feed data %d on %d", ret, __LINE__);
+            }
+            vad_res->vad_filled_block--;
+            esp_gmf_data_queue_release_read(vad_res->in_q);
+            return 0;
+        }
+    }
+    esp_gmf_data_queue_acquire_read(vad_res->in_q, (void **)&feed_data, &read_size, ESP_GMF_DATA_QUEUE_WAIT_FOREVER);
+    if (feed_data == NULL) {
+        ESP_LOGE(TAG, "Fail to get from dev src queue on %d", __LINE__);
+        return -1;
+    }
+    // Fill working buffer and do detection
+    audio_aec_fill_vad_working_buf(src, feed_data, read_size);
+    vad_state_t vad_state = vad_res->vadnet->detect(vad_res->vad_model, (int16_t *)vad_res->vad_working_buf);
+    switch (vad_res->vad_state) {
+        case VAD_CHECKING_STARTED:
+            ret = audio_aec_feed_data(src, feed_data, read_size);
+            esp_gmf_data_queue_release_read(vad_res->in_q);
+            if (ret < 0) {
+                ESP_LOGE(TAG, "Fail to feed data %d on %d", ret, __LINE__);
+                break;
+            }
+            if (vad_state == VAD_SILENCE) {
+                if (vad_res->silent_block == 0) {
+                    ESP_LOGI(TAG, "VAD ended");
+                }
+                vad_res->silent_block++;
+                if (vad_res->silent_block >= VAD_SILENT_BLOCK) {
+                    vad_res->vad_state = VAD_CHECKING_ENDED;
+                }
+            }
+            break;
+        case VAD_CHECKING_ENDED:
+            if (src->wait_feeding) {
+                ret = audio_aec_feed_data(src, feed_data, read_size);
+                esp_gmf_data_queue_release_read(vad_res->in_q);
+                if (ret < 0) {
+                    ESP_LOGE(TAG, "Fail to feed data %d on %d", ret, __LINE__);
+                }
+                break;
+            }
+            int v = 0;
+            while (msg_q_recv(vad_res->vad_q, &v, sizeof(v), true) == 0);
+            vad_res->vad_state = VAD_CHECKING_DETECTING;
+            vad_res->vad_filled_block = 0;
+            ESP_LOGI(TAG, "VAD Detecting");
+            // fallthrough
+        case VAD_CHECKING_DETECTING:
+            if (vad_res->vad_filled_block < VAD_CACHE_BLOCK) {
+                vad_res->vad_filled_block++;
+            }
+            esp_gmf_data_queue_release_read(vad_res->in_q);
+            if (vad_state == VAD_SPEECH) {
+                ESP_LOGI(TAG, "VAD started");
+                vad_res->vad_state = VAD_CHECKING_STARTED;
+                vad_res->silent_block = 0;
+                // Rewind and resend again
+                esp_gmf_data_queue_rewind(vad_res->in_q, VAD_CACHE_BLOCK);
+            }
+            v = msg_q_number(vad_res->vad_q);
+            if (v < VAD_CACHE_BLOCK) {
+                msg_q_send(vad_res->vad_q, &v, sizeof(v));
+            }
+            ret = 0;
+            break;
+        default:
+            break;
+    }
+    return ret > 0 ? 0 : ret;
+}
+
+static void codec_dev_read_thread(void *arg)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)arg;
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    int read_size = src->cache_size * get_src_channel(src);
+    bool err = false;
+    while (!src->stopping) {
+        void *data = NULL;
+        if (esp_gmf_data_queue_acquire_write(vad_res->in_q, &data, read_size, ESP_GMF_DATA_QUEUE_WAIT_FOREVER) != 0 ||
+            data == NULL) {
+            break;
+        }
+        int ret = esp_codec_dev_read(src->handle, (uint8_t *)data, read_size);
+        if (ret != 0) {
+            ESP_LOGE(TAG, "Fail to read data %d", ret);
+            esp_gmf_data_queue_release_write(vad_res->in_q, 0);
+            err = true;
+            break;
+        }
+        esp_gmf_data_queue_release_write(vad_res->in_q, read_size);
+    }
+    if (err) {
+        esp_gmf_data_queue_wakeup(vad_res->in_q);
+    }
+    vad_res->dev_src_running = false;
+    ESP_LOGI(TAG, "Codec src in exited");
+    capture_thread_destroy(NULL);
+}
+
+static inline int audio_aec_src_read_from_vad(audio_aec_src_t *src)
+{
+    int ret = 0;
+    int read_size = src->cache_size * get_src_channel(src);
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    do {
+        vad_res->dev_src_running = true;
+        capture_thread_handle_t thread = NULL;
+        capture_thread_create_from_scheduler(&thread, "codec_dev_src", codec_dev_read_thread, src);
+        if (thread == NULL) {
+            ret = -1;
+            vad_res->dev_src_running = false;
+            break;
+        }
+        while (!src->stopping) {
+            // Handle read by vad
+            ret = audio_aec_read_by_vad(src, read_size);
+            if (ret != 0) {
+                ESP_LOGE(TAG, "Fail to read data ddd %d", ret);
+                break;
+            }
+        }
+    } while (0);
+    if (vad_res->in_q) {
+        esp_gmf_data_queue_wakeup(vad_res->in_q);
+    }
+    if (ret) {
+        src->in_error = true;
+        int v = msg_q_number(vad_res->vad_q);
+        if (v < VAD_CACHE_BLOCK) {
+            msg_q_send(vad_res->vad_q, &v, sizeof(v));
+        }
+    }
+    // Wait for codec source exited
+    WAIT_STATE_TIMEOUT(vad_res->dev_src_running);
+    return ret;
+}
+
+static inline int audio_aec_src_read_directly(audio_aec_src_t *src)
+{
+    int read_size = src->cache_size * get_src_channel(src);
+    int ret = 0;
+    uint32_t *feed_data = NULL;
+    do {
+        feed_data = malloc(read_size);
+        if (feed_data == NULL) {
+            ret = -1;
+            break;
+        }
+        while (!src->stopping) {
+            ret = esp_codec_dev_read(src->handle, feed_data, read_size);
+            if (ret != 0) {
+                ESP_LOGE(TAG, "Fail to read data %d", ret);
+                break;
+            }
+            ret = src->afe_handle->feed(src->afe_data, (int16_t *)feed_data);
+            if (ret < 0) {
+                ESP_LOGE(TAG, "Fail to feed data %d", ret);
+                break;
+            }
+        }
+    } while (0);
+    if (ret < 0) {
+        src->in_error = true;
+    }
+    if (feed_data) {
+        capture_free(feed_data);
+    }
+    return ret;
+}
+
+static void audio_aec_src_buffer_in_thread(void *arg)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)arg;
+    if (src->vad_res) {
+        audio_aec_src_read_from_vad(src);
+    } else {
+        audio_aec_src_read_directly(src);
+    }
+    src->in_quit = true;
+    ESP_LOGI(TAG, "Buffer in exited");
+    capture_thread_destroy(NULL);
+}
+
+static void release_vad(audio_aec_src_t *src)
+{
+    if (src->vad_res == NULL) {
+        return;
+    }
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    if (vad_res->vadnet) {
+        vad_res->vadnet->destroy(vad_res->vad_model);
+        vad_res->vadnet = NULL;
+    }
+    if (vad_res->in_q) {
+        esp_gmf_data_queue_destroy(vad_res->in_q);
+        vad_res->in_q = NULL;
+    }
+    if (vad_res->vad_working_buf) {
+        capture_free(vad_res->vad_working_buf);
+        vad_res->vad_working_buf = NULL;
+    }
+    if (vad_res->vad_q) {
+        msg_q_destroy(vad_res->vad_q);
+        vad_res->vad_q = NULL;
+    }
+    vad_res->vad_filled_block = 0;
+    capture_free(src->vad_res);
+    src->vad_res = NULL;
+}
+
+static esp_capture_err_t prepare_vad(audio_aec_src_t *src, int audio_chunksize)
+{
+    if (src->models == NULL || src->data_on_vad == false) {
+        return ESP_CAPTURE_ERR_OK;
+    }
+    char *model_name = esp_srmodel_filter(src->models, ESP_VADN_PREFIX, NULL);
+    esp_vadn_iface_t *vadnet = (esp_vadn_iface_t *)esp_vadn_handle_from_name(model_name);
+    if (vadnet == NULL) {
+        ESP_LOGW(TAG, "VAD model not found");
+        return ESP_CAPTURE_ERR_NOT_FOUND;
+    }
+    src->vad_res = capture_calloc(1, sizeof(audio_aec_vad_res_t));
+    if (src->vad_res == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate vad res");
+        return ESP_CAPTURE_ERR_NO_MEM;
+    }
+    audio_aec_vad_res_t *vad_res = src->vad_res;
+    do {
+        vad_res->vad_channel = (uint8_t)(strchr(src->mic_layout, 'M') - src->mic_layout);
+        vad_res->vadnet = vadnet;
+        vad_res->vad_model = vadnet->create(model_name, VAD_MODE_0, 1, 32, 64);
+        if (vad_res->vad_model == NULL) {
+            ESP_LOGE(TAG, "Failed to create vad model");
+            break;
+        }
+        int cache_size = (VAD_CACHE_BLOCK * 3) * (src->cache_size * get_src_channel(src) + 16);
+        vad_res->in_q = esp_gmf_data_queue_create(cache_size);
+        if (vad_res->in_q == NULL) {
+            ESP_LOGE(TAG, "Failed to create vad cache");
+            break;
+        }
+        // Only one channel data for vad
+        vad_res->vad_working_buf = capture_calloc(1, src->cache_size);
+        if (vad_res->vad_working_buf == NULL) {
+            ESP_LOGE(TAG, "Failed to allocate vad cache");
+            break;
+        }
+        vad_res->vad_q = msg_q_create(VAD_CACHE_BLOCK, sizeof(int));
+        if (vad_res->vad_q == NULL) {
+            ESP_LOGE(TAG, "Failed to create vad queue");
+            break;
+        }
+        vad_res->vad_state = VAD_CHECKING_DETECTING;
+        return ESP_CAPTURE_ERR_OK;
+    } while (0);
+    release_vad(src);
+    return ESP_CAPTURE_ERR_NO_MEM;
+}
+
+static esp_capture_err_t audio_aec_src_stop(esp_capture_audio_src_if_t *h);
+
+static esp_capture_err_t audio_aec_src_start(esp_capture_audio_src_if_t *h)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)h;
+    esp_codec_dev_sample_info_t fs = {
+        .sample_rate = src->info.sample_rate,
+        .bits_per_sample = 16,
+        .channel = src->channel,
+        .channel_mask = src->channel_mask,
+    };
+    src->in_quit = true;
+    int ret = esp_codec_dev_open(src->handle, &fs);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed to open codec device, ret=%d", ret);
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    ret = open_afe(src);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed to open AFE");
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    int audio_chunksize = src->afe_handle->get_feed_chunksize(src->afe_data);
+    src->cache_size = audio_chunksize * (16 / 8);
+    if (src->data_on_vad) {
+        ret = prepare_vad(src, audio_chunksize);
+        if (ret != ESP_CAPTURE_ERR_OK) {
+            return ret;
+        }
+    }
+    src->cached_frame = capture_calloc(1, src->cache_size);
+    if (src->cached_frame == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate cache frame");
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    src->samples = 0;
+    src->cached_read_pos = src->cache_fill = 0;
+    src->stopping = false;
+
+    capture_thread_handle_t thread = NULL;
+    int thread_ret = capture_thread_create_from_scheduler(
+        &thread,
+        "buffer_in",
+        audio_aec_src_buffer_in_thread,
+        src);
+    if (thread_ret != 0 || thread == NULL) {
+        ESP_LOGE(TAG, "Failed to create buffer input thread, ret=%d", thread_ret);
+        audio_aec_src_stop(h);
+        return ESP_CAPTURE_ERR_NO_RESOURCES;
+    }
+    src->start = true;
+    src->in_quit = false;
+    return ESP_CAPTURE_ERR_OK;
+}
+
+static esp_capture_err_t audio_aec_src_read_frame(esp_capture_audio_src_if_t *h, esp_capture_stream_frame_t *frame)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)h;
+    if (src->start == false) {
+        return ESP_CAPTURE_ERR_NOT_SUPPORTED;
+    }
+    frame->pts = (uint32_t)(src->samples * 1000 / src->info.sample_rate);
+
+    int need_size = frame->size;
+    uint8_t *frame_data = frame->data;
+    while (need_size > 0) {
+        if (src->cached_read_pos < src->cache_fill) {
+            int left = src->cache_fill - src->cached_read_pos;
+            if (left > need_size) {
+                left = need_size;
+            }
+            memcpy(frame_data, src->cached_frame + src->cached_read_pos, left);
+            src->cached_read_pos += left;
+            need_size -= left;
+            frame_data += left;
+            continue;
+        }
+        if (src->in_quit || src->in_error) {
+            return ESP_CAPTURE_ERR_INTERNAL;
+        }
+        src->cache_fill = 0;
+        src->cached_read_pos = 0;
+        bool use_silent = false;
+        audio_aec_vad_res_t *vad_res = src->vad_res;
+        if (vad_res && vad_res->vad_state != VAD_CHECKING_STARTED) {
+            // Receive from queue
+            int v = 0;
+            msg_q_recv(vad_res->vad_q, &v, sizeof(v), false);
+#ifdef VALID_ON_VAD
+            frame->size = 0;
+            return ESP_CAPTURE_ERR_OK;
+#endif
+            memset(src->cached_frame, 0, src->cache_size);
+            src->cache_fill = src->cache_size;
+            use_silent = true;
+        }
+        if (use_silent == false) {
+            src->wait_feeding = true;
+            afe_fetch_result_t *res = src->afe_handle->fetch(src->afe_data);
+            src->wait_feeding = false;
+            if (res->ret_value != ESP_OK) {
+                ESP_LOGE(TAG, "Fail to read from AEC ret %d", res->ret_value);
+                // When feed fetch not match may return error ignore it currently
+            }
+            if (res->wakeup_state == WAKENET_DETECTED && src->wake_cb != NULL) {
+                int64_t now_us = esp_timer_get_time();
+                if (last_wake_callback_us == 0 ||
+                    now_us - last_wake_callback_us >= WAKE_DEBOUNCE_US) {
+                    last_wake_callback_us = now_us;
+                    src->wake_cb(src->wake_ctx);
+                }
+            }
+            dump_data(1, res->data, res->data_size);
+            if (res->data_size <= src->cache_size) {
+                memcpy(src->cached_frame, res->data, res->data_size);
+                src->cache_fill = res->data_size;
+            } else {
+                ESP_LOGE(TAG, "Why so huge %d", res->data_size);
+            }
+        }
+    }
+    src->samples += frame->size / 2;
+    return ESP_CAPTURE_ERR_OK;
+}
+
+static int close_afe_in_ram(void *arg)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)arg;
+    if (src->models) {
+        esp_srmodel_deinit(src->models);
+        src->models = NULL;
+    }
+    if (src->afe_data) {
+        src->afe_handle->destroy(src->afe_data);
+        src->afe_data = NULL;
+    }
+    return 0;
+}
+
+static esp_capture_err_t audio_aec_src_stop(esp_capture_audio_src_if_t *h)
+{
+    audio_aec_src_t *src = (audio_aec_src_t *)h;
+    esp_capture_err_t ret = ESP_CAPTURE_ERR_OK;
+    if (src->in_quit == false) {
+        // fetch once
+        if (src->vad_res && src->vad_res->vad_state != VAD_CHECKING_STARTED) {
+        } else {
+            src->afe_handle->fetch(src->afe_data);
+        }
+        src->stopping = true;
+        WAIT_STATE_TIMEOUT(src->in_quit == false);
+    }
+    release_vad(src);
+
+    CAPTURE_RUN_SYNC_IN_RAM("afe_close", close_afe_in_ram, src, ret, AFE_RUN_STACK);
+
+    if (src->cached_frame) {
+        capture_free(src->cached_frame);
+        src->cached_frame = NULL;
+    }
+    if (src->handle) {
+        esp_codec_dev_close(src->handle);
+    }
+    dump_data(DUMP_STOP_IDX, NULL, 0);
+    src->in_error = false;
+    src->start = false;
+    return ret;
+}
+
+static esp_capture_err_t audio_aec_src_close(esp_capture_audio_src_if_t *h)
+{
+    return ESP_CAPTURE_ERR_OK;
+}
+
+esp_capture_audio_src_if_t *room_capture_new_audio_aec_src(room_capture_audio_aec_src_cfg_t *cfg)
+{
+    if (cfg == NULL || cfg->record_handle == NULL) {
+        return NULL;
+    }
+    audio_aec_src_t *src = capture_calloc(1, sizeof(audio_aec_src_t));
+    if (src == NULL) {
+        return NULL;
+    }
+    src->base.open = audio_aec_src_open;
+    src->base.get_support_codecs = audio_aec_src_get_support_codecs;
+    src->base.negotiate_caps = audio_aec_src_negotiate_caps;
+    src->base.start = audio_aec_src_start;
+    src->base.read_frame = audio_aec_src_read_frame;
+    src->base.stop = audio_aec_src_stop;
+    src->base.close = audio_aec_src_close;
+    src->handle = cfg->record_handle;
+    src->channel = cfg->channel ? cfg->channel : 2;
+    src->channel_mask = cfg->channel_mask;
+    src->data_on_vad = cfg->data_on_vad;
+    src->wake_cb = cfg->wake_cb;
+    src->wake_ctx = cfg->wake_ctx;
+    if (cfg->mic_layout == NULL) {
+        src->mic_layout = "MR";
+    } else {
+        src->mic_layout = cfg->mic_layout;
+    }
+    return &src->base;
+}
+
+#endif  /* CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32P4 */

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_aec_src.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_aec_src.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_capture_audio_src_if.h"
+
+typedef struct {
+    const char *mic_layout;
+    void *record_handle;
+    uint8_t channel;
+    uint8_t channel_mask;
+    bool data_on_vad;
+    void (*wake_cb)(void *ctx);
+    void *wake_ctx;
+} room_capture_audio_aec_src_cfg_t;
+
+esp_capture_audio_src_if_t *room_capture_new_audio_aec_src(
+    room_capture_audio_aec_src_cfg_t *cfg);

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -564,6 +564,86 @@ static void style_canvas_screen(int32_t pad)
     lv_obj_remove_flag(canvas_screen, LV_OBJ_FLAG_SCROLLABLE);
 }
 
+static const lv_font_t *font_for_usage(const char *usage);
+
+/*
+ * Diagnostic placeholder: a full-bleed field with a border drawn exactly on the
+ * safe-area inset and dots at each safe-area corner. Solid coverage makes panel
+ * flush artifacts obvious, and the markers show at a glance how much of the
+ * rectangle the rounded glass actually clips.
+ */
+static void show_test_card_locked(void)
+{
+    lv_obj_clean(canvas_screen);
+    clear_images_locked();
+    style_canvas_screen(0);
+
+    lv_obj_t *field = lv_obj_create(canvas_screen);
+    lv_obj_remove_style_all(field);
+    lv_obj_set_size(field, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_color(field, lv_color_hex(0x202830), 0);
+    lv_obj_set_style_bg_opa(field, LV_OPA_COVER, 0);
+    lv_obj_remove_flag(field, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_remove_flag(field, LV_OBJ_FLAG_CLICKABLE);
+
+    lv_obj_t *safe = lv_obj_create(field);
+    lv_obj_remove_style_all(safe);
+    lv_obj_set_pos(safe, ROOM_CANVAS_SAFE_PAD, ROOM_CANVAS_SAFE_PAD);
+    lv_obj_set_size(
+        safe,
+        ROOM_CANVAS_WIDTH - 2 * ROOM_CANVAS_SAFE_PAD,
+        ROOM_CANVAS_HEIGHT - 2 * ROOM_CANVAS_SAFE_PAD);
+    lv_obj_set_style_border_width(safe, 2, 0);
+    lv_obj_set_style_border_color(safe, lv_color_hex(0x36d399), 0);
+    lv_obj_set_style_radius(safe, 8, 0);
+    lv_obj_set_style_bg_opa(safe, LV_OPA_TRANSP, 0);
+    lv_obj_remove_flag(safe, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_remove_flag(safe, LV_OBJ_FLAG_CLICKABLE);
+
+    static const lv_align_t corners[] = {
+        LV_ALIGN_TOP_LEFT,
+        LV_ALIGN_TOP_RIGHT,
+        LV_ALIGN_BOTTOM_LEFT,
+        LV_ALIGN_BOTTOM_RIGHT,
+    };
+    for (size_t i = 0; i < sizeof(corners) / sizeof(corners[0]); ++i) {
+        lv_obj_t *dot = lv_obj_create(safe);
+        lv_obj_remove_style_all(dot);
+        lv_obj_set_size(dot, 14, 14);
+        lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+        lv_obj_set_style_bg_color(dot, lv_color_hex(0xf87272), 0);
+        lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+        lv_obj_align(dot, corners[i], 0, 0);
+        lv_obj_remove_flag(dot, LV_OBJ_FLAG_CLICKABLE);
+    }
+
+    lv_obj_t *caption = lv_label_create(safe);
+    lv_obj_set_style_text_color(caption, lv_color_white(), 0);
+    lv_obj_set_style_text_font(caption, font_for_usage("body"), 0);
+    lv_label_set_text(caption, "safe area\ntap to exit");
+    lv_obj_set_style_text_align(caption, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_center(caption);
+}
+
+/*
+ * Uniform fill with zero content variation. If the panel still shows streaks
+ * here, the artifact is in the transfer path; if this is clean while the test
+ * card streaks, it is in rendering.
+ */
+static void show_solid_fill_locked(void)
+{
+    lv_obj_clean(canvas_screen);
+    clear_images_locked();
+    style_canvas_screen(0);
+    lv_obj_t *field = lv_obj_create(canvas_screen);
+    lv_obj_remove_style_all(field);
+    lv_obj_set_size(field, LV_PCT(100), LV_PCT(100));
+    lv_obj_set_style_bg_color(field, lv_color_hex(0x1040c0), 0);
+    lv_obj_set_style_bg_opa(field, LV_OPA_COVER, 0);
+    lv_obj_remove_flag(field, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_remove_flag(field, LV_OBJ_FLAG_CLICKABLE);
+}
+
 static void show_placeholder_locked(void)
 {
     lv_obj_clean(canvas_screen);
@@ -1911,12 +1991,35 @@ void room_canvas_debug_toggle(void)
 {
     char *payload = NULL;
     esp_openclaw_node_error_t error = {0};
-    esp_err_t err = canvas_active
-        ? room_canvas_hide(&payload, &error)
-        : room_canvas_present(NULL, &payload, &error);
-    if (err == ESP_OK) {
-        free(payload);
+    if (canvas_active) {
+        if (room_canvas_hide(&payload, &error) == ESP_OK) {
+            free(payload);
+        }
+        room_ui_show_awake_hint();
+        return;
     }
+    if (root_component_id != NULL) {
+        if (room_canvas_present(NULL, &payload, &error) == ESP_OK) {
+            free(payload);
+        }
+        return;
+    }
+    /* Nothing pushed yet: cycle the two diagnostic views so the panel itself
+     * can be judged (solid fill isolates the transfer path from rendering). */
+    if (!bsp_display_lock(ROOM_CANVAS_DISPLAY_LOCK_MS)) {
+        return;
+    }
+    static bool show_solid;
+    if (show_solid) {
+        show_solid_fill_locked();
+    } else {
+        show_test_card_locked();
+    }
+    show_solid = !show_solid;
+    activate_canvas_locked();
+    bsp_display_unlock();
+    bsp_display_brightness_set(ROOM_CANVAS_BRIGHTNESS);
+    room_ui_refresh();
 }
 
 esp_err_t room_canvas_init(void)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -185,6 +185,16 @@ static esp_err_t http_event(esp_http_client_event_t *event)
     if (response == NULL) {
         return ESP_FAIL;
     }
+    /* timeout_ms bounds one socket operation; the wall-clock deadline also
+     * bounds connect, header, and data progress across the whole request. */
+    bool check_deadline = event->event_id == HTTP_EVENT_ON_CONNECTED ||
+        event->event_id == HTTP_EVENT_ON_HEADER ||
+        (event->event_id == HTTP_EVENT_ON_DATA && event->data_len > 0);
+    if (check_deadline && response->deadline_us != 0 &&
+        esp_timer_get_time() > response->deadline_us) {
+        response->timed_out = true;
+        return ESP_ERR_TIMEOUT;
+    }
     if (event->event_id == HTTP_EVENT_REDIRECT) {
         response->data_len = 0;
         free(response->content_type);
@@ -200,12 +210,6 @@ static esp_err_t http_event(esp_http_client_event_t *event)
         free(response->content_type);
         response->content_type = copy;
     } else if (event->event_id == HTTP_EVENT_ON_DATA && event->data_len > 0) {
-        /* timeout_ms bounds one socket operation; a trickling server would
-         * otherwise hold this synchronous command open indefinitely. */
-        if (response->deadline_us != 0 && esp_timer_get_time() > response->deadline_us) {
-            response->timed_out = true;
-            return ESP_ERR_TIMEOUT;
-        }
         size_t required = response->data_len + (size_t)event->data_len;
         if (!response_reserve(response, required)) {
             return response->too_large ? ESP_ERR_INVALID_SIZE : ESP_ERR_NO_MEM;
@@ -984,12 +988,15 @@ static lv_flex_align_t cross_alignment(const char *alignment)
     return LV_FLEX_ALIGN_START;
 }
 
-static room_canvas_image_t *find_image(const char *component_id)
+static room_canvas_image_t *find_image(
+    room_canvas_image_t *retained_images,
+    size_t retained_image_count,
+    const char *component_id)
 {
-    for (size_t i = 0; i < image_count; ++i) {
-        if (images[i].component_id != NULL &&
-            strcmp(images[i].component_id, component_id) == 0) {
-            return &images[i];
+    for (size_t i = 0; i < retained_image_count; ++i) {
+        if (retained_images[i].component_id != NULL &&
+            strcmp(retained_images[i].component_id, component_id) == 0) {
+            return &retained_images[i];
         }
     }
     return NULL;
@@ -1008,6 +1015,8 @@ static void button_event(lv_event_t *event)
 static lv_obj_t *render_component(
     const char *id,
     lv_obj_t *parent,
+    room_canvas_image_t *render_images,
+    size_t render_image_count,
     size_t depth,
     bool root,
     bool parent_row,
@@ -1027,6 +1036,8 @@ static void apply_weight(lv_obj_t *object, const room_canvas_component_t *entry)
 static void render_children(
     cJSON *props,
     lv_obj_t *parent,
+    room_canvas_image_t *render_images,
+    size_t render_image_count,
     size_t depth,
     bool parent_row,
     size_t *node_budget,
@@ -1042,6 +1053,8 @@ static void render_children(
             render_component(
                 child->valuestring,
                 parent,
+                render_images,
+                render_image_count,
                 depth + 1,
                 false,
                 parent_row,
@@ -1058,6 +1071,8 @@ static lv_obj_t *render_container(
     const room_canvas_component_t *entry,
     cJSON *props,
     lv_obj_t *parent,
+    room_canvas_image_t *render_images,
+    size_t render_image_count,
     size_t depth,
     bool root,
     bool row,
@@ -1083,7 +1098,15 @@ static lv_obj_t *render_container(
         LV_PCT(100),
         root ? LV_PCT(100) : LV_SIZE_CONTENT);
     apply_weight(object, entry);
-    render_children(props, object, depth, row, node_budget, out_error);
+    render_children(
+        props,
+        object,
+        render_images,
+        render_image_count,
+        depth,
+        row,
+        node_budget,
+        out_error);
     if (alignment_text != NULL && strcmp(alignment_text, "stretch") == 0) {
         uint32_t child_count = lv_obj_get_child_count(object);
         for (uint32_t i = 0; i < child_count; ++i) {
@@ -1101,6 +1124,8 @@ static lv_obj_t *render_container(
 static lv_obj_t *render_component(
     const char *id,
     lv_obj_t *parent,
+    room_canvas_image_t *render_images,
+    size_t render_image_count,
     size_t depth,
     bool root,
     bool parent_row,
@@ -1144,6 +1169,8 @@ static lv_obj_t *render_component(
             entry,
             props,
             parent,
+            render_images,
+            render_image_count,
             depth,
             root,
             false,
@@ -1155,6 +1182,8 @@ static lv_obj_t *render_component(
             entry,
             props,
             parent,
+            render_images,
+            render_image_count,
             depth,
             root,
             true,
@@ -1177,7 +1206,10 @@ static lv_obj_t *render_component(
         return label;
     }
     if (strcmp(name, "Image") == 0) {
-        room_canvas_image_t *image = find_image(id);
+        room_canvas_image_t *image = find_image(
+            render_images,
+            render_image_count,
+            id);
         if (image == NULL) {
             lv_obj_t *missing = lv_label_create(parent);
             lv_label_set_text(missing, "[Image]");
@@ -1225,6 +1257,8 @@ static lv_obj_t *render_component(
             render_component(
                 child->valuestring,
                 card,
+                render_images,
+                render_image_count,
                 depth + 1,
                 false,
                 false,
@@ -1346,37 +1380,77 @@ static esp_err_t prefetch_a2ui_images(esp_openclaw_node_error_t *out_error)
         }
     }
 
-    lv_obj_clean(canvas_screen);
-    clear_images_locked();
-    for (size_t i = 0; i < fetched_count; ++i) {
-        images[i] = fetched[i];
-        memset(&fetched[i], 0, sizeof(fetched[i]));
-        ++image_count;
+    lv_obj_t *container = lv_obj_create(canvas_screen);
+    if (container == NULL) {
+        for (size_t i = 0; i < fetched_count; ++i) {
+            release_image(&fetched[i]);
+        }
+        bsp_display_unlock();
+        return set_error(
+            out_error,
+            "INTERNAL",
+            "not enough memory to stage the A2UI surface",
+            ESP_ERR_NO_MEM);
     }
-    style_canvas_screen();
-    if (root_component_id != NULL) {
-        esp_openclaw_node_error_t render_error = {0};
-        size_t node_budget = ROOM_CANVAS_MAX_RENDER_NODES;
-        render_component(
-            root_component_id,
-            canvas_screen,
-            1,
-            true,
-            false,
-            &node_budget,
-            &render_error);
+    /* This hidden transaction root has exactly the canvas content geometry,
+     * so an LV_PCT(100) root renders as it did directly on canvas_screen. */
+    lv_obj_add_flag(container, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_remove_style_all(container);
+    lv_obj_set_style_bg_opa(container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_pad_all(container, 0, 0);
+    lv_obj_set_style_border_width(container, 0, 0);
+    lv_obj_set_layout(container, LV_LAYOUT_NONE);
+    lv_obj_set_pos(container, 0, 0);
+    lv_obj_set_size(container, LV_PCT(100), LV_PCT(100));
+    lv_obj_remove_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(container, LV_SCROLLBAR_MODE_OFF);
+
+    esp_openclaw_node_error_t render_error = {0};
+    size_t node_budget = ROOM_CANVAS_MAX_RENDER_NODES;
+    lv_obj_t *root = render_component(
+        root_component_id,
+        container,
+        fetched,
+        fetched_count,
+        1,
+        true,
+        false,
+        &node_budget,
+        &render_error);
+    if (root == NULL || render_error.code != NULL) {
+        lv_obj_delete(container);
+        for (size_t i = 0; i < fetched_count; ++i) {
+            release_image(&fetched[i]);
+        }
         if (render_error.code != NULL) {
             *out_error = render_error;
-            show_placeholder_locked();
-            activate_canvas_locked();
-            bsp_display_unlock();
-            bsp_display_brightness_set(ROOM_CANVAS_BRIGHTNESS);
-            room_ui_refresh();
-            return ESP_ERR_INVALID_SIZE;
+        } else {
+            set_error(
+                out_error,
+                "INTERNAL",
+                "not enough memory to render the A2UI surface",
+                ESP_ERR_NO_MEM);
         }
-    } else {
-        show_placeholder_locked();
+        bsp_display_unlock();
+        return render_error.code != NULL ? ESP_ERR_INVALID_SIZE : ESP_ERR_NO_MEM;
     }
+
+    uint32_t child_count = lv_obj_get_child_count(canvas_screen);
+    for (uint32_t i = child_count; i > 0; --i) {
+        lv_obj_t *child = lv_obj_get_child(canvas_screen, (int32_t)i - 1);
+        if (child != container) {
+            lv_obj_delete(child);
+        }
+    }
+    clear_images_locked();
+    for (size_t i = 0; i < fetched_count; ++i) {
+        /* LVGL retains the heap draw-buffer pointer, so moving its owning
+         * record to stable storage does not invalidate the staged widget. */
+        images[i] = fetched[i];
+        memset(&fetched[i], 0, sizeof(fetched[i]));
+    }
+    image_count = fetched_count;
+    lv_obj_remove_flag(container, LV_OBJ_FLAG_HIDDEN);
     activate_canvas_locked();
     bsp_display_unlock();
     bsp_display_brightness_set(ROOM_CANVAS_BRIGHTNESS);

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -548,12 +548,19 @@ static bool validate_image_locked(room_canvas_image_t *image)
     return true;
 }
 
-static void style_canvas_screen(void)
+/*
+ * The physical glass has large rounded corners, so laid-out content needs a
+ * safe-area inset (Apple's "safe area") to stay visible. Full-bleed image
+ * presentation intentionally keeps zero padding, like wallpaper.
+ */
+#define ROOM_CANVAS_SAFE_PAD 32
+
+static void style_canvas_screen(int32_t pad)
 {
     lv_obj_set_style_bg_color(canvas_screen, lv_color_black(), 0);
     lv_obj_set_style_bg_opa(canvas_screen, LV_OPA_COVER, 0);
     lv_obj_set_style_text_color(canvas_screen, lv_color_white(), 0);
-    lv_obj_set_style_pad_all(canvas_screen, 12, 0);
+    lv_obj_set_style_pad_all(canvas_screen, pad, 0);
     lv_obj_remove_flag(canvas_screen, LV_OBJ_FLAG_SCROLLABLE);
 }
 
@@ -561,7 +568,7 @@ static void show_placeholder_locked(void)
 {
     lv_obj_clean(canvas_screen);
     clear_images_locked();
-    style_canvas_screen();
+    style_canvas_screen(ROOM_CANVAS_SAFE_PAD);
     lv_obj_t *label = lv_label_create(canvas_screen);
     lv_obj_set_style_text_color(label, lv_color_white(), 0);
 #if LV_FONT_MONTSERRAT_20
@@ -633,7 +640,7 @@ static esp_err_t show_present_image(
 
     lv_obj_clean(canvas_screen);
     clear_images_locked();
-    style_canvas_screen();
+    style_canvas_screen(0);
     images[0] = *image;
     memset(image, 0, sizeof(*image));
     image_count = 1;
@@ -1404,6 +1411,9 @@ static esp_err_t prefetch_a2ui_images(esp_openclaw_node_error_t *out_error)
     lv_obj_set_size(container, LV_PCT(100), LV_PCT(100));
     lv_obj_remove_flag(container, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_scrollbar_mode(container, LV_SCROLLBAR_MODE_OFF);
+    /* Background taps must reach the screen's tap-to-hide handler; A2UI
+     * buttons stay individually clickable. */
+    lv_obj_remove_flag(container, LV_OBJ_FLAG_CLICKABLE);
 
     esp_openclaw_node_error_t render_error = {0};
     size_t node_budget = ROOM_CANVAS_MAX_RENDER_NODES;
@@ -1450,6 +1460,10 @@ static esp_err_t prefetch_a2ui_images(esp_openclaw_node_error_t *out_error)
         memset(&fetched[i], 0, sizeof(fetched[i]));
     }
     image_count = fetched_count;
+    /* The image path runs full-bleed (pad 0); restore the safe-area inset for
+     * laid-out content. Only on success, so a failed render leaves the screen
+     * exactly as it was. */
+    style_canvas_screen(ROOM_CANVAS_SAFE_PAD);
     lv_obj_remove_flag(container, LV_OBJ_FLAG_HIDDEN);
     activate_canvas_locked();
     bsp_display_unlock();
@@ -1876,6 +1890,35 @@ static esp_err_t apply_a2ui_array(
     return ESP_OK;
 }
 
+/* Tap on empty canvas background returns to the status screen. */
+static void canvas_screen_clicked(lv_event_t *event)
+{
+    (void)event;
+    char *payload = NULL;
+    esp_openclaw_node_error_t error = {0};
+    if (room_canvas_hide(&payload, &error) == ESP_OK) {
+        free(payload);
+    }
+}
+
+/*
+ * Debug view cycling for the on-device buttons/touch: status -> canvas
+ * (existing A2UI content or the placeholder) -> status. Safe from LVGL event
+ * callbacks too: the display lock is a recursive mutex and neither branch
+ * deletes the object dispatching the event.
+ */
+void room_canvas_debug_toggle(void)
+{
+    char *payload = NULL;
+    esp_openclaw_node_error_t error = {0};
+    esp_err_t err = canvas_active
+        ? room_canvas_hide(&payload, &error)
+        : room_canvas_present(NULL, &payload, &error);
+    if (err == ESP_OK) {
+        free(payload);
+    }
+}
+
 esp_err_t room_canvas_init(void)
 {
     if (!bsp_display_lock(ROOM_CANVAS_DISPLAY_LOCK_MS)) {
@@ -1889,7 +1932,8 @@ esp_err_t room_canvas_init(void)
         ESP_LOGE(TAG, "failed to create canvas screen");
         return ESP_ERR_NO_MEM;
     }
-    style_canvas_screen();
+    style_canvas_screen(ROOM_CANVAS_SAFE_PAD);
+    lv_obj_add_event_cb(canvas_screen, canvas_screen_clicked, LV_EVENT_CLICKED, NULL);
     bsp_display_unlock();
     return ESP_OK;
 }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -1979,6 +1979,9 @@ static void canvas_screen_clicked(lv_event_t *event)
     if (room_canvas_hide(&payload, &error) == ESP_OK) {
         free(payload);
     }
+    /* Same contract as the BOOT/status toggle: a user-initiated exit must not
+     * land on the idle-dark screen and look like a dead panel. */
+    room_ui_show_awake_hint();
 }
 
 /*

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
@@ -11,6 +11,8 @@ esp_err_t room_canvas_init(void);
 void room_canvas_set_node(esp_openclaw_node_handle_t node);
 void room_canvas_set_gateway_http_base(const char *base_url);
 bool room_canvas_is_active(void);
+/** Cycle status <-> canvas for the on-device debug controls. */
+void room_canvas_debug_toggle(void);
 
 esp_err_t room_canvas_present(
     const char *url,

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
@@ -14,6 +14,7 @@
 #include "esp_codec_dev.h"
 #include "esp_codec_dev_defaults.h"
 #include "esp_log.h"
+#include "freertos/idf_additions.h"
 #include "media_lib_err.h"
 #include "room_aec_src.h"
 
@@ -256,12 +257,38 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
         return ESP_FAIL;
     }
 
-    if (xTaskCreate(wake_drain_task, "wake_drain", 3072, NULL, 5, NULL) != pdPASS) {
+    if (xTaskCreateWithCaps(
+            wake_drain_task,
+            "wake_drain",
+            3072,
+            NULL,
+            5,
+            NULL,
+            MALLOC_CAP_SPIRAM) != pdPASS) {
         return ESP_ERR_NO_MEM;
     }
     ESP_LOGI(TAG, "ambient WakeNet detections are wired from the AFE");
     ESP_LOGI(TAG, "24 kHz dual-channel capture and device AEC are active");
     return ESP_OK;
+}
+
+esp_err_t room_media_set_ambient_wake(bool enabled)
+{
+    if (wake_sink == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    /*
+     * While a Talk call runs, WebRTC consumes the same AEC/AFE pipeline and
+     * keeps wake detection alive on its own. Leaving this scan path enabled as
+     * well only adds a second consumer that the Opus encoder starves, which
+     * overflows the AFE feed ringbuffer. Disable it for the duration.
+     */
+    esp_capture_run_mode_t mode = enabled
+        ? ESP_CAPTURE_RUN_MODE_ALWAYS
+        : ESP_CAPTURE_RUN_MODE_DISABLE;
+    return esp_capture_sink_enable(wake_sink, mode) == ESP_CAPTURE_ERR_OK
+        ? ESP_OK
+        : ESP_FAIL;
 }
 
 esp_err_t room_media_get_webrtc_provider(esp_webrtc_media_provider_t *provider)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
@@ -21,6 +21,7 @@
 
 static esp_capture_handle_t capture;
 static esp_capture_sink_handle_t talk_sink;
+static esp_capture_sink_handle_t wake_sink;
 static av_render_handle_t player;
 static room_wake_callback_t wake_callback;
 static void *wake_callback_ctx;
@@ -142,6 +143,26 @@ static esp_err_t room_audio_codecs_init(
     return *record != NULL && *playback != NULL ? ESP_OK : ESP_ERR_NO_MEM;
 }
 
+/*
+ * The AFE only runs its WakeNet pass inside fetch(), and fetch() is driven by a
+ * consumer reading the sink. Nothing else reads this path while no Talk call is
+ * active, so drain it here: the frames are discarded, but draining keeps the
+ * pipeline turning (and its feed ringbuffer from overflowing) so ambient wake
+ * detections keep arriving through the AFE callback.
+ */
+static void wake_drain_task(void *arg)
+{
+    (void)arg;
+    for (;;) {
+        esp_capture_stream_frame_t frame = {.stream_type = ESP_CAPTURE_STREAM_TYPE_AUDIO};
+        if (esp_capture_sink_acquire_frame(wake_sink, &frame, false) != ESP_CAPTURE_ERR_OK) {
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+        esp_capture_sink_release_frame(wake_sink, &frame);
+    }
+}
+
 esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
 {
     wake_callback = callback;
@@ -187,8 +208,24 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
             .bits_per_sample = 16,
         },
     };
+    /*
+     * Sink 1 exists only to keep the AEC/AFE pipeline running whenever no Talk
+     * call is active: WakeNet lives inside that pipeline, so without an
+     * always-on path the AFE never fetches and ambient wake never fires.
+     * Nothing consumes its frames; the wake callback comes from the AFE.
+     */
+    esp_capture_sink_cfg_t wake_cfg = {
+        .audio_info = {
+            .format_id = ESP_CAPTURE_FMT_ID_PCM,
+            .sample_rate = 16000,
+            .channel = 1,
+            .bits_per_sample = 16,
+        },
+    };
     // esp_webrtc owns sink 0 and retrieves this exact pre-created path after capture starts.
     if (esp_capture_sink_setup(capture, 0, &talk_cfg, &talk_sink) != ESP_CAPTURE_ERR_OK ||
+        esp_capture_sink_setup(capture, 1, &wake_cfg, &wake_sink) != ESP_CAPTURE_ERR_OK ||
+        esp_capture_sink_enable(wake_sink, ESP_CAPTURE_RUN_MODE_ALWAYS) != ESP_CAPTURE_ERR_OK ||
         esp_capture_start(capture) != ESP_CAPTURE_ERR_OK) {
         return ESP_FAIL;
     }
@@ -219,6 +256,9 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
         return ESP_FAIL;
     }
 
+    if (xTaskCreate(wake_drain_task, "wake_drain", 3072, NULL, 5, NULL) != pdPASS) {
+        return ESP_ERR_NO_MEM;
+    }
     ESP_LOGI(TAG, "ambient WakeNet detections are wired from the AFE");
     ESP_LOGI(TAG, "24 kHz dual-channel capture and device AEC are active");
     return ESP_OK;

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
@@ -9,13 +9,13 @@
 #include "esp_audio_dec_default.h"
 #include "esp_audio_enc_default.h"
 #include "esp_capture.h"
-#include "esp_capture_defaults.h"
 #include "esp_capture_sink.h"
 #include "esp_check.h"
 #include "esp_codec_dev.h"
 #include "esp_codec_dev_defaults.h"
 #include "esp_log.h"
 #include "media_lib_err.h"
+#include "room_aec_src.h"
 
 #define TAG "room_media"
 
@@ -27,6 +27,14 @@ static void *wake_callback_ctx;
 static i2s_chan_handle_t audio_tx;
 static i2s_chan_handle_t audio_rx;
 static const audio_codec_data_if_t *audio_data;
+
+static void room_afe_wake(void *ctx)
+{
+    (void)ctx;
+    if (wake_callback != NULL) {
+        wake_callback("hiesp", wake_callback_ctx);
+    }
+}
 
 static esp_err_t room_audio_codecs_init(
     esp_codec_dev_handle_t *record,
@@ -149,14 +157,15 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
         return ESP_FAIL;
     }
 
-    esp_capture_audio_aec_src_cfg_t source_cfg = {
+    room_capture_audio_aec_src_cfg_t source_cfg = {
         .mic_layout = "MR",
         .record_handle = record,
         .channel = 2,
         // ES7210 packs the two enabled analog inputs into the two standard-I2S slots.
         .channel_mask = 0x3,
+        .wake_cb = room_afe_wake,
     };
-    esp_capture_audio_src_if_t *audio_source = esp_capture_new_audio_aec_src(&source_cfg);
+    esp_capture_audio_src_if_t *audio_source = room_capture_new_audio_aec_src(&source_cfg);
     if (audio_source == NULL) {
         return ESP_ERR_NO_MEM;
     }
@@ -210,17 +219,7 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
         return ESP_FAIL;
     }
 
-    /*
-     * The AEC capture source above already owns the board's single WakeNet
-     * instance inside its AFE pipeline; creating a second esp-sr instance on
-     * this model aborts inside the closed library on hardware. The AFE does
-     * not surface its wake detections through esp_capture yet, so ambient
-     * wake stays off until that seam exists; the console `wake` command and
-     * gateway-triggered Talk remain fully functional.
-     */
-    ESP_LOGW(
-        TAG,
-        "ambient wake-word detection is disabled on this build; use the console `wake` command to start Talk");
+    ESP_LOGI(TAG, "ambient WakeNet detections are wired from the AFE");
     ESP_LOGI(TAG, "24 kHz dual-channel capture and device AEC are active");
     return ESP_OK;
 }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.h
@@ -6,4 +6,7 @@
 typedef void (*room_wake_callback_t)(const char *wake_word, void *ctx);
 
 esp_err_t room_media_init(room_wake_callback_t callback, void *ctx);
+/** Enable or disable the ambient wake scan path (disable while Talk owns the pipeline). */
+esp_err_t room_media_set_ambient_wake(bool enabled);
+
 esp_err_t room_media_get_webrtc_provider(esp_webrtc_media_provider_t *provider);

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -14,9 +14,9 @@
 #define ROOM_UI_DRAW_ROWS 16
 
 /*
- * The SH8601 requires even-aligned flush windows; odd-aligned partial flushes
- * leave single-row seams. Full-width stripes also keep the chunk cadence even
- * for narrow dirty regions (chunk rows = buffer px / area width).
+ * The SH8601 latches flush windows on 2-pixel boundaries, so dirty areas are
+ * expanded to even rows and full width. Only LV_EVENT_INVALIDATE_AREA carries
+ * an area; refresh-time events do not, and must not be hooked here.
  */
 static void room_ui_align_flush_area(lv_event_t *event)
 {
@@ -96,11 +96,10 @@ void room_ui_init(void)
         heap_caps_free(draw_b);
         ESP_LOGW(TAG, "no internal DMA memory for the draw buffer; flushes will bounce");
     }
-    bsp_display_unlock();
+    /* Registering mutates the display's event list, which the LVGL port task
+     * walks on every refresh; keep the lock held across it. */
     lv_display_add_event_cb(display, room_ui_align_flush_area, LV_EVENT_INVALIDATE_AREA, NULL);
-    /* esp_lvgl_port feeds its rounder from both events; some dirty areas are
-     * (re)injected at refresh time and bypass INVALIDATE_AREA alone. */
-    lv_display_add_event_cb(display, room_ui_align_flush_area, LV_EVENT_REFR_REQUEST, NULL);
+    bsp_display_unlock();
     if (!bsp_display_lock(0)) {
         ESP_LOGE(TAG, "failed to lock display during initialization");
         return;

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -3,9 +3,13 @@
 #include <string.h>
 
 #include "bsp/esp-bsp.h"
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "lvgl.h"
 #include "room_canvas.h"
+
+/* 16 rows x 410 px x RGB565 = ~13 KiB, matching CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT. */
+#define ROOM_UI_DRAW_ROWS 16
 
 static const char *TAG = "room_ui";
 static lv_obj_t *status_label;
@@ -18,10 +22,42 @@ static char current_detail[48];
 
 void room_ui_init(void)
 {
-    if (bsp_display_start() == NULL) {
+    lv_display_t *display = bsp_display_start();
+    if (display == NULL) {
         ESP_LOGE(TAG, "failed to start display");
         return;
     }
+    /*
+     * The BSP's draw buffer is allocated from the default heap and lands in
+     * PSRAM, which this QSPI panel cannot DMA from. esp_lcd then bounce-buffers
+     * every flush through a fresh internal allocation, and once Wi-Fi/TLS and
+     * the always-on audio pipeline claim internal RAM those allocations start
+     * failing, silently dropping flushes (stale/overlapping pixels on screen).
+     * Own the draw buffer instead: internal DMA-capable memory taken once here,
+     * before the network and audio stacks start, so no per-flush allocation is
+     * ever needed. Must run under the display lock; the LVGL port task is
+     * already rendering into the buffers this replaces.
+     */
+    if (!bsp_display_lock(0)) {
+        ESP_LOGE(TAG, "failed to lock display for draw buffer setup");
+        return;
+    }
+    size_t draw_bytes = (size_t)BSP_LCD_H_RES * ROOM_UI_DRAW_ROWS * 2;
+    void *draw_buffer = heap_caps_aligned_alloc(
+        CONFIG_LV_DRAW_BUF_ALIGN,
+        draw_bytes,
+        MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    if (draw_buffer != NULL) {
+        lv_display_set_buffers(
+            display,
+            draw_buffer,
+            NULL,
+            (uint32_t)draw_bytes,
+            LV_DISPLAY_RENDER_MODE_PARTIAL);
+    } else {
+        ESP_LOGW(TAG, "no internal DMA memory for the draw buffer; flushes will bounce");
+    }
+    bsp_display_unlock();
     if (!bsp_display_lock(0)) {
         ESP_LOGE(TAG, "failed to lock display during initialization");
         return;

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -69,18 +69,31 @@ void room_ui_init(void)
         return;
     }
     size_t draw_bytes = (size_t)BSP_LCD_H_RES * ROOM_UI_DRAW_ROWS * 2;
-    void *draw_buffer = heap_caps_aligned_alloc(
+    /* Two buffers: the panel DMAs one chunk while LVGL renders the next. With a
+     * single buffer the renderer and the in-flight transfer share memory, which
+     * shows up as streaks of the wrong row on the glass. */
+    void *draw_a = heap_caps_aligned_alloc(
         CONFIG_LV_DRAW_BUF_ALIGN,
         draw_bytes,
         MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-    if (draw_buffer != NULL) {
+    void *draw_b = heap_caps_aligned_alloc(
+        CONFIG_LV_DRAW_BUF_ALIGN,
+        draw_bytes,
+        MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    if (draw_a != NULL) {
         lv_display_set_buffers(
             display,
-            draw_buffer,
-            NULL,
+            draw_a,
+            draw_b,
             (uint32_t)draw_bytes,
             LV_DISPLAY_RENDER_MODE_PARTIAL);
+        ESP_LOGI(
+            TAG,
+            "draw buffers: %u bytes x%d internal DMA",
+            (unsigned)draw_bytes,
+            draw_b != NULL ? 2 : 1);
     } else {
+        heap_caps_free(draw_b);
         ESP_LOGW(TAG, "no internal DMA memory for the draw buffer; flushes will bounce");
     }
     bsp_display_unlock();
@@ -180,6 +193,22 @@ void room_ui_set(room_ui_state_t state, const char *detail)
         /* AMOLED is fully dark while idle; active states use a deliberately low brightness. */
         bsp_display_brightness_set(painted_state == ROOM_UI_IDLE ? 0 : 18);
     }
+}
+
+void room_ui_show_awake_hint(void)
+{
+    if (status_label == NULL) {
+        return;
+    }
+    if (!bsp_display_lock(100)) {
+        return;
+    }
+    lv_label_set_text(status_label, "OpenClaw\ntap or BOOT for canvas");
+    lv_obj_set_style_text_align(status_label, LV_TEXT_ALIGN_CENTER, 0);
+    bsp_display_unlock();
+    /* A user-initiated exit must not look like a dead panel, so override the
+     * idle-dark policy until the next state change repaints. */
+    bsp_display_brightness_set(18);
 }
 
 void room_ui_refresh(void)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -8,8 +8,34 @@
 #include "lvgl.h"
 #include "room_canvas.h"
 
-/* 16 rows x 410 px x RGB565 = ~13 KiB, matching CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT. */
+/* 16 rows x 410 px x RGB565 = ~13 KiB, matching CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT.
+ * Must stay EVEN: flush chunks advance by this many rows and the SH8601
+ * latches windows on 2-pixel boundaries. */
 #define ROOM_UI_DRAW_ROWS 16
+
+/*
+ * The SH8601 requires even-aligned flush windows; odd-aligned partial flushes
+ * leave single-row seams. Full-width stripes also keep the chunk cadence even
+ * for narrow dirty regions (chunk rows = buffer px / area width).
+ */
+static void room_ui_align_flush_area(lv_event_t *event)
+{
+    lv_area_t *area = lv_event_get_param(event);
+    if (area == NULL) {
+        return;
+    }
+    area->x1 = 0;
+    area->x2 = BSP_LCD_H_RES - 1;
+    area->y1 &= ~1;
+    area->y2 |= 1;
+}
+
+/* Tap on the status screen jumps to the canvas view. */
+static void room_ui_status_clicked(lv_event_t *event)
+{
+    (void)event;
+    room_canvas_debug_toggle();
+}
 
 static const char *TAG = "room_ui";
 static lv_obj_t *status_label;
@@ -58,6 +84,10 @@ void room_ui_init(void)
         ESP_LOGW(TAG, "no internal DMA memory for the draw buffer; flushes will bounce");
     }
     bsp_display_unlock();
+    lv_display_add_event_cb(display, room_ui_align_flush_area, LV_EVENT_INVALIDATE_AREA, NULL);
+    /* esp_lvgl_port feeds its rounder from both events; some dirty areas are
+     * (re)injected at refresh time and bypass INVALIDATE_AREA alone. */
+    lv_display_add_event_cb(display, room_ui_align_flush_area, LV_EVENT_REFR_REQUEST, NULL);
     if (!bsp_display_lock(0)) {
         ESP_LOGE(TAG, "failed to lock display during initialization");
         return;
@@ -72,6 +102,11 @@ void room_ui_init(void)
 #endif
     lv_obj_center(status_label);
     lv_label_set_text(status_label, "OpenClaw");
+    lv_obj_add_event_cb(
+        lv_screen_active(),
+        room_ui_status_clicked,
+        LV_EVENT_CLICKED,
+        NULL);
     bsp_display_unlock();
     bsp_display_brightness_set(0);
 }
@@ -105,7 +140,8 @@ static bool room_ui_render_locked(void)
                 lv_obj_center(talk_pill_label);
             }
             lv_label_set_text(talk_pill_label, labels[current_state]);
-            lv_obj_align(talk_pill, LV_ALIGN_TOP_RIGHT, -8, 8);
+            /* The rounded glass clips the corners; top-center stays visible. */
+            lv_obj_align(talk_pill, LV_ALIGN_TOP_MID, 0, 14);
         }
         return false;
     }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.h
@@ -13,3 +13,5 @@ void room_ui_init(void);
 void room_ui_set(room_ui_state_t state, const char *detail);
 /** Repaint the most recently set state, e.g. after leaving canvas mode. */
 void room_ui_refresh(void);
+/** Show a visible status hint after a user-initiated exit from canvas. */
+void room_ui_show_awake_hint(void);

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/sdkconfig.defaults
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/sdkconfig.defaults
@@ -22,11 +22,17 @@ CONFIG_LV_USE_CLIB_MALLOC=y
 # leaving the panel garbled or dark. Keep the flush chunk small (16 rows is
 # ~13 KiB) and reserve enough internal memory that the bounce always succeeds.
 CONFIG_BSP_DISPLAY_LVGL_BUF_HEIGHT=16
-CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=131072
+# Task stacks and DMA can only come from internal RAM, and with the 256-byte
+# always-internal threshold nothing else needs it; give them the whole budget.
+CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=262144
 CONFIG_LV_USE_LODEPNG=y
 CONFIG_LV_USE_SNAPSHOT=y
-CONFIG_ESP_OPENCLAW_NODE_TASK_STACK_SIZE=12288
-CONFIG_ESP_OPENCLAW_NODE_TRANSPORT_TASK_STACK_SIZE=12288
+# Two node clients (node + operator role) each run a component task and a
+# websocket task, and all four stacks must be internal RAM. 12 KiB each cost
+# 48 KiB of the scarcest pool and starved websocket task creation once the
+# always-on audio pipeline was added; 8 KiB matches the IDF default.
+CONFIG_ESP_OPENCLAW_NODE_TASK_STACK_SIZE=8192
+CONFIG_ESP_OPENCLAW_NODE_TRANSPORT_TASK_STACK_SIZE=8192
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 # PSRAM-first memory policy, matching every esp-webrtc-solution demo config
 # (openai_demo etc.): Wi-Fi/LWIP buffers and mbedTLS allocations in PSRAM and a


### PR DESCRIPTION
## What Problem This Solves

Three gaps remained after the Canvas node landed: ambient "Hi ESP" wake was disabled, the panel showed content-derived streaks under load, and the device had no way to change views on its own hardware. Hardware testing then surfaced a class of memory failures that presented as "No memory" on screen and as wakes that never started a call.

## Why This Change Was Made

**Ambient wake.** The AEC capture source's AFE already runs WakeNet internally, but `esp_capture` 1.0.2 exposes no wake-event surface, and creating a second esp-sr instance aborts inside the closed library on this hardware. The one compilation unit is vendored locally (with provenance and an upstream-and-drop note) and given a `wake_cb`, invoked on `afe_fetch_result_t.wakeup_state == WAKENET_DETECTED` with a 2-second debounce. The AFE only runs its WakeNet pass inside `fetch()`, which is driven by a sink consumer — so an always-on PCM sink plus a drain task keeps the pipeline turning; without the drain, its feed ringbuffer overflows continuously. Scanning pauses during a call, where WebRTC already drives the pipeline and the Opus encoder would otherwise starve the drain.

**Display streaks.** Artifacts carried colour from elsewhere in the frame (the safe-area border's green replicated into rows that should have been background), which rules out tearing: LVGL was rendering into the same buffer the panel was still DMA-reading. The fix is two internal DMA-capable chunk buffers. The earlier PSRAM-bounce failure mode is also closed by owning the draw buffer outright, allocated at boot before the network and audio stacks take internal RAM.

**Memory.** Measured internal heap after boot is ~50-64 KiB free with a ~25-30 KiB largest block, while the two node clients (node + operator role) each requested 12 KiB task stacks — so the operator client's websocket task could not be allocated and retried forever, which is why a wake sometimes detected but never started a call. Stacks return to the IDF-default 8 KiB, supervisor tasks move their stacks to PSRAM, and the Talk starter becomes a persistent boot-time worker rather than an 8 KiB allocation attempted at wake time. Boot now logs heap so this class of failure is measurable.

**Safe area and on-device controls.** The glass is heavily rounded, so content laid out to the panel rectangle disappeared into the corners. Laid-out content insets 32 px; presented images stay full-bleed by design. Tap or the BOOT button cycles status → test card → solid fill, and a user-initiated exit shows a readable hint instead of the idle-dark policy that made a normal exit look like a dead panel.

## User Impact

The node wakes hands-free on "Hi ESP" and runs a full Talk call, the panel renders cleanly under sustained canvas and call load, and the device is inspectable without a serial console.

## Evidence

Measured over serial on the physical board, paired to a live gateway:

- Wake: five spoken utterances produced five detections, zero ringbuffer overflows; a wake reaches `talk.client.create` → DTLS/SRTP → `PeerConnectionState: 7`.
- Display: 0 flush failures across 12+ render cycles plus an active call (previously 11 per render, then 56 once the audio pipeline was added). Test card and solid fill both visually confirmed clean; all four safe-area corner markers visible inside the round glass.
- Memory: 0 websocket task-creation failures (previously 38-43 in a 20 s window). 0 panics.
- Null-root behaviour verified directly: after `canvas.a2ui.reset`, `canvas.present` returns `{"shown":true,"kind":"a2ui","components":0}` — the placeholder path is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
