### PR TITLE
fix(room-node): keep the canvas surface token warm across idle gaps

### DIFF
--- a/components/esp-openclaw-node/CHANGELOG.md
+++ b/components/esp-openclaw-node/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `esp_openclaw_node_store_plugin_surface_url()` so applications can adopt refreshed capability-scoped surface URLs (for example from a `plugin.surface.refresh` RPC) into the component's canonical store.
 - Point component manifest `url`/`repository` at the repo's new home under the `openclaw` GitHub org.
 - Advertise gateway protocol `minProtocol 3` / `maxProtocol 4`. Current gateways strip plugin-owned capabilities (for example `canvas`) and withhold `pluginSurfaceUrls` from legacy v3-only node sessions.
 - Capture `hello-ok` plugin surface URLs and expose `esp_openclaw_node_dup_plugin_surface_url()` for application URL resolution.

--- a/components/esp-openclaw-node/include/esp_openclaw_node.h
+++ b/components/esp-openclaw-node/include/esp_openclaw_node.h
@@ -403,6 +403,21 @@ char *esp_openclaw_node_dup_plugin_surface_url(
     esp_openclaw_node_handle_t node,
     const char *surface);
 
+/**
+ * @brief Store a refreshed plugin surface URL for @p surface.
+ *
+ * Gateways mint capability-scoped surface URLs with an idle expiry; a
+ * `plugin.surface.refresh` RPC returns a replacement. Storing it here keeps
+ * `esp_openclaw_node_dup_plugin_surface_url()` the single read path. The next
+ * `hello-ok` overwrites the whole set again.
+ *
+ * @return `ESP_OK`, `ESP_ERR_INVALID_ARG`, or `ESP_ERR_NO_MEM`.
+ */
+esp_err_t esp_openclaw_node_store_plugin_surface_url(
+    esp_openclaw_node_handle_t node,
+    const char *surface,
+    const char *url);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/esp-openclaw-node/src/esp_openclaw_node.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node.c
@@ -622,6 +622,44 @@ bool esp_openclaw_node_has_saved_session(esp_openclaw_node_handle_t node)
     return present;
 }
 
+esp_err_t esp_openclaw_node_store_plugin_surface_url(
+    esp_openclaw_node_handle_t node,
+    const char *surface,
+    const char *url)
+{
+    if (node == NULL || surface == NULL || surface[0] == '\0' ||
+        url == NULL || url[0] == '\0') {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_err_t err = ESP_OK;
+    esp_openclaw_node_lock_state(node);
+    cJSON *urls = node->plugin_surface_urls_json != NULL
+        ? cJSON_Parse(node->plugin_surface_urls_json)
+        : NULL;
+    if (!cJSON_IsObject(urls)) {
+        cJSON_Delete(urls);
+        urls = cJSON_CreateObject();
+    }
+    if (urls == NULL) {
+        err = ESP_ERR_NO_MEM;
+    } else {
+        cJSON_DeleteItemFromObjectCaseSensitive(urls, surface);
+        char *serialized = cJSON_AddStringToObject(urls, surface, url) != NULL
+            ? cJSON_PrintUnformatted(urls)
+            : NULL;
+        if (serialized == NULL) {
+            err = ESP_ERR_NO_MEM;
+        } else {
+            free(node->plugin_surface_urls_json);
+            node->plugin_surface_urls_json = serialized;
+        }
+        cJSON_Delete(urls);
+    }
+    esp_openclaw_node_unlock_state(node);
+    return err;
+}
+
 char *esp_openclaw_node_dup_plugin_surface_url(
     esp_openclaw_node_handle_t node,
     const char *surface)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
@@ -114,7 +114,7 @@ The node registers these commands. Canvas: `placement` is accepted by `canvas.pr
 | `talk.start` | `{}` | `{"started":true}` |
 | `talk.stop` | `{}` | `{"stopped":true}` |
 
-`canvas.present`, `canvas.navigate`, and A2UI `Image` components accept HTTP(S) URLs. A URL beginning with `/` is resolved through the Gateway's authenticated `canvas` plugin surface URL and the connected Gateway HTTP origin. The device follows redirects, uses the ESP certificate bundle for HTTPS, and accepts only content whose bytes begin with PNG or JPEG magic. Each fetch has a 10-second timeout.
+`canvas.present`, `canvas.navigate`, and A2UI `Image` components accept HTTP(S) URLs. A URL beginning with `/` is resolved through the Gateway's authenticated `canvas` plugin surface URL and the connected Gateway HTTP origin. The device follows redirects, uses the ESP certificate bundle for HTTPS, and accepts only content whose bytes begin with PNG or JPEG magic. Each fetch has a 10-second timeout. The capability-scoped surface URL the Gateway mints has an idle expiry, so the firmware keeps it warm with a periodic `plugin.surface.refresh` RPC — a present after hours of quiet works exactly like the first one.
 
 Prefer JPEG for photos: the hardware-tuned decoder finishes a full-screen image in ~50 ms and decodes straight into the display buffer, while PNG goes through pure-C lodepng at roughly a tenth of that speed (~500 ms for the same frame). PNG remains the right choice for sharp-edged synthetic content.
 

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -584,6 +584,8 @@ static esp_err_t start_operator_client(void)
     xSemaphoreTake(state_lock, portMAX_DELAY);
     operator_client = created;
     xSemaphoreGive(state_lock);
+    /* The canvas keep-warm refresh needs operator scope. */
+    room_canvas_set_refresh_client(created);
     return esp_openclaw_node_request_connect(created, &request);
 }
 

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -2075,9 +2075,90 @@ esp_err_t room_canvas_init(void)
     return ESP_OK;
 }
 
+/*
+ * The gateway mints the canvas surface URL with a ~10-minute idle expiry and
+ * slides it only on use, so a quiet room's first present after a long gap
+ * used to fail FETCH_FAILED until the next reconnect. Command handlers run on
+ * the component task and cannot wait for a gateway response (the response
+ * would be processed by the very task that is waiting), so instead of a
+ * refresh-and-retry inside the fetch, a periodic RPC keeps the token warm
+ * from the esp_timer task. The response callback stores the fresh URL in the
+ * component, which stays the single read path.
+ */
+#define ROOM_CANVAS_SURFACE_REFRESH_US (8LL * 60 * 1000000)
+
+static void surface_refresh_response(
+    esp_openclaw_node_handle_t responding_client,
+    const esp_openclaw_node_gateway_result_t *result,
+    void *user_ctx)
+{
+    (void)responding_client;
+    (void)user_ctx;
+    if (!result->ok || result->payload_json == NULL) {
+        ESP_LOGW(
+            TAG,
+            "canvas surface refresh failed: %s",
+            result->error_message != NULL ? result->error_message : "unknown");
+        return;
+    }
+    cJSON *payload = cJSON_Parse(result->payload_json);
+    cJSON *urls = cJSON_IsObject(payload)
+        ? cJSON_GetObjectItemCaseSensitive(payload, "pluginSurfaceUrls")
+        : NULL;
+    cJSON *url = cJSON_IsObject(urls)
+        ? cJSON_GetObjectItemCaseSensitive(urls, "canvas")
+        : NULL;
+    /* Store on the NODE client: dup_plugin_surface_url there stays the single
+     * read path for canvas URL resolution regardless of which role minted. */
+    if (cJSON_IsString(url) && url->valuestring != NULL && canvas_node != NULL &&
+        esp_openclaw_node_store_plugin_surface_url(canvas_node, "canvas", url->valuestring) == ESP_OK) {
+        ESP_LOGI(TAG, "canvas surface URL refreshed");
+    } else {
+        ESP_LOGW(TAG, "canvas surface refresh returned no canvas URL");
+    }
+    cJSON_Delete(payload);
+}
+
+static esp_openclaw_node_handle_t refresh_client;
+
+static void surface_refresh_tick(void *arg)
+{
+    (void)arg;
+    if (refresh_client == NULL) {
+        return;
+    }
+    /* plugin.surface.refresh needs operator scope, so it rides the operator
+     * connection; the token it mints authorizes because the gateway accepts a
+     * capability from any live client that owns it. Away from the gateway the
+     * request fails UNAVAILABLE and the next tick retries; a reconnect mints
+     * fresh URLs on its own via hello-ok. */
+    (void)esp_openclaw_node_gateway_request(
+        refresh_client,
+        "plugin.surface.refresh",
+        "{\"surface\":\"canvas\"}",
+        surface_refresh_response,
+        NULL);
+}
+
 void room_canvas_set_node(esp_openclaw_node_handle_t node)
 {
     canvas_node = node;
+}
+
+void room_canvas_set_refresh_client(esp_openclaw_node_handle_t operator_node)
+{
+    refresh_client = operator_node;
+    static esp_timer_handle_t refresh_timer;
+    if (refresh_timer == NULL) {
+        const esp_timer_create_args_t args = {
+            .callback = surface_refresh_tick,
+            .name = "canvas_surface",
+        };
+        if (esp_timer_create(&args, &refresh_timer) == ESP_OK &&
+            esp_timer_start_periodic(refresh_timer, ROOM_CANVAS_SURFACE_REFRESH_US) != ESP_OK) {
+            ESP_LOGW(TAG, "canvas surface keep-warm timer unavailable");
+        }
+    }
 }
 
 void room_canvas_set_gateway_http_base(const char *base_url)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
@@ -9,6 +9,8 @@
 
 esp_err_t room_canvas_init(void);
 void room_canvas_set_node(esp_openclaw_node_handle_t node);
+/** Operator-role client used for plugin.surface.refresh (operator scope). */
+void room_canvas_set_refresh_client(esp_openclaw_node_handle_t operator_node);
 void room_canvas_set_gateway_http_base(const char *base_url);
 bool room_canvas_is_active(void);
 /** Cycle status <-> canvas for the on-device debug controls. */


### PR DESCRIPTION
## What

Fixes the last known correctness gap in the canvas path: the gateway mints the capability-scoped canvas surface URL with a ~10-minute **idle expiry that slides only on use**, so a quiet room's first `canvas.present` after a long gap failed `FETCH_FAILED` until the next reconnect — a silent dead-end on the agent's primary display path.

**Design:** command handlers run on the component task and cannot wait for a gateway response (the response would be processed by the very task that is waiting — refresh-and-retry inside the fetch deadlocks by construction). Instead the firmware mirrors the gateway's sliding-window policy: a periodic `plugin.surface.refresh` RPC (every 8 minutes, from the esp_timer task) keeps the token warm, so the failure mode stops existing rather than being retried around.

Two facts discovered on hardware shaped the final shape:
- `plugin.surface.refresh` requires **operator scope** — the node role is rejected with `unauthorized role: node` (observed live). The refresh rides the device's operator connection; the gateway authorizes a capability held by any live client.
- The refreshed URL is stored into the node client's canonical surface store via the new component API `esp_openclaw_node_store_plugin_surface_url()`, keeping `esp_openclaw_node_dup_plugin_surface_url()` the single read path (component CHANGELOG updated).

## Evidence

Both directions, on the physical device against the live gateway:
- **Before (node-role attempt):** refresh fired at the 8-minute mark and failed `unauthorized role: node`; `canvas.present` after 12.6 idle minutes reproduced the original `FETCH_FAILED`.
- **After (operator routing):** serial logged `canvas surface URL refreshed` at the 8-minute mark; `canvas.present` after **12.8 idle minutes succeeded** — the exact scenario that failed live earlier tonight.

Autoreview (gpt-5.6-sol, high): clean, "patch is correct (0.98)".
