### PR TITLE
chore: update repo URLs after transfer to openclaw org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [Component README](./components/esp-openclaw-node/README.md) for more de
 
 ## Start Here
 
-<a href="https://espressif.github.io/esp-openclaw-node/">
+<a href="https://openclaw.github.io/esp-openclaw-node/">
   <img alt="Try it with ESP Launchpad" src="https://espressif.github.io/esp-launchpad/assets/try_with_launchpad.png" width="220" height="62">
 </a>
 

--- a/components/esp-openclaw-node/CHANGELOG.md
+++ b/components/esp-openclaw-node/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Point component manifest `url`/`repository` at the repo's new home under the `openclaw` GitHub org.
 - Advertise gateway protocol `minProtocol 3` / `maxProtocol 4`. Current gateways strip plugin-owned capabilities (for example `canvas`) and withhold `pluginSurfaceUrls` from legacy v3-only node sessions.
 - Capture `hello-ok` plugin surface URLs and expose `esp_openclaw_node_dup_plugin_surface_url()` for application URL resolution.
 - Add role-keyed sessions, explicit device-token auth, operator scope advertisement, Gateway events, and correlated asynchronous RPCs for voice-room clients.

--- a/components/esp-openclaw-node/idf_component.yml
+++ b/components/esp-openclaw-node/idf_component.yml
@@ -1,7 +1,7 @@
 version: "1.0.0"
 description: "ESP-IDF component for running OpenClaw Nodes on ESP32 devices."
-url: https://github.com/espressif/esp-openclaw-node
-repository: https://github.com/espressif/esp-openclaw-node.git
+url: https://github.com/openclaw/esp-openclaw-node
+repository: https://github.com/openclaw/esp-openclaw-node.git
 repository_info:
   path: "components/esp-openclaw-node"
 


### PR DESCRIPTION
The repo moved from the `espressif` org to `openclaw`, but two references never followed:

- `components/esp-openclaw-node/idf_component.yml` still listed the old `url`/`repository`, so the Component Registry page links to a redirect instead of the canonical home.
- The README's "Try it with ESP Launchpad" badge pointed at `espressif.github.io/esp-openclaw-node/`, which now returns **404** — GitHub Pages does not redirect across transfers the way repos do. The link is updated to `openclaw.github.io/esp-openclaw-node/` (verified serving 200).

The CI upload workflow's `namespace: "espressif"` for the Component Registry is intentionally untouched.

Also adds a changelog entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
