### PR TITLE
feat(room-node): fluid face — tween rig, blink choreography, gestures, 60 Hz

### DIFF
--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
@@ -49,13 +49,29 @@ for the entire duration of a call and every `node.invoke` — including
 
 ## Agent face
 
-Talk states render as a procedural face instead of text: two expressive eyes
-(blink, micro-saccades, mood styling) and a mouth whose height follows the
-mean amplitude of the audio the model is actually playing, tapped from the
-audio render path. Connecting shows a thinking gaze; listening widens the eyes
-with a slow bob; errors and setup fall back to text. The face uses more AMOLED
-brightness (40 vs 18) so expressions read across a room, and `canvas.snapshot`
-captures it like any other screen.
+Talk states render as a procedural face instead of text, animated by a tween
+rig: every parameter (eye geometry, gaze, tilt, eyelids, color, mouth) eases
+toward its target with authored curves, so moods and states glide instead of
+snapping. On top of the rig: blink choreography (accelerating close, bounced
+open, occasional double blinks, cat-style slow blinks when happy or sleepy,
+and blinks masking large gaze jumps), saccades with anticipation and
+overshoot, breathing, squash-and-stretch (eyes widen as lids drop), per-eye
+tilt for the eyebrow-less emotional range (outer corners up reads delighted,
+inner corners up reads worried), sliding eyelids, and an arc mouth that rests
+as a mood-shaped smile or frown. While speaking, the mouth becomes three
+equalizer bars driven by the actual playback amplitude with staggered delays,
+and the eyes swell slightly on emphasis. The refresh runs at 60 Hz
+(`LV_DEF_REFR_PERIOD=16`). Errors and setup fall back to text; the face uses
+more AMOLED brightness (40 vs 18) so expressions read across a room, and
+`canvas.snapshot` captures it like any other screen.
+
+`face.gesture {"name":"surprise|yawn|nod|shake"}` plays a short authored
+keyframe gesture; outside a call it pops the face up briefly as a stage. The
+wake word and `talk.start` play the surprise beat automatically, the face
+double-blinks when waking from dark or canvas, and a long-held hint face
+yawns once. Status/talk state is recorded under its own spinlock and painting
+retries on display contention, so a busy display can never lose a state
+transition.
 
 `face.set` styles the face: `{"mood":"neutral|happy|excited|thinking|sleepy|sad","holdMs":0..600000}`.
 During a call — even while canvas covers it — the mood rides the active face
@@ -94,6 +110,7 @@ The node registers these commands. Canvas: `placement` is accepted by `canvas.pr
 | `canvas.a2ui.push` | `{"messages":[{...},{...}]}` or `{"jsonl":"..."}`; `messages` wins when both are present | A2UI payload above |
 | `canvas.a2ui.reset` | `{}` | `{"reset":true}` |
 | `face.set` | `{"mood":"happy","holdMs":8000}` | `{"mood":"happy","holdMs":8000,"visible":true}` |
+| `face.gesture` | `{"name":"nod"}` | `{"gesture":"nod","played":true}` |
 | `talk.start` | `{}` | `{"started":true}` |
 | `talk.stop` | `{}` | `{"stopped":true}` |
 

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -500,6 +500,8 @@ static void on_wake(const char *wake_word, void *ctx)
         return;
     }
     room_ui_set(ROOM_UI_CONNECTING, wake_word);
+    /* The magic beat: eyes snap wide the instant the wake word lands. */
+    room_face_play_gesture(ROOM_FACE_GESTURE_SURPRISE);
     xTaskNotifyGive(talk_start_worker);
 }
 
@@ -771,6 +773,7 @@ static esp_err_t handle_talk_start(
         *out_payload_json = strdup("{\"started\":false,\"alreadyActive\":true}");
     } else {
         room_ui_set(ROOM_UI_CONNECTING, "agent");
+        room_face_play_gesture(ROOM_FACE_GESTURE_SURPRISE);
         xTaskNotifyGive(talk_start_worker);
         *out_payload_json = strdup("{\"started\":true}");
     }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_face.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_face.c
@@ -1,10 +1,16 @@
 /*
- * Procedural agent face for the round AMOLED: two expressive eyes and a
- * speech-reactive mouth, drawn with plain LVGL objects so redraws stay small.
- * A 33 ms LVGL timer owns all geometry; everything the outside world can
- * change (state, mood, speech level) is written atomically and applied on the
- * next tick, so no caller needs anything beyond the display lock LVGL already
- * requires.
+ * Procedural agent face for the round AMOLED, built on a tween rig: every
+ * visible parameter (eye geometry, gaze, tilt, eyelids, color, mouth) carries
+ * a current value and an eased target, so mood and state changes glide
+ * instead of snapping. Layered on top: a blink choreographer (asymmetric
+ * close/open, double blinks, cat-style slow blinks, saccade masking), gaze
+ * with anticipation and overshoot, breathing, speech-reactive mouth bars, and
+ * a small authored keyframe gesture table (surprise, yawn, nod, shake).
+ *
+ * Concurrency model: the tick runs under the LVGL port mutex; every outside
+ * writer (commands, gestures, show/hide) holds the same recursive display
+ * lock, so all animation state is single-lock. The speech level alone is
+ * written lock-free from the audio task as aligned 32-bit values.
  */
 #include "room_face.h"
 
@@ -30,10 +36,99 @@
 #define EYE_GAP 78
 #define EYE_CENTER_Y 200
 #define MOUTH_CENTER_Y 342
-#define MOUTH_W 132
-#define FACE_TICK_MS 33
+#define FACE_TICK_MS 16
 /* Speech level decays to closed when the model pauses mid-utterance. */
-#define SPEECH_LEVEL_STALE_US 300000
+#define SPEECH_STALE_MS 300
+
+/* ---------------------------------------------------------------- tweens */
+
+typedef enum {
+    FACE_EASE_LINEAR = 0,
+    FACE_EASE_OUT_CUBIC,
+    /* Anticipation dip, ~9% overshoot, settle: the "organic motion" curve. */
+    FACE_EASE_OUT_BACK,
+    /* Opens past target then settles: blink-open bounce. */
+    FACE_EASE_OUT_BOUNCE,
+    FACE_EASE_IN_QUAD,
+} face_ease_t;
+
+typedef struct {
+    int32_t from;
+    int32_t to;
+    int32_t value;
+    uint16_t duration_ms;
+    uint16_t elapsed_ms;
+    uint8_t ease;
+} face_tween_t;
+
+/* Piecewise curves; p and the result are Q10 (0..1024). Segment corners are
+ * softened by the 60 Hz tick rate, and the shape (dip/overshoot/settle) is
+ * what the eye actually reads. */
+static int32_t ease_apply(uint8_t ease, int32_t p)
+{
+    switch (ease) {
+    case FACE_EASE_OUT_CUBIC: {
+        int32_t inv = 1024 - p;
+        return 1024 - (int32_t)(((int64_t)inv * inv * inv) >> 20);
+    }
+    case FACE_EASE_OUT_BACK:
+        if (p < 150) {
+            return -(p * 45) / 150;
+        }
+        if (p < 650) {
+            return -45 + ((p - 150) * (1120 + 45)) / 500;
+        }
+        return 1120 - ((p - 650) * (1120 - 1024)) / 374;
+    case FACE_EASE_OUT_BOUNCE:
+        if (p < 800) {
+            int32_t inv = 1024 - (p * 1024) / 800;
+            return 1078 - (int32_t)(((int64_t)inv * inv * 1078) >> 20);
+        }
+        return 1078 - ((p - 800) * (1078 - 1024)) / 224;
+    case FACE_EASE_IN_QUAD:
+        return (int32_t)(((int64_t)p * p) >> 10);
+    default:
+        return p;
+    }
+}
+
+static void tween_go(face_tween_t *t, int32_t to, uint16_t duration_ms, uint8_t ease)
+{
+    if (t->to == to && t->elapsed_ms < t->duration_ms) {
+        return;
+    }
+    t->from = t->value;
+    t->to = to;
+    t->duration_ms = duration_ms > 0 ? duration_ms : 1;
+    t->elapsed_ms = 0;
+    t->ease = ease;
+}
+
+static void tween_jump(face_tween_t *t, int32_t to)
+{
+    t->from = to;
+    t->to = to;
+    t->value = to;
+    t->elapsed_ms = t->duration_ms = 1;
+}
+
+static void tween_step(face_tween_t *t, uint16_t dt_ms)
+{
+    if (t->elapsed_ms >= t->duration_ms) {
+        t->value = t->to;
+        return;
+    }
+    t->elapsed_ms = (uint16_t)(t->elapsed_ms + dt_ms);
+    if (t->elapsed_ms >= t->duration_ms) {
+        t->value = t->to;
+        return;
+    }
+    int32_t p = ((int32_t)t->elapsed_ms * 1024) / t->duration_ms;
+    int32_t eased = ease_apply(t->ease, p);
+    t->value = t->from + (int32_t)(((int64_t)(t->to - t->from) * eased) >> 10);
+}
+
+/* ------------------------------------------------------------------ moods */
 
 typedef enum {
     ROOM_FACE_MOOD_NEUTRAL = 0,
@@ -48,85 +143,419 @@ typedef enum {
 typedef struct {
     const char *name;
     uint32_t color;
-    /* Percent of the base eye height/width the mood settles at. */
     uint8_t eye_h_pct;
     uint8_t eye_w_pct;
     int8_t eye_dy;
-    /* Saccade cadence; excited darts, sleepy barely moves. */
+    /* Signed outer-corner lift in 0.1 deg: positive reads delighted, negative
+     * reads worried — the whole eyebrow-less emotional vocabulary. */
+    int16_t tilt_ddeg;
+    uint8_t lid_pct;
+    /* Resting mouth curve: positive smiles, negative frowns, 0 flat. */
+    int8_t smile;
     uint16_t saccade_min_ms;
     uint16_t saccade_max_ms;
+    /* Chance (percent) a scheduled blink becomes a slow, held cat blink. */
+    uint8_t slow_blink_pct;
 } room_face_mood_style_t;
 
 static const room_face_mood_style_t MOODS[ROOM_FACE_MOOD_COUNT] = {
-    [ROOM_FACE_MOOD_NEUTRAL] = {"neutral", 0x53d7ff, 100, 100, 0, 1600, 3200},
-    [ROOM_FACE_MOOD_HAPPY] = {"happy", 0xffd166, 46, 108, -10, 1400, 2800},
-    [ROOM_FACE_MOOD_EXCITED] = {"excited", 0xff7a4d, 112, 104, -4, 500, 1200},
-    [ROOM_FACE_MOOD_THINKING] = {"thinking", 0x9b8cff, 62, 96, -14, 2200, 3600},
-    [ROOM_FACE_MOOD_SLEEPY] = {"sleepy", 0x62b8a8, 34, 100, 14, 3600, 5600},
-    [ROOM_FACE_MOOD_SAD] = {"sad", 0x5f8bff, 52, 92, 16, 2600, 4200},
+    [ROOM_FACE_MOOD_NEUTRAL] = {"neutral", 0x53d7ff, 100, 100, 0, 0, 0, 24, 1600, 3200, 4},
+    [ROOM_FACE_MOOD_HAPPY] = {"happy", 0xffd166, 72, 106, -8, 34, 0, 96, 1400, 2800, 30},
+    [ROOM_FACE_MOOD_EXCITED] = {"excited", 0xff7a4d, 114, 96, -4, 16, 0, 80, 500, 1100, 0},
+    [ROOM_FACE_MOOD_THINKING] = {"thinking", 0x9b8cff, 80, 96, -12, -10, 12, 8, 2200, 3600, 0},
+    [ROOM_FACE_MOOD_SLEEPY] = {"sleepy", 0x62b8a8, 70, 102, 12, 0, 45, 16, 3600, 5600, 45},
+    [ROOM_FACE_MOOD_SAD] = {"sad", 0x5f8bff, 78, 94, 14, -34, 18, -72, 2600, 4200, 0},
 };
+
+/* --------------------------------------------------------------- gestures */
+
+#define FACE_KF_KEEP INT16_MIN
+/* A keyframe overrides rig targets; FACE_KF_KEEP leaves that channel on its
+ * mood baseline. `restore` retargets everything back over duration_ms. */
+typedef struct {
+    uint16_t duration_ms;
+    uint8_t ease;
+    bool restore;
+    int16_t eye_h_pct;
+    int16_t eye_w_pct;
+    int16_t eye_dy;
+    int16_t tilt_ddeg;
+    int16_t gaze_x;
+    /* 0 hides the "o" mouth; >0 shows a tall oval that percent of max. */
+    int16_t mouth_o_pct;
+} face_keyframe_t;
+
+static const face_keyframe_t GESTURE_SURPRISE[] = {
+    {90, FACE_EASE_OUT_CUBIC, false, 132, 110, -6, 0, FACE_KF_KEEP, 0},
+    {140, FACE_EASE_LINEAR, false, 132, 110, -6, 0, FACE_KF_KEEP, 0},
+    {320, FACE_EASE_OUT_BACK, true, 0, 0, 0, 0, 0, 0},
+};
+static const face_keyframe_t GESTURE_YAWN[] = {
+    {380, FACE_EASE_OUT_CUBIC, false, 26, 108, 8, 0, FACE_KF_KEEP, 88},
+    {260, FACE_EASE_LINEAR, false, 26, 108, 8, 0, FACE_KF_KEEP, 88},
+    {420, FACE_EASE_OUT_CUBIC, true, 0, 0, 0, 0, 0, 0},
+};
+static const face_keyframe_t GESTURE_NOD[] = {
+    {150, FACE_EASE_OUT_CUBIC, false, 92, 100, 16, FACE_KF_KEEP, FACE_KF_KEEP, 0},
+    {140, FACE_EASE_OUT_CUBIC, false, 100, 100, -4, FACE_KF_KEEP, FACE_KF_KEEP, 0},
+    {150, FACE_EASE_OUT_CUBIC, false, 92, 100, 16, FACE_KF_KEEP, FACE_KF_KEEP, 0},
+    {200, FACE_EASE_OUT_BACK, true, 0, 0, 0, 0, 0, 0},
+};
+static const face_keyframe_t GESTURE_SHAKE[] = {
+    {120, FACE_EASE_OUT_CUBIC, false, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, -14, 0},
+    {130, FACE_EASE_OUT_CUBIC, false, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, 14, 0},
+    {120, FACE_EASE_OUT_CUBIC, false, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, FACE_KF_KEEP, -8, 0},
+    {180, FACE_EASE_OUT_BACK, true, 0, 0, 0, 0, 0, 0},
+};
+
+typedef struct {
+    const face_keyframe_t *frames;
+    uint8_t count;
+    const char *name;
+} face_gesture_def_t;
+
+static const face_gesture_def_t GESTURES[] = {
+    [ROOM_FACE_GESTURE_SURPRISE] = {GESTURE_SURPRISE, 3, "surprise"},
+    [ROOM_FACE_GESTURE_YAWN] = {GESTURE_YAWN, 3, "yawn"},
+    [ROOM_FACE_GESTURE_NOD] = {GESTURE_NOD, 4, "nod"},
+    [ROOM_FACE_GESTURE_SHAKE] = {GESTURE_SHAKE, 4, "shake"},
+};
+
+/* -------------------------------------------------------------- rig state */
 
 static lv_obj_t *face_root;
 static lv_obj_t *eye_left;
 static lv_obj_t *eye_right;
-static lv_obj_t *mouth;
+static lv_obj_t *lid_left;
+static lv_obj_t *lid_right;
+static lv_obj_t *mouth_arc;
+static lv_obj_t *mouth_o;
+static lv_obj_t *bars[3];
 static lv_timer_t *face_timer;
 
-/* Cross-task inputs, applied by the timer tick. */
 static volatile room_face_state_t face_state;
-/* Hint lifetime is owned by the face tick (one timeline owner under the LVGL
- * lock); zero while no hint is armed. */
 static int64_t hint_until_us;
+static bool hint_yawned;
+static int64_t hint_shown_at_us;
 static volatile uint8_t face_mood_index;
-static volatile uint8_t speech_level;
-/* 32-bit millisecond stamp: aligned 32-bit stores are atomic on Xtensa, so
- * the audio task can write it lock-free; unsigned math survives wraparound. */
-static volatile uint32_t speech_level_at_ms;
 static volatile int64_t mood_hold_until_us;
 
-/* Timer-task-only animation state. */
+/* Lock-free audio inputs (aligned 32-bit stores are atomic on Xtensa). */
+static volatile uint8_t speech_level;
+static volatile uint32_t speech_level_at_ms;
+
+/* All tweens step under the LVGL lock. */
+static face_tween_t tw_eye_h;   /* percent of EYE_BASE_H */
+static face_tween_t tw_eye_w;   /* percent of EYE_BASE_W */
+static face_tween_t tw_eye_dy;  /* px */
+static face_tween_t tw_tilt;    /* 0.1 deg, +outer-up */
+static face_tween_t tw_lid;     /* percent of eye height covered */
+static face_tween_t tw_gaze_x;  /* px */
+static face_tween_t tw_gaze_y;  /* px */
+static face_tween_t tw_smile;   /* -100..100 */
+static face_tween_t tw_r, tw_g, tw_b;
+static face_tween_t tw_mouth_o; /* percent, 0 hidden */
+static face_tween_t tw_sparkle; /* extra eye percent while speech peaks */
+
+/* Blink choreography. */
+typedef enum { BLINK_IDLE = 0, BLINK_CLOSING, BLINK_HOLD, BLINK_OPENING } blink_phase_t;
+static blink_phase_t blink_phase;
+static uint16_t blink_elapsed_ms;
+static bool blink_slow;
+static bool blink_double_pending;
 static int64_t next_blink_us;
-static int64_t blink_started_us;
+static int64_t last_blink_us;
+static int32_t blink_q10 = 1024; /* 1024 open .. 0 closed; may settle >1024 */
+
+/* Gaze scheduling. */
 static int64_t next_saccade_us;
-static int32_t saccade_x, saccade_y;
-static int32_t eased_dx, eased_dy;
-static int32_t mouth_height_q8;
+
+/* Gesture playback. */
+static const face_gesture_def_t *active_gesture;
+static uint8_t gesture_frame;
+static bool gesture_pending_advance;
+
 static uint32_t tick_count;
+static int64_t last_tick_us;
 
 static uint32_t face_rand(uint32_t bound)
 {
-    /* xorshift keeps blinks/saccades unsynchronized without libc rand state. */
-    static uint32_t state = 0x9d2c5680;
-    state ^= state << 13;
-    state ^= state >> 17;
-    state ^= state << 5;
-    return state % bound;
+    static uint32_t rng = 0x9d2c5680;
+    rng ^= rng << 13;
+    rng ^= rng >> 17;
+    rng ^= rng << 5;
+    return rng % bound;
 }
 
-static void schedule_blink(int64_t now_us)
+static const room_face_mood_style_t *current_mood(room_face_state_t state)
+{
+    room_face_mood_t index = (room_face_mood_t)face_mood_index;
+    if (state == ROOM_FACE_THINKING && index == ROOM_FACE_MOOD_NEUTRAL) {
+        return &MOODS[ROOM_FACE_MOOD_THINKING];
+    }
+    return &MOODS[index];
+}
+
+/* Retarget the rig for the current state+mood; gestures suspend this. */
+static void face_retarget(uint16_t duration_ms, uint8_t ease)
+{
+    room_face_state_t state = face_state;
+    const room_face_mood_style_t *mood = current_mood(state);
+    int32_t eye_h = mood->eye_h_pct;
+    int32_t eye_w = mood->eye_w_pct;
+    if (state == ROOM_FACE_LISTENING || state == ROOM_FACE_HINT) {
+        eye_h = (eye_h * 110) / 100;
+        eye_w = (eye_w * 104) / 100;
+    }
+    tween_go(&tw_eye_h, eye_h, duration_ms, ease);
+    tween_go(&tw_eye_w, eye_w, duration_ms, ease);
+    tween_go(&tw_eye_dy, mood->eye_dy, duration_ms, ease);
+    tween_go(&tw_tilt, mood->tilt_ddeg, duration_ms, ease);
+    tween_go(&tw_lid, mood->lid_pct, duration_ms, ease);
+    tween_go(&tw_smile, mood->smile, duration_ms, ease);
+    tween_go(&tw_mouth_o, 0, duration_ms, FACE_EASE_OUT_CUBIC);
+    lv_color_t c = lv_color_hex(mood->color);
+    tween_go(&tw_r, c.red, duration_ms, FACE_EASE_OUT_CUBIC);
+    tween_go(&tw_g, c.green, duration_ms, FACE_EASE_OUT_CUBIC);
+    tween_go(&tw_b, c.blue, duration_ms, FACE_EASE_OUT_CUBIC);
+}
+
+static void gesture_apply_frame(void)
+{
+    const face_keyframe_t *kf = &active_gesture->frames[gesture_frame];
+    if (kf->restore) {
+        face_retarget(kf->duration_ms, kf->ease);
+        return;
+    }
+    const room_face_mood_style_t *mood = current_mood(face_state);
+    if (kf->eye_h_pct != FACE_KF_KEEP) {
+        tween_go(&tw_eye_h, kf->eye_h_pct, kf->duration_ms, kf->ease);
+    }
+    if (kf->eye_w_pct != FACE_KF_KEEP) {
+        tween_go(&tw_eye_w, kf->eye_w_pct, kf->duration_ms, kf->ease);
+    }
+    if (kf->eye_dy != FACE_KF_KEEP) {
+        tween_go(&tw_eye_dy, mood->eye_dy + kf->eye_dy, kf->duration_ms, kf->ease);
+    }
+    if (kf->tilt_ddeg != FACE_KF_KEEP) {
+        tween_go(&tw_tilt, kf->tilt_ddeg, kf->duration_ms, kf->ease);
+    }
+    if (kf->gaze_x != FACE_KF_KEEP) {
+        tween_go(&tw_gaze_x, kf->gaze_x, kf->duration_ms, kf->ease);
+    }
+    tween_go(&tw_mouth_o, kf->mouth_o_pct, kf->duration_ms, kf->ease);
+}
+
+static void gesture_start(room_face_gesture_t gesture)
+{
+    active_gesture = &GESTURES[gesture];
+    gesture_frame = 0;
+    gesture_pending_advance = false;
+    gesture_apply_frame();
+}
+
+static void gesture_step(void)
+{
+    if (active_gesture == NULL) {
+        return;
+    }
+    /* Frames advance when their primary tween lands; eye_h drives most
+     * gestures and gaze drives shake, so wait on whichever the frame set. */
+    const face_keyframe_t *kf = &active_gesture->frames[gesture_frame];
+    const face_tween_t *lead =
+        kf->gaze_x != FACE_KF_KEEP && kf->eye_h_pct == FACE_KF_KEEP ? &tw_gaze_x : &tw_eye_h;
+    if (kf->restore) {
+        lead = &tw_eye_h;
+    }
+    if (lead->elapsed_ms < lead->duration_ms) {
+        return;
+    }
+    if (gesture_frame + 1 >= active_gesture->count) {
+        active_gesture = NULL;
+        return;
+    }
+    ++gesture_frame;
+    gesture_apply_frame();
+}
+
+/* ------------------------------------------------------------------ blink */
+
+static void schedule_blink(int64_t now_us, const room_face_mood_style_t *mood)
 {
     next_blink_us = now_us + 2200000 + (int64_t)face_rand(2600) * 1000;
+    blink_slow = face_rand(100) < mood->slow_blink_pct;
 }
+
+static void trigger_blink(bool slow, bool make_double)
+{
+    if (blink_phase != BLINK_IDLE) {
+        return;
+    }
+    blink_phase = BLINK_CLOSING;
+    blink_elapsed_ms = 0;
+    blink_slow = slow;
+    blink_double_pending = make_double;
+    last_blink_us = esp_timer_get_time();
+}
+
+static void blink_step(uint16_t dt_ms, int64_t now_us, const room_face_mood_style_t *mood)
+{
+    if (blink_phase == BLINK_IDLE) {
+        if (now_us >= next_blink_us) {
+            trigger_blink(blink_slow, face_rand(100) < 15);
+            schedule_blink(now_us, mood);
+        }
+        blink_q10 = 1024;
+        return;
+    }
+    blink_elapsed_ms = (uint16_t)(blink_elapsed_ms + dt_ms);
+    uint16_t close_ms = blink_slow ? 150 : 60;
+    uint16_t hold_ms = blink_slow ? 160 : 30;
+    uint16_t open_ms = blink_slow ? 230 : 115;
+    switch (blink_phase) {
+    case BLINK_CLOSING: {
+        int32_t p = blink_elapsed_ms >= close_ms ? 1024 : ((int32_t)blink_elapsed_ms * 1024) / close_ms;
+        /* Lids fall: accelerating close reads natural. */
+        blink_q10 = 1024 - ease_apply(FACE_EASE_IN_QUAD, p);
+        if (blink_elapsed_ms >= close_ms) {
+            blink_phase = BLINK_HOLD;
+            blink_elapsed_ms = 0;
+        }
+        break;
+    }
+    case BLINK_HOLD:
+        blink_q10 = 0;
+        if (blink_elapsed_ms >= hold_ms) {
+            blink_phase = BLINK_OPENING;
+            blink_elapsed_ms = 0;
+        }
+        break;
+    case BLINK_OPENING: {
+        int32_t p = blink_elapsed_ms >= open_ms ? 1024 : ((int32_t)blink_elapsed_ms * 1024) / open_ms;
+        /* Decelerating open with a small settle bounce past fully-open. */
+        blink_q10 = ease_apply(FACE_EASE_OUT_BOUNCE, p);
+        if (blink_elapsed_ms >= open_ms) {
+            blink_phase = BLINK_IDLE;
+            blink_q10 = 1024;
+            if (blink_double_pending) {
+                blink_double_pending = false;
+                /* Second blink of a double lands ~140 ms after the first. */
+                next_blink_us = esp_timer_get_time() + 140000;
+                blink_slow = false;
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+/* ------------------------------------------------------------------- gaze */
 
 static void schedule_saccade(int64_t now_us, const room_face_mood_style_t *mood)
 {
     uint32_t span = (uint32_t)(mood->saccade_max_ms - mood->saccade_min_ms);
-    next_saccade_us = now_us + (int64_t)mood->saccade_min_ms * 1000 +
-        (int64_t)face_rand(span) * 1000;
-    saccade_x = (int32_t)face_rand(29) - 14;
-    saccade_y = (int32_t)face_rand(17) - 8;
+    next_saccade_us = now_us + (int64_t)mood->saccade_min_ms * 1000 + (int64_t)face_rand(span) * 1000;
+    int32_t gx = (int32_t)face_rand(29) - 14;
+    int32_t gy = (int32_t)face_rand(17) - 8;
+    if (face_state == ROOM_FACE_THINKING) {
+        gx -= 10;
+        gy -= 12;
+    }
+    int32_t jump_x = gx - tw_gaze_x.value;
+    if (jump_x < 0) {
+        jump_x = -jump_x;
+    }
+    /* Big gaze jumps are masked with a blink, as real eyes do. */
+    if (jump_x > 18 && blink_phase == BLINK_IDLE &&
+        esp_timer_get_time() - last_blink_us > 800000) {
+        trigger_blink(false, false);
+    }
+    uint16_t travel_ms = 220 + (uint16_t)face_rand(90);
+    tween_go(&tw_gaze_x, gx, travel_ms, FACE_EASE_OUT_BACK);
+    tween_go(&tw_gaze_y, gy, travel_ms, FACE_EASE_OUT_BACK);
 }
+
+/* ------------------------------------------------------------------ mouth */
+
+/* Rolling speech levels feed three bars with staggered delays, so the mouth
+ * reads as a wave moving through it rather than three copies of one value. */
+#define LEVEL_RING 12
+static uint8_t level_ring[LEVEL_RING];
+static uint8_t level_ring_at;
+
+static void mouth_apply(int32_t smile, lv_color_t color)
+{
+    bool speaking = face_state == ROOM_FACE_SPEAKING;
+    bool o_mouth = tw_mouth_o.value > 4;
+    if (o_mouth) {
+        int32_t h = 10 + (tw_mouth_o.value * 52) / 100;
+        int32_t w = 44 - (h * 14) / 62;
+        lv_obj_clear_flag(mouth_o, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_size(mouth_o, w, h);
+        lv_obj_set_pos(mouth_o, FACE_WIDTH / 2 - w / 2, MOUTH_CENTER_Y - h / 2);
+        lv_obj_set_style_bg_color(mouth_o, color, 0);
+    } else {
+        lv_obj_add_flag(mouth_o, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    if (speaking && !o_mouth) {
+        lv_obj_add_flag(mouth_arc, LV_OBJ_FLAG_HIDDEN);
+        uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+        uint8_t live = now_ms - speech_level_at_ms > SPEECH_STALE_MS ? 0 : speech_level;
+        level_ring[level_ring_at] = live;
+        level_ring_at = (uint8_t)((level_ring_at + 1) % LEVEL_RING);
+        static const uint8_t TAPS[3] = {1, 5, 9};
+        for (int i = 0; i < 3; ++i) {
+            uint8_t tap = level_ring[(level_ring_at + LEVEL_RING - TAPS[i]) % LEVEL_RING];
+            int32_t h = 8 + ((int32_t)tap * 46) / 255;
+            /* Tall bars narrow slightly: "oh" vs "ee". */
+            int32_t w = 32 - (h * 6) / 54;
+            lv_obj_clear_flag(bars[i], LV_OBJ_FLAG_HIDDEN);
+            lv_obj_set_size(bars[i], w, h);
+            lv_obj_set_pos(bars[i], FACE_WIDTH / 2 - 24 - 48 + i * 48 + (32 - w) / 2,
+                           MOUTH_CENTER_Y - h / 2);
+            lv_obj_set_style_bg_color(bars[i], color, 0);
+        }
+        return;
+    }
+    for (int i = 0; i < 3; ++i) {
+        lv_obj_add_flag(bars[i], LV_OBJ_FLAG_HIDDEN);
+    }
+    if (o_mouth) {
+        lv_obj_add_flag(mouth_arc, LV_OBJ_FLAG_HIDDEN);
+        return;
+    }
+    /* Resting mouth: an arc segment. Positive curve smiles (bottom of a
+     * circle above the mouth line), negative frowns (top of one below). */
+    int32_t curve = smile;
+    if (curve > -8 && curve < 8) {
+        curve = curve < 0 ? -8 : 8;
+    }
+    int32_t mag = curve < 0 ? -curve : curve;
+    int32_t diameter = 300 - mag; /* deeper curve = tighter circle */
+    lv_obj_clear_flag(mouth_arc, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_size(mouth_arc, diameter, diameter);
+    if (curve > 0) {
+        lv_arc_set_bg_angles(mouth_arc, 55, 125);
+        lv_obj_set_pos(mouth_arc, FACE_WIDTH / 2 - diameter / 2,
+                       MOUTH_CENTER_Y - diameter + 26);
+    } else {
+        lv_arc_set_bg_angles(mouth_arc, 235, 305);
+        lv_obj_set_pos(mouth_arc, FACE_WIDTH / 2 - diameter / 2, MOUTH_CENTER_Y - 26);
+    }
+    lv_obj_set_style_arc_color(mouth_arc, color, LV_PART_MAIN);
+}
+
+/* ------------------------------------------------------------------- tick */
 
 static void face_hint_refresh(void *arg)
 {
     (void)arg;
-    /* A face.set may have re-armed the hint between expiry and this callback
-     * (both run under the LVGL lock); the repaint belongs only to a hint that
-     * is still expired. */
     if (face_state == ROOM_FACE_HINT && hint_until_us != 0) {
         return;
     }
-    /* Repaint the stored UI state: idle hides the face and darkens the panel. */
     room_ui_refresh();
 }
 
@@ -138,106 +567,111 @@ static void face_tick(lv_timer_t *timer)
         return;
     }
     int64_t now_us = esp_timer_get_time();
+    uint16_t dt_ms = (uint16_t)((now_us - last_tick_us) / 1000);
+    last_tick_us = now_us;
+    if (dt_ms < 4) {
+        dt_ms = 4;
+    } else if (dt_ms > 50) {
+        dt_ms = 50;
+    }
     ++tick_count;
+
     if (state == ROOM_FACE_HINT && hint_until_us != 0 && now_us >= hint_until_us) {
-        /* Expire the hint from the tick itself: it runs under the LVGL lock,
-         * retries every frame, and a re-armed deadline simply moves it. Keep
-         * the deadline armed if the async alloc fails so the next tick retries
-         * instead of leaving the panel lit forever. */
         if (lv_async_call(face_hint_refresh, NULL) == LV_RESULT_OK) {
             hint_until_us = 0;
         }
         return;
+    }
+    /* A long-held hint earns one yawn. */
+    if (state == ROOM_FACE_HINT && !hint_yawned && active_gesture == NULL &&
+        hint_until_us - now_us > 6000000 && now_us - hint_shown_at_us > 12000000) {
+        hint_yawned = true;
+        gesture_start(ROOM_FACE_GESTURE_YAWN);
     }
 
     room_face_mood_t mood_index = (room_face_mood_t)face_mood_index;
     if (mood_hold_until_us != 0 && now_us > mood_hold_until_us) {
         mood_hold_until_us = 0;
         face_mood_index = ROOM_FACE_MOOD_NEUTRAL;
+        face_retarget(300, FACE_EASE_OUT_CUBIC);
         mood_index = ROOM_FACE_MOOD_NEUTRAL;
     }
-    /* Thinking is a state-derived look unless the agent pinned a mood. */
-    if (state == ROOM_FACE_THINKING && mood_index == ROOM_FACE_MOOD_NEUTRAL) {
-        mood_index = ROOM_FACE_MOOD_THINKING;
-    }
-    /* The hint renders exactly like listening. */
-    if (state == ROOM_FACE_HINT) {
-        state = ROOM_FACE_LISTENING;
-    }
-    const room_face_mood_style_t *mood = &MOODS[mood_index];
+    const room_face_mood_style_t *mood = current_mood(state);
+    (void)mood_index;
 
-    /* Blink: 130 ms close-then-open envelope. */
-    if (blink_started_us == 0 && now_us >= next_blink_us) {
-        blink_started_us = now_us;
-    }
-    int32_t blink_pct = 100;
-    if (blink_started_us != 0) {
-        int64_t phase_us = now_us - blink_started_us;
-        if (phase_us >= 130000) {
-            blink_started_us = 0;
-            schedule_blink(now_us);
-        } else {
-            int32_t p = (int32_t)(phase_us / 1000);
-            blink_pct = p < 65 ? 100 - (p * 94) / 65 : 6 + ((p - 65) * 94) / 65;
-        }
-    }
-
-    /* Saccades ease toward the target so motion reads organic, not stepped. */
-    if (now_us >= next_saccade_us) {
+    gesture_step();
+    blink_step(dt_ms, now_us, mood);
+    if (active_gesture == NULL && now_us >= next_saccade_us) {
         schedule_saccade(now_us, mood);
     }
-    eased_dx += (saccade_x - eased_dx) / 4;
-    eased_dy += (saccade_y - eased_dy) / 4;
 
-    int32_t eye_w = (EYE_BASE_W * mood->eye_w_pct) / 100;
-    int32_t eye_h = (EYE_BASE_H * mood->eye_h_pct) / 100;
-    if (state == ROOM_FACE_LISTENING) {
-        eye_h = (eye_h * 112) / 100;
-        eye_w = (eye_w * 106) / 100;
+    face_tween_t *all[] = {&tw_eye_h, &tw_eye_w, &tw_eye_dy, &tw_tilt, &tw_lid,
+                           &tw_gaze_x, &tw_gaze_y, &tw_smile, &tw_r, &tw_g, &tw_b,
+                           &tw_mouth_o, &tw_sparkle};
+    for (size_t i = 0; i < sizeof(all) / sizeof(all[0]); ++i) {
+        tween_step(all[i], dt_ms);
     }
-    eye_h = (eye_h * blink_pct) / 100;
+
+    /* Speech sparkle: eyes swell slightly on emphasis. */
+    if (state == ROOM_FACE_SPEAKING) {
+        uint32_t now_ms = (uint32_t)(now_us / 1000);
+        bool peak = now_ms - speech_level_at_ms <= SPEECH_STALE_MS && speech_level > 205;
+        tween_go(&tw_sparkle, peak ? 6 : 0, peak ? 90 : 320, FACE_EASE_OUT_CUBIC);
+    } else if (tw_sparkle.to != 0) {
+        tween_go(&tw_sparkle, 0, 200, FACE_EASE_OUT_CUBIC);
+    }
+
+    /* Breathing: slow size-and-bob pulse; stronger while listening. */
+    static const int8_t BREATH[16] = {0, 2, 4, 6, 7, 8, 7, 6, 4, 2, 0, -2, -4, -5, -4, -2};
+    uint32_t breath_period_ticks = 4200 / FACE_TICK_MS; /* ~0.24 Hz */
+    int32_t breath = BREATH[(tick_count * 16 / breath_period_ticks) % 16];
+    bool attentive = state == ROOM_FACE_LISTENING || state == ROOM_FACE_HINT;
+    int32_t bob = attentive ? (breath * 4) / 8 : (breath * 2) / 8;
+    int32_t breath_pct = breath / 4; /* +-1% size */
+
+    /* Compose eye geometry: mood/gesture base x blink x breath x sparkle,
+     * with squash widening the eye as the lid drops (volume conservation). */
+    int32_t h_pct = tw_eye_h.value + breath_pct + tw_sparkle.value;
+    int32_t w_pct = tw_eye_w.value + breath_pct / 2 + tw_sparkle.value;
+    int32_t eye_h = (EYE_BASE_H * h_pct) / 100;
+    int32_t eye_w = (EYE_BASE_W * w_pct) / 100;
+    int32_t bq = blink_q10;
+    if (bq < 0) {
+        bq = 0;
+    }
+    int32_t closed_q10 = bq > 1024 ? 0 : 1024 - bq;
+    eye_h = (int32_t)(((int64_t)eye_h * bq) >> 10);
+    eye_w = eye_w + (int32_t)(((int64_t)eye_w * closed_q10) >> 10) / 6;
     if (eye_h < 6) {
         eye_h = 6;
     }
-    /* Gentle breathing bob while listening; thinking gazes up and away. */
-    int32_t bob = 0;
-    if (state == ROOM_FACE_LISTENING) {
-        static const int8_t BOB[8] = {0, 2, 4, 2, 0, -2, -4, -2};
-        bob = BOB[(tick_count / 6) % 8];
-    }
-    int32_t gaze_dx = state == ROOM_FACE_THINKING ? -12 : 0;
-    int32_t gaze_dy = state == ROOM_FACE_THINKING ? -14 : 0;
 
-    int32_t center_x = FACE_WIDTH / 2 + eased_dx + gaze_dx;
-    int32_t center_y = EYE_CENTER_Y + mood->eye_dy + eased_dy + gaze_dy + bob;
-    lv_color_t color = lv_color_hex(mood->color);
-    lv_obj_set_style_bg_color(eye_left, color, 0);
-    lv_obj_set_style_bg_color(eye_right, color, 0);
-    lv_obj_set_style_bg_color(mouth, color, 0);
-    lv_obj_set_size(eye_left, eye_w, eye_h);
-    lv_obj_set_size(eye_right, eye_w, eye_h);
-    lv_obj_set_pos(eye_left, center_x - EYE_GAP - eye_w / 2, center_y - eye_h / 2);
-    lv_obj_set_pos(eye_right, center_x + EYE_GAP - eye_w / 2, center_y - eye_h / 2);
+    int32_t center_x = FACE_WIDTH / 2 + tw_gaze_x.value;
+    int32_t center_y = EYE_CENTER_Y + tw_eye_dy.value + tw_gaze_y.value + bob;
+    lv_color_t color = lv_color_make((uint8_t)tw_r.value, (uint8_t)tw_g.value, (uint8_t)tw_b.value);
 
-    if (state == ROOM_FACE_SPEAKING) {
-        int32_t level = speech_level;
-        uint32_t age_ms = (uint32_t)(now_us / 1000) - speech_level_at_ms;
-        if (age_ms > SPEECH_LEVEL_STALE_US / 1000) {
-            level = 0;
+    lv_obj_t *eyes[2] = {eye_left, eye_right};
+    lv_obj_t *lids[2] = {lid_left, lid_right};
+    for (int i = 0; i < 2; ++i) {
+        int32_t ex = center_x + (i == 0 ? -EYE_GAP : EYE_GAP) - eye_w / 2;
+        lv_obj_set_style_bg_color(eyes[i], color, 0);
+        lv_obj_set_size(eyes[i], eye_w, eye_h);
+        lv_obj_set_pos(eyes[i], ex, center_y - eye_h / 2);
+        /* +tilt lifts outer corners (delight); -tilt lifts inner (worry). */
+        lv_obj_set_style_transform_rotation(eyes[i], i == 0 ? tw_tilt.value : -tw_tilt.value, 0);
+        int32_t lid_h = (eye_h * tw_lid.value) / 100;
+        if (lid_h > 2) {
+            lv_obj_clear_flag(lids[i], LV_OBJ_FLAG_HIDDEN);
+            lv_obj_set_size(lids[i], eye_w + 10, lid_h + 6);
+            lv_obj_set_pos(lids[i], ex - 5, center_y - eye_h / 2 - 6);
+        } else {
+            lv_obj_add_flag(lids[i], LV_OBJ_FLAG_HIDDEN);
         }
-        /* Fast attack, slow decay: mouths open quickly and close smoothly. */
-        int32_t target_q8 = (8 + (level * 44) / 255) << 8;
-        int32_t rate = target_q8 > mouth_height_q8 ? 2 : 6;
-        mouth_height_q8 += (target_q8 - mouth_height_q8) / rate;
-        int32_t mouth_h = mouth_height_q8 >> 8;
-        lv_obj_clear_flag(mouth, LV_OBJ_FLAG_HIDDEN);
-        lv_obj_set_size(mouth, MOUTH_W, mouth_h);
-        lv_obj_set_pos(mouth, (FACE_WIDTH - MOUTH_W) / 2 + eased_dx / 2, MOUTH_CENTER_Y - mouth_h / 2);
-    } else {
-        lv_obj_add_flag(mouth, LV_OBJ_FLAG_HIDDEN);
-        mouth_height_q8 = 8 << 8;
     }
+    mouth_apply(tw_smile.value, color);
 }
+
+/* -------------------------------------------------------------- lifecycle */
 
 esp_err_t room_face_create(lv_obj_t *parent)
 {
@@ -255,21 +689,63 @@ esp_err_t room_face_create(lv_obj_t *parent)
 
     eye_left = lv_obj_create(face_root);
     eye_right = lv_obj_create(face_root);
-    mouth = lv_obj_create(face_root);
-    if (eye_left == NULL || eye_right == NULL || mouth == NULL) {
-        lv_obj_delete(face_root);
-        face_root = NULL;
-        return ESP_ERR_NO_MEM;
-    }
-    lv_obj_t *parts[] = {eye_left, eye_right, mouth};
-    for (size_t i = 0; i < 3; ++i) {
+    lid_left = lv_obj_create(face_root);
+    lid_right = lv_obj_create(face_root);
+    mouth_arc = lv_arc_create(face_root);
+    mouth_o = lv_obj_create(face_root);
+    bars[0] = lv_obj_create(face_root);
+    bars[1] = lv_obj_create(face_root);
+    bars[2] = lv_obj_create(face_root);
+    lv_obj_t *parts[] = {eye_left, eye_right, lid_left, lid_right, mouth_o,
+                         bars[0], bars[1], bars[2]};
+    bool ok = mouth_arc != NULL;
+    for (size_t i = 0; i < sizeof(parts) / sizeof(parts[0]); ++i) {
+        if (parts[i] == NULL) {
+            ok = false;
+            continue;
+        }
         lv_obj_remove_style_all(parts[i]);
         lv_obj_set_style_bg_opa(parts[i], LV_OPA_COVER, 0);
         lv_obj_set_style_radius(parts[i], 26, 0);
         lv_obj_remove_flag(parts[i], LV_OBJ_FLAG_CLICKABLE);
     }
-    lv_obj_set_style_radius(mouth, 12, 0);
+    if (!ok) {
+        lv_obj_delete(face_root);
+        face_root = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    for (int i = 0; i < 2; ++i) {
+        lv_obj_t *eye = i == 0 ? eye_left : eye_right;
+        lv_obj_set_style_transform_pivot_x(eye, lv_pct(50), 0);
+        lv_obj_set_style_transform_pivot_y(eye, lv_pct(50), 0);
+    }
+    lv_obj_set_style_bg_color(lid_left, lv_color_black(), 0);
+    lv_obj_set_style_bg_color(lid_right, lv_color_black(), 0);
+    lv_obj_set_style_radius(lid_left, 8, 0);
+    lv_obj_set_style_radius(lid_right, 8, 0);
+    lv_obj_set_style_radius(mouth_o, 18, 0);
+    lv_obj_set_style_radius(bars[0], 10, 0);
+    lv_obj_set_style_radius(bars[1], 10, 0);
+    lv_obj_set_style_radius(bars[2], 10, 0);
+    /* The arc is a bare stroke: style its background arc, hide the rest. */
+    lv_obj_remove_style_all(mouth_arc);
+    lv_obj_set_style_arc_width(mouth_arc, 9, LV_PART_MAIN);
+    lv_obj_set_style_arc_rounded(mouth_arc, true, LV_PART_MAIN);
+    lv_obj_set_style_arc_opa(mouth_arc, LV_OPA_COVER, LV_PART_MAIN);
+    lv_obj_set_style_arc_opa(mouth_arc, LV_OPA_TRANSP, LV_PART_INDICATOR);
+    lv_obj_set_style_bg_opa(mouth_arc, LV_OPA_TRANSP, LV_PART_KNOB);
+    lv_obj_remove_flag(mouth_arc, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_flag(face_root, LV_OBJ_FLAG_HIDDEN);
+
+    tween_jump(&tw_eye_h, 100);
+    tween_jump(&tw_eye_w, 100);
+    tween_jump(&tw_gaze_x, 0);
+    tween_jump(&tw_gaze_y, 0);
+    lv_color_t c = lv_color_hex(MOODS[ROOM_FACE_MOOD_NEUTRAL].color);
+    tween_jump(&tw_r, c.red);
+    tween_jump(&tw_g, c.green);
+    tween_jump(&tw_b, c.blue);
+    tween_jump(&tw_smile, MOODS[ROOM_FACE_MOOD_NEUTRAL].smile);
 
     face_timer = lv_timer_create(face_tick, FACE_TICK_MS, NULL);
     if (face_timer == NULL) {
@@ -286,11 +762,18 @@ void room_face_show(room_face_state_t state)
     if (face_root == NULL || state == ROOM_FACE_HIDDEN) {
         return;
     }
+    bool waking = face_state == ROOM_FACE_HIDDEN;
     face_state = state;
     int64_t now_us = esp_timer_get_time();
+    last_tick_us = now_us;
     if (next_blink_us == 0) {
-        schedule_blink(now_us);
-        schedule_saccade(now_us, &MOODS[ROOM_FACE_MOOD_NEUTRAL]);
+        schedule_blink(now_us, &MOODS[ROOM_FACE_MOOD_NEUTRAL]);
+        next_saccade_us = now_us + 600000;
+    }
+    face_retarget(220, FACE_EASE_OUT_CUBIC);
+    if (waking && active_gesture == NULL) {
+        /* Coming back from dark or canvas: a quick double blink says "hi". */
+        trigger_blink(false, true);
     }
     lv_obj_clear_flag(face_root, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_foreground(face_root);
@@ -302,6 +785,8 @@ void room_face_show_hint(int64_t until_us)
     room_face_show(ROOM_FACE_HINT);
     if (face_state == ROOM_FACE_HINT) {
         hint_until_us = until_us;
+        hint_shown_at_us = esp_timer_get_time();
+        hint_yawned = false;
     }
 }
 
@@ -312,6 +797,7 @@ void room_face_hide(void)
     }
     face_state = ROOM_FACE_HIDDEN;
     hint_until_us = 0;
+    active_gesture = NULL;
     lv_obj_add_flag(face_root, LV_OBJ_FLAG_HIDDEN);
     lv_timer_pause(face_timer);
 }
@@ -321,16 +807,44 @@ bool room_face_is_visible(void)
     return face_state != ROOM_FACE_HIDDEN;
 }
 
+void room_face_reset_mood(void)
+{
+    face_mood_index = ROOM_FACE_MOOD_NEUTRAL;
+    mood_hold_until_us = 0;
+}
+
+void room_face_play_gesture(room_face_gesture_t gesture)
+{
+    if ((int)gesture < 0 || (int)gesture >= (int)(sizeof(GESTURES) / sizeof(GESTURES[0]))) {
+        return;
+    }
+    if (!bsp_display_lock(100)) {
+        return;
+    }
+    if (face_root != NULL && face_state != ROOM_FACE_HIDDEN) {
+        gesture_start(gesture);
+        ESP_LOGI(TAG, "gesture: %s", GESTURES[gesture].name);
+    }
+    bsp_display_unlock();
+}
+
 void room_face_set_speech_level(uint8_t level)
 {
     speech_level = level;
     speech_level_at_ms = (uint32_t)(esp_timer_get_time() / 1000);
 }
 
-void room_face_reset_mood(void)
+/* --------------------------------------------------------------- commands */
+
+static esp_err_t face_command_error(
+    esp_openclaw_node_error_t *out_error,
+    const char *code,
+    const char *message,
+    esp_err_t err)
 {
-    face_mood_index = ROOM_FACE_MOOD_NEUTRAL;
-    mood_hold_until_us = 0;
+    out_error->code = code;
+    out_error->message = message;
+    return err;
 }
 
 static esp_err_t handle_face_set(
@@ -346,9 +860,8 @@ static esp_err_t handle_face_set(
     cJSON *params = cJSON_ParseWithLength(params_json, params_len);
     if (!cJSON_IsObject(params)) {
         cJSON_Delete(params);
-        out_error->code = "INVALID_PARAMS";
-        out_error->message = "face.set params must be a JSON object";
-        return ESP_ERR_INVALID_ARG;
+        return face_command_error(
+            out_error, "INVALID_PARAMS", "face.set params must be a JSON object", ESP_ERR_INVALID_ARG);
     }
     cJSON *mood = cJSON_GetObjectItemCaseSensitive(params, "mood");
     cJSON *hold = cJSON_GetObjectItemCaseSensitive(params, "holdMs");
@@ -364,10 +877,11 @@ static esp_err_t handle_face_set(
         (cJSON_IsNumber(hold) && hold->valuedouble >= 0 && hold->valuedouble <= 600000);
     if (mood_index < 0 || !hold_valid) {
         cJSON_Delete(params);
-        out_error->code = "INVALID_PARAMS";
-        out_error->message =
-            "face.set requires mood neutral|happy|excited|thinking|sleepy|sad and optional holdMs 0..600000";
-        return ESP_ERR_INVALID_ARG;
+        return face_command_error(
+            out_error,
+            "INVALID_PARAMS",
+            "face.set requires mood neutral|happy|excited|thinking|sleepy|sad and optional holdMs 0..600000",
+            ESP_ERR_INVALID_ARG);
     }
     int64_t hold_ms = hold != NULL ? (int64_t)hold->valuedouble : 0;
     cJSON_Delete(params);
@@ -376,9 +890,8 @@ static esp_err_t handle_face_set(
      * transitions, which repaint under the same lock. The lock is recursive,
      * so the hint path below may take it again. */
     if (!bsp_display_lock(200)) {
-        out_error->code = "UNAVAILABLE";
-        out_error->message = "the display is busy; retry face.set";
-        return ESP_ERR_TIMEOUT;
+        return face_command_error(
+            out_error, "UNAVAILABLE", "the display is busy; retry face.set", ESP_ERR_TIMEOUT);
     }
     bool talk_active = room_ui_talk_face_active();
     bool canvas_covering = room_canvas_is_active();
@@ -386,8 +899,8 @@ static esp_err_t handle_face_set(
         /* Mood rides the (possibly canvas-covered) talk face; hold 0 keeps it
          * until the call ends. */
         face_mood_index = (uint8_t)mood_index;
-        mood_hold_until_us =
-            hold_ms > 0 ? esp_timer_get_time() + hold_ms * 1000 : 0;
+        mood_hold_until_us = hold_ms > 0 ? esp_timer_get_time() + hold_ms * 1000 : 0;
+        face_retarget(260, FACE_EASE_OUT_CUBIC);
     } else {
         /* No talk session: the mood always times out. Without canvas the face
          * pops up on its own so the expression has a visible outcome; under
@@ -398,6 +911,7 @@ static esp_err_t handle_face_set(
         if (!canvas_covering) {
             room_ui_show_face_hint((uint32_t)show_ms);
         }
+        face_retarget(260, FACE_EASE_OUT_CUBIC);
     }
     bool visible = room_face_is_visible();
     bsp_display_unlock();
@@ -412,18 +926,84 @@ static esp_err_t handle_face_set(
         visible ? "true" : "false");
     *out_payload_json = strdup(payload);
     if (*out_payload_json == NULL) {
-        out_error->code = "INTERNAL";
-        out_error->message = "not enough memory for the command result";
-        return ESP_ERR_NO_MEM;
+        return face_command_error(
+            out_error, "INTERNAL", "not enough memory for the command result", ESP_ERR_NO_MEM);
+    }
+    return ESP_OK;
+}
+
+static esp_err_t handle_face_gesture(
+    esp_openclaw_node_handle_t node,
+    void *context,
+    const char *params_json,
+    size_t params_len,
+    char **out_payload_json,
+    esp_openclaw_node_error_t *out_error)
+{
+    (void)node;
+    (void)context;
+    cJSON *params = cJSON_ParseWithLength(params_json, params_len);
+    cJSON *name = cJSON_IsObject(params)
+        ? cJSON_GetObjectItemCaseSensitive(params, "name")
+        : NULL;
+    const char *text = cJSON_IsString(name) ? name->valuestring : NULL;
+    int index = -1;
+    for (int i = 0; text != NULL && i < (int)(sizeof(GESTURES) / sizeof(GESTURES[0])); ++i) {
+        if (strcmp(text, GESTURES[i].name) == 0) {
+            index = i;
+            break;
+        }
+    }
+    cJSON_Delete(params);
+    if (index < 0) {
+        return face_command_error(
+            out_error,
+            "INVALID_PARAMS",
+            "face.gesture requires name surprise|yawn|nod|shake",
+            ESP_ERR_INVALID_ARG);
+    }
+
+    if (!bsp_display_lock(200)) {
+        return face_command_error(
+            out_error, "UNAVAILABLE", "the display is busy; retry face.gesture", ESP_ERR_TIMEOUT);
+    }
+    bool visible = room_face_is_visible();
+    if (!visible && !room_canvas_is_active()) {
+        /* Give the gesture a stage: pop the hint face up briefly. */
+        room_ui_show_face_hint(6000);
+        visible = room_face_is_visible();
+    }
+    if (visible) {
+        gesture_start((room_face_gesture_t)index);
+    }
+    bsp_display_unlock();
+
+    char payload[80];
+    snprintf(
+        payload,
+        sizeof(payload),
+        "{\"gesture\":\"%s\",\"played\":%s}",
+        GESTURES[index].name,
+        visible ? "true" : "false");
+    *out_payload_json = strdup(payload);
+    if (*out_payload_json == NULL) {
+        return face_command_error(
+            out_error, "INTERNAL", "not enough memory for the command result", ESP_ERR_NO_MEM);
     }
     return ESP_OK;
 }
 
 esp_err_t room_face_register_node_commands(esp_openclaw_node_handle_t node)
 {
-    const esp_openclaw_node_command_t command = {
-        .name = "face.set",
-        .handler = handle_face_set,
+    static const esp_openclaw_node_command_t COMMANDS[] = {
+        {.name = "face.set", .handler = handle_face_set},
+        {.name = "face.gesture", .handler = handle_face_gesture},
     };
-    return esp_openclaw_node_register_command(node, &command);
+    for (size_t i = 0; i < sizeof(COMMANDS) / sizeof(COMMANDS[0]); ++i) {
+        esp_err_t err = esp_openclaw_node_register_command(node, &COMMANDS[i]);
+        if (err != ESP_OK) {
+            return err;
+        }
+    }
+    return ESP_OK;
 }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_face.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_face.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "esp_err.h"
@@ -16,6 +17,14 @@ typedef enum {
     ROOM_FACE_HINT,
 } room_face_state_t;
 
+/** Short authored keyframe gestures layered over the tween rig. */
+typedef enum {
+    ROOM_FACE_GESTURE_SURPRISE = 0,
+    ROOM_FACE_GESTURE_YAWN,
+    ROOM_FACE_GESTURE_NOD,
+    ROOM_FACE_GESTURE_SHAKE,
+} room_face_gesture_t;
+
 /** Create the face widgets on `parent`. Display lock must be held. */
 esp_err_t room_face_create(lv_obj_t *parent);
 
@@ -28,8 +37,11 @@ bool room_face_is_visible(void);
 /** Drop any held mood back to neutral. Display lock must be held. */
 void room_face_reset_mood(void);
 
+/** Play a gesture; takes the display lock internally, callable from any task. */
+void room_face_play_gesture(room_face_gesture_t gesture);
+
 /** Latest playback loudness 0..255; called from the audio render task, lock-free. */
 void room_face_set_speech_level(uint8_t level);
 
-/** Registers the face.set node command. */
+/** Registers the face.set and face.gesture node commands. */
 esp_err_t room_face_register_node_commands(esp_openclaw_node_handle_t node);

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -44,9 +44,38 @@ static lv_obj_t *status_label;
 static lv_obj_t *talk_pill;
 static lv_obj_t *talk_pill_label;
 /* Last state/detail survive canvas mode so leaving it restores the live Talk
- * state instead of forcing idle while a call is still active. */
+ * state instead of forcing idle while a call is still active. Guarded by
+ * their own spinlock so a display-lock timeout can never DROP a transition:
+ * losing the operator-ready IDLE update once left the face stuck in the
+ * connecting look forever. Painting may fail and retry; the fact may not.  */
+static portMUX_TYPE state_mux = portMUX_INITIALIZER_UNLOCKED;
 static room_ui_state_t current_state = ROOM_UI_IDLE;
 static char current_detail[48];
+
+static void repaint_retry_expired(void *arg);
+
+/* One-shot retry: a failed display-lock paint self-heals shortly after. */
+static void arm_repaint_retry(void)
+{
+    static esp_timer_handle_t retry_timer;
+    if (retry_timer == NULL) {
+        const esp_timer_create_args_t args = {
+            .callback = repaint_retry_expired,
+            .name = "ui_repaint",
+        };
+        if (esp_timer_create(&args, &retry_timer) != ESP_OK) {
+            return;
+        }
+    }
+    esp_timer_stop(retry_timer);
+    esp_timer_start_once(retry_timer, 40000);
+}
+
+static void repaint_retry_expired(void *arg)
+{
+    (void)arg;
+    room_ui_refresh();
+}
 
 void room_ui_init(void)
 {
@@ -143,9 +172,15 @@ static bool room_ui_state_uses_face(room_ui_state_t state)
 static bool room_ui_render_locked(void)
 {
     static const char *labels[] = {"OpenClaw", "Listening", "Connecting", "Speaking", "Error", "Setup"};
+    /* Snapshot the fact under its own lock; the writer may not hold ours. */
+    taskENTER_CRITICAL(&state_mux);
+    room_ui_state_t state = current_state;
+    char detail[sizeof(current_detail)];
+    memcpy(detail, current_detail, sizeof(detail));
+    taskEXIT_CRITICAL(&state_mux);
     if (room_canvas_is_active()) {
         room_face_hide();
-        if (current_state == ROOM_UI_IDLE) {
+        if (state == ROOM_UI_IDLE) {
             /* A call that ended behind canvas must not leak its mood into the
              * next call. */
             room_face_reset_mood();
@@ -170,7 +205,7 @@ static bool room_ui_render_locked(void)
                 lv_obj_set_style_text_font(talk_pill_label, &lv_font_montserrat_14, 0);
                 lv_obj_center(talk_pill_label);
             }
-            lv_label_set_text(talk_pill_label, labels[current_state]);
+            lv_label_set_text(talk_pill_label, labels[state]);
             /* The rounded glass clips the corners; top-center stays visible. */
             lv_obj_align(talk_pill, LV_ALIGN_TOP_MID, 0, 14);
         }
@@ -181,10 +216,10 @@ static bool room_ui_render_locked(void)
         talk_pill = NULL;
         talk_pill_label = NULL;
     }
-    if (room_ui_state_uses_face(current_state)) {
+    if (room_ui_state_uses_face(state)) {
         room_face_show(
-            current_state == ROOM_UI_SPEAKING ? ROOM_FACE_SPEAKING
-            : current_state == ROOM_UI_CONNECTING ? ROOM_FACE_THINKING
+            state == ROOM_UI_SPEAKING ? ROOM_FACE_SPEAKING
+            : state == ROOM_UI_CONNECTING ? ROOM_FACE_THINKING
                                                   : ROOM_FACE_LISTENING);
         /* If face creation failed at boot, fall through to the text states. */
         if (room_face_is_visible()) {
@@ -200,9 +235,9 @@ static bool room_ui_render_locked(void)
     lv_obj_clear_flag(status_label, LV_OBJ_FLAG_HIDDEN);
     lv_label_set_text_fmt(
         status_label,
-        current_detail[0] != '\0' ? "%s\n%s" : "%s",
-        labels[current_state],
-        current_detail);
+        detail[0] != '\0' ? "%s\n%s" : "%s",
+        labels[state],
+        detail);
     return true;
 }
 
@@ -216,7 +251,9 @@ bool room_ui_talk_face_active(void)
 static void room_ui_paint_and_unlock(void)
 {
     bool apply_brightness = room_ui_render_locked();
+    taskENTER_CRITICAL(&state_mux);
     room_ui_state_t painted_state = current_state;
+    taskEXIT_CRITICAL(&state_mux);
     bsp_display_unlock();
     if (apply_brightness) {
         /* AMOLED is fully dark while idle; the face gets more headroom than
@@ -234,14 +271,18 @@ void room_ui_set(room_ui_state_t state, const char *detail)
         ESP_LOGE(TAG, "status display is not initialized");
         return;
     }
-    if (!bsp_display_lock(100)) {
-        ESP_LOGE(TAG, "failed to lock display for status update");
-        return;
-    }
+    /* Record the fact unconditionally; rendering is best-effort below. */
+    taskENTER_CRITICAL(&state_mux);
     current_state = state;
     current_detail[0] = '\0';
     if (detail != NULL) {
         strlcpy(current_detail, detail, sizeof(current_detail));
+    }
+    taskEXIT_CRITICAL(&state_mux);
+    if (!bsp_display_lock(100)) {
+        ESP_LOGW(TAG, "display busy; state stored, repaint retries");
+        arm_repaint_retry();
+        return;
     }
     room_ui_paint_and_unlock();
 }
@@ -293,7 +334,7 @@ void room_ui_refresh(void)
         return;
     }
     if (!bsp_display_lock(100)) {
-        ESP_LOGE(TAG, "failed to lock display for status refresh");
+        arm_repaint_retry();
         return;
     }
     /* Repaint the stored state under one lock hold; a concurrent Talk

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/sdkconfig.defaults
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/sdkconfig.defaults
@@ -51,3 +51,6 @@ CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
 # command handling is microsecond-scale JSON work.
 CONFIG_ESP_OPENCLAW_NODE_TASK_PRIORITY=11
 CONFIG_ESP_OPENCLAW_NODE_TRANSPORT_TASK_PRIORITY=11
+# 60 Hz refresh for the animated face: measured face redraw cost is a few
+# MB/s against a ~25 MB/s panel budget. Fast saccades visibly smooth out.
+CONFIG_LV_DEF_REFR_PERIOD=16


### PR DESCRIPTION
## What

The face learns to move like a character instead of a state machine. Everything rides a new tween rig — every visible parameter (eye geometry, gaze, tilt, eyelids, color, mouth) eases toward its target with authored curves (ease-out cubic, anticipation + overshoot, settle bounce) — so moods and states glide into each other instead of snapping.

Layered on the rig:

- **Blink choreography**: accelerating close, decelerating open with a settle bounce, occasional double blinks, cat-style slow held blinks when happy or sleepy, and large gaze jumps masked by a blink the way real eyes do it.
- **Gaze**: saccades with a tiny anticipation dip and ~9% overshoot; thinking gazes up-and-away; breathing bob everywhere (stronger while listening).
- **Shape language**: squash-and-stretch (eyes widen as lids drop), per-eye transform tilt for the eyebrow-less emotional range (outer corners up = delighted, inner corners up = worried), sliding black eyelids for sleepy/half-lidded looks, and an arc mouth that rests as a mood-shaped smile — or a genuine frown for sad.
- **Speaking**: the mouth becomes three equalizer bars driven by the actual playback amplitude with staggered ring-buffer delays (a wave rolls through the mouth), tall bars narrow slightly ("oh" vs "ee"), and the eyes swell on emphasis peaks.
- **Gestures**: an authored keyframe table — surprise, yawn, nod, shake — playable by the agent via the new `face.gesture` command. The wake word and `talk.start` play the surprise beat automatically, waking from dark or canvas double-blinks, and a long-held hint face yawns once.
- **60 Hz** LVGL refresh (`LV_DEF_REFR_PERIOD=16`); measured face redraw cost is a few MB/s against the ~25 MB/s panel budget.

## Root-cause fix included

While verifying, the face got stuck in the connecting look after a reboot. Root cause: `room_ui_set` took the display lock with a 100 ms timeout and **silently dropped the state transition on contention** — the operator-ready IDLE update lost that race once and the stale state persisted forever. State is now recorded under its own spinlock unconditionally (record facts where they happen); painting is best-effort with a 40 ms retry timer. A busy display can never lose a fact again.

## Evidence

On hardware against the live gateway: all six moods snapshot-verified (cyan neutral with soft smile, tilt-lifted yellow happy, tall orange excited, lidded violet thinking, slit-eyed teal sleepy, frowning blue sad), the speaking equalizer bars captured mid-call, all four gestures return `played:true`, the idle hint expires back to idle-dark, and a full `talk.start` → mid-call snapshot → `talk.stop` cycle is green. Motion fluidity itself is inherently un-photographable through the ~1 s snapshot pipeline — that judgment belongs to human eyes on the glass.

Autoreview (gpt-5.6-sol, high): **clean on the first pass** — "patch is correct (0.93)".

Operator note: the new `face.gesture` command needs `gateway.nodes.commands.allow` + one `openclaw nodes approve` (done for the dev gateway; documented in the README).
