### PR TITLE
fix(node): explicit connect requests preempt the reconnect loop

### DIFF
--- a/components/esp-openclaw-node/README.md
+++ b/components/esp-openclaw-node/README.md
@@ -292,13 +292,18 @@ and explicit auth input on behalf of the application.
 
 Request rules:
 
-- `ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION` is valid only when a saved
-reconnect session is present
-Applications can check saved-session availability with
-`esp_openclaw_node_has_saved_session()` before submitting that request.
-- explicit connect requests are valid only when no session is active and no
-  connect or disconnect request is in flight
-- `esp_openclaw_node_request_disconnect()` is valid only while the node is ready
+- `ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION` is valid only while idle and
+returns `ESP_ERR_NOT_FOUND` when no saved reconnect session is present. The
+persisted session is reloaded from NVS on every saved-session request, so a
+handoff token stored by a sibling-role client is picked up without recreating
+the handle.
+- explicit connect requests (setup code, token, password, no-auth) preempt: an
+in-flight connect attempt ends with a `CONNECT_FAILED(CANCELED)` event and an
+established session ends with `DISCONNECTED(REQUESTED)` before the new attempt
+starts. Automatic reconnect loops must use `SAVED_SESSION` so they can never
+displace an operator-issued request.
+- `esp_openclaw_node_request_disconnect()` disconnects a ready session or
+cancels an in-flight connect attempt (`CONNECT_FAILED(CANCELED)`)
 - once destroy begins, new async requests are rejected
 
 For each accepted connect request, wait for exactly one terminal outcome before

--- a/components/esp-openclaw-node/include/esp_openclaw_node.h
+++ b/components/esp-openclaw-node/include/esp_openclaw_node.h
@@ -66,6 +66,7 @@ typedef enum {
     ESP_OPENCLAW_NODE_CONNECT_FAILURE_CONNECTION_LOST,             /**< The transport dropped before connect completed. */
     ESP_OPENCLAW_NODE_CONNECT_FAILURE_AUTH_REJECTED,               /**< The gateway rejected the auth material or signature. */
     ESP_OPENCLAW_NODE_CONNECT_FAILURE_SESSION_FINALIZATION_FAILED, /**< `hello-ok` handling failed after initial auth acceptance. */
+    ESP_OPENCLAW_NODE_CONNECT_FAILURE_CANCELED,                    /**< The attempt was canceled by a local disconnect or a superseding explicit connect request. */
 } esp_openclaw_node_connect_failure_reason_t;
 
 /** @brief Payload for @ref ESP_OPENCLAW_NODE_EVENT_CONNECT_FAILED. */
@@ -325,15 +326,30 @@ esp_err_t esp_openclaw_node_register_command(
  * - gateway password
  * - no-auth
  *
+ * `SAVED_SESSION` requests are accepted only while idle: they are the
+ * automatic-reconnect path and must never displace an operator-issued attempt.
+ * Every other source is an operator decision and preempts whatever the client
+ * is doing — an in-flight connect attempt or an established session is torn
+ * down first (its terminal event carries the `CANCELED` reason) and the new
+ * attempt starts from the fresh material. Without this, a device stuck
+ * retrying a dead gateway could never be re-provisioned from the console.
+ *
+ * One narrowing of the one-terminal-event rule: an accepted `SAVED_SESSION`
+ * request that loses the race with a concurrent explicit request is dropped
+ * without its own terminal event; the explicit attempt's outcome is the next
+ * event the callback sees, and reconnect loops retry from terminal events
+ * anyway.
+ *
  * @param[in] node Node handle.
  * @param[in] request Connect request to submit.
  *
  * @return
  *      - `ESP_OK` if the request was accepted into the component queue
  *      - `ESP_ERR_INVALID_ARG` if `node` or `request` is invalid
- *      - `ESP_ERR_INVALID_STATE` if a session is already active, another
- *        connect or disconnect request is already in progress, the saved
- *        reconnect session is missing for `SAVED_SESSION`, or destroy has begun
+ *      - `ESP_ERR_INVALID_STATE` if destroy has begun, or a `SAVED_SESSION`
+ *        request arrived while a session or another control request is active
+ *      - `ESP_ERR_NOT_FOUND` if the saved reconnect session is missing for
+ *        `SAVED_SESSION`
  *      - `ESP_ERR_NO_MEM` if the request could not be copied or queued
  *      - `ESP_FAIL` on an unexpected local submission failure
  */
@@ -342,15 +358,20 @@ esp_err_t esp_openclaw_node_request_connect(
     const esp_openclaw_node_connect_request_t *request);
 
 /**
- * @brief Request disconnect of the active session.
+ * @brief Request disconnect of the active session or cancel a connect attempt.
+ *
+ * A ready session ends with a `DISCONNECTED(REQUESTED)` event. An in-flight
+ * connect attempt is aborted and ends with a `CONNECT_FAILED(CANCELED)` event;
+ * without this cancel path, a client retrying an unreachable gateway would be
+ * uncontrollable until its connect timeout expired.
  *
  * @param[in] node Node handle.
  *
  * @return
  *      - `ESP_OK` if the request was accepted into the component queue
  *      - `ESP_ERR_INVALID_ARG` if `node` is `NULL`
- *      - `ESP_ERR_INVALID_STATE` if no active session is present or destroy has
- *        begun
+ *      - `ESP_ERR_INVALID_STATE` if the client is idle (nothing to disconnect),
+ *        another control request is pending, or destroy has begun
  *      - `ESP_ERR_NO_MEM` if the request could not be queued
  *      - `ESP_FAIL` on an unexpected local submission failure
  */

--- a/components/esp-openclaw-node/src/esp_openclaw_node.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node.c
@@ -556,6 +556,29 @@ esp_err_t esp_openclaw_node_request_connect(
         return ESP_ERR_INVALID_ARG;
     }
 
+    if (request->source == ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION) {
+        /* NVS is the authoritative session store and a sibling client can
+         * update it behind this handle's back: a re-pair on the node-role
+         * client persists a fresh operator handoff token that this handle's
+         * boot-time snapshot has never seen. Reload before every
+         * saved-session attempt so recovery needs no handle recreation. */
+        esp_openclaw_node_persisted_session_t fresh = {0};
+        esp_err_t load_err = esp_openclaw_node_persisted_session_load(
+            node->config.role,
+            &fresh);
+        if (load_err == ESP_OK) {
+            esp_openclaw_node_lock_state(node);
+            esp_openclaw_node_persisted_session_free(&node->persisted_session);
+            node->persisted_session = fresh;
+            esp_openclaw_node_unlock_state(node);
+        } else {
+            ESP_LOGW(
+                ESP_OPENCLAW_NODE_TAG,
+                "saved-session reload from NVS failed, using in-memory copy: %s",
+                esp_err_to_name(load_err));
+        }
+    }
+
     esp_openclaw_node_connect_request_source_t connect_source = {0};
     esp_err_t err =
         esp_openclaw_node_build_connect_source_from_request(

--- a/components/esp-openclaw-node/src/esp_openclaw_node_connect_source.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_connect_source.c
@@ -318,8 +318,10 @@ void esp_openclaw_node_free_connect_material(esp_openclaw_node_connect_material_
 static esp_err_t validate_saved_session_connect_preflight_locked(
     esp_openclaw_node_handle_t node)
 {
+    /* NOT_FOUND (not INVALID_STATE) so callers can tell "no session material
+     * exists, re-pair" apart from "client is busy, retry later". */
     if (!esp_openclaw_node_saved_session_is_present_locked(node)) {
-        return ESP_ERR_INVALID_STATE;
+        return ESP_ERR_NOT_FOUND;
     }
     return esp_openclaw_node_validate_tls_preflight(
         &node->config,
@@ -410,10 +412,20 @@ esp_err_t esp_openclaw_node_reserve_connect_request_locked(
         node->state == ESP_OPENCLAW_NODE_INTERNAL_CLOSED) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (node->state != ESP_OPENCLAW_NODE_INTERNAL_IDLE) {
+
+    /* The control slot is single-entry: a second request while one is queued
+     * would race for it and drop silently. */
+    if (node->pending_control != ESP_OPENCLAW_NODE_PENDING_CONTROL_REQUEST_NONE) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (node->pending_control != ESP_OPENCLAW_NODE_PENDING_CONTROL_REQUEST_NONE) {
+    /* Saved-session requests come from automatic reconnect loops and must
+     * never displace anything: idle-only. Explicit sources are operator
+     * decisions and also reserve from CONNECTING/READY — the worker tears the
+     * old attempt or session down (CANCELED/REQUESTED terminal event) before
+     * starting the new one. Without this preemption a device retrying a dead
+     * gateway can never be re-provisioned from the console. */
+    if (source->kind == ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_SAVED_SESSION &&
+        node->state != ESP_OPENCLAW_NODE_INTERNAL_IDLE) {
         return ESP_ERR_INVALID_STATE;
     }
 

--- a/components/esp-openclaw-node/src/esp_openclaw_node_protocol.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_protocol.c
@@ -552,7 +552,10 @@ static connect_response_finalize_result_t finalize_connect_response_success(
         free(node->plugin_surface_urls_json);
         node->plugin_surface_urls_json = plugin_surface_urls_json;
         node->state = ESP_OPENCLAW_NODE_INTERNAL_READY;
-        esp_openclaw_node_clear_pending_control_locked(node);
+        /* Do NOT clear pending_control here: this attempt's CONNECT
+         * reservation was already consumed when the transport started, so
+         * anything present now is a queued disconnect/preempt that must still
+         * run against the ready session — clearing it loses that request. */
         esp_openclaw_node_clear_session_wait_state_locked(node);
         esp_openclaw_node_clear_connect_source_struct(&node->active_connect_source);
         result.outcome = CONNECT_RESPONSE_OUTCOME_CONNECTED;

--- a/components/esp-openclaw-node/src/esp_openclaw_node_runtime.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_runtime.c
@@ -129,12 +129,46 @@ static void handle_request_connect(
     esp_openclaw_node_work_message_t *message)
 {
     esp_openclaw_node_lock_state(node);
-    bool ready_to_start =
-        node->state == ESP_OPENCLAW_NODE_INTERNAL_IDLE &&
-        node->pending_control == ESP_OPENCLAW_NODE_PENDING_CONTROL_REQUEST_CONNECT;
-    if (!ready_to_start) {
+    esp_openclaw_node_internal_state_t state = node->state;
+    if (state == ESP_OPENCLAW_NODE_INTERNAL_DESTROYING ||
+        state == ESP_OPENCLAW_NODE_INTERNAL_CLOSED) {
         esp_openclaw_node_unlock_state(node);
         return;
+    }
+    if (state != ESP_OPENCLAW_NODE_INTERNAL_IDLE) {
+        /* Saved-session requests are reconnect-loop traffic: reserved
+         * idle-only, but a preempting explicit request can slip in before
+         * this message is processed. Drop it rather than let auto-reconnect
+         * cancel an operator-issued attempt; the loop retries on the next
+         * terminal event. */
+        if (message->connect_source.kind ==
+            ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_SAVED_SESSION) {
+            esp_openclaw_node_unlock_state(node);
+            return;
+        }
+        /* An explicit request reserved over a live attempt/session: tear the
+         * old one down first so its terminal event fires before the new
+         * attempt starts. */
+        esp_openclaw_node_unlock_state(node);
+        if (esp_openclaw_node_state_is_connecting(state)) {
+            esp_openclaw_node_complete_connect_failed(
+                node,
+                ESP_OPENCLAW_NODE_CONNECT_FAILURE_CANCELED,
+                ESP_OK,
+                NULL,
+                true);
+        } else {
+            esp_openclaw_node_complete_disconnected(
+                node,
+                ESP_OPENCLAW_NODE_DISCONNECTED_REASON_REQUESTED,
+                ESP_OK,
+                true);
+        }
+        esp_openclaw_node_lock_state(node);
+        if (node->state != ESP_OPENCLAW_NODE_INTERNAL_IDLE) {
+            esp_openclaw_node_unlock_state(node);
+            return;
+        }
     }
     esp_openclaw_node_clear_pending_control_locked(node);
     esp_openclaw_node_clear_connect_source_struct(&node->active_connect_source);
@@ -160,11 +194,27 @@ static void handle_request_disconnect(esp_openclaw_node_handle_t node)
     esp_openclaw_node_lock_state(node);
     bool request_pending =
         node->pending_control == ESP_OPENCLAW_NODE_PENDING_CONTROL_REQUEST_DISCONNECT;
+    bool was_connecting = esp_openclaw_node_state_is_connecting(node->state);
     bool has_transport =
         node->ws != NULL || node->active_transport_id != 0;
     esp_openclaw_node_unlock_state(node);
 
     if (!request_pending) {
+        /* The session/attempt this targeted already terminated on its own;
+         * complete_* cleared the reservation and emitted the terminal event. */
+        return;
+    }
+
+    /* A canceled connect attempt is a CONNECT_FAILED terminal, not
+     * DISCONNECTED: callers wait for exactly one outcome per accepted
+     * connect request. */
+    if (was_connecting) {
+        esp_openclaw_node_complete_connect_failed(
+            node,
+            ESP_OPENCLAW_NODE_CONNECT_FAILURE_CANCELED,
+            ESP_OK,
+            NULL,
+            has_transport);
         return;
     }
 
@@ -446,7 +496,10 @@ static esp_err_t reserve_disconnect_request_locked(esp_openclaw_node_handle_t no
         return ESP_ERR_INVALID_STATE;
     }
 
-    if (node->state != ESP_OPENCLAW_NODE_INTERNAL_READY) {
+    /* CONNECTING is accepted as a cancel: without it, a client retrying an
+     * unreachable gateway is uncontrollable until its connect timeout. */
+    if (node->state != ESP_OPENCLAW_NODE_INTERNAL_READY &&
+        !esp_openclaw_node_state_is_connecting(node->state)) {
         return ESP_ERR_INVALID_STATE;
     }
     if (node->pending_control != ESP_OPENCLAW_NODE_PENDING_CONTROL_REQUEST_NONE) {

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
@@ -782,7 +782,7 @@ TEST_CASE("connect saved session without persisted session fails", "[esp_opencla
     TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_create(&config, &node));
     TEST_ASSERT_NOT_NULL(node);
     TEST_ASSERT_FALSE(esp_openclaw_node_has_saved_session(node));
-    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, request_connect_saved_session(node));
+    TEST_ASSERT_EQUAL(ESP_ERR_NOT_FOUND, request_connect_saved_session(node));
 
     TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_destroy(node));
 }
@@ -1150,7 +1150,7 @@ TEST_CASE("node.invoke.request is ignored until handshake reaches ready", "[esp_
     vSemaphoreDelete(command_ctx.release);
 }
 
-TEST_CASE("disconnect is rejected while transport start is in progress", "[esp_openclaw_node][transport]")
+TEST_CASE("disconnect while transport start is in progress cancels the attempt", "[esp_openclaw_node][transport]")
 {
     reset_openclaw_storage();
     reset_transport_state();
@@ -1173,12 +1173,13 @@ TEST_CASE("disconnect is rejected while transport start is in progress", "[esp_o
         ESP_OK,
         request_connect_no_auth(node, "ws://gateway.example/ws"));
     TEST_ASSERT_TRUE(xSemaphoreTake(s_transport_state.start_entered, pdMS_TO_TICKS(1000)) == pdTRUE);
-    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, esp_openclaw_node_request_disconnect(node));
+    /* The cancel is accepted while the attempt is connecting; it is processed
+     * after the blocked transport start returns. */
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_request_disconnect(node));
     TEST_ASSERT_TRUE(xSemaphoreGive(s_transport_state.start_release) == pdTRUE);
 
     TEST_ASSERT_TRUE(wait_for_event(ESP_OPENCLAW_NODE_EVENT_CONNECT_FAILED, pdMS_TO_TICKS(1000)));
     TEST_ASSERT_EQUAL(0, s_event_recorder.connected_count);
-    TEST_ASSERT_EQUAL(1, s_event_recorder.connect_failed_count);
     TEST_ASSERT_EQUAL(0, s_event_recorder.disconnected_count);
     TEST_ASSERT_FALSE(esp_openclaw_node_has_saved_session(node));
 
@@ -1189,7 +1190,7 @@ TEST_CASE("disconnect is rejected while transport start is in progress", "[esp_o
     s_transport_state.start_release = NULL;
 }
 
-TEST_CASE("disconnect is rejected after connect request send while still connecting", "[esp_openclaw_node][transport]")
+TEST_CASE("disconnect after connect request send cancels before hello-ok lands", "[esp_openclaw_node][transport]")
 {
     reset_openclaw_storage();
     reset_transport_state();
@@ -1223,7 +1224,10 @@ TEST_CASE("disconnect is rejected after connect request send while still connect
 
     char *connect_id = extract_first_json_id(s_transport_state.last_sent_text);
     TEST_ASSERT_NOT_NULL(connect_id);
-    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, esp_openclaw_node_request_disconnect(node));
+    /* The cancel is accepted while connecting and is queued ahead of the
+     * hello-ok data event, so the attempt ends CONNECT_FAILED(CANCELED) and
+     * the late hello-ok is dropped against the torn-down transport. */
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_request_disconnect(node));
 
     char connect_response[512] = {0};
     snprintf(
@@ -1235,11 +1239,14 @@ TEST_CASE("disconnect is rejected after connect request send while still connect
     TEST_ASSERT_TRUE(xSemaphoreGive(s_transport_state.send_text_release) == pdTRUE);
     emit_ws_event(WEBSOCKET_EVENT_DATA, connect_response, ESP_OK);
 
-    TEST_ASSERT_TRUE(wait_for_event(ESP_OPENCLAW_NODE_EVENT_CONNECTED, pdMS_TO_TICKS(1000)));
-    TEST_ASSERT_EQUAL(1, s_event_recorder.connected_count);
-    TEST_ASSERT_EQUAL(0, s_event_recorder.connect_failed_count);
+    TEST_ASSERT_TRUE(wait_for_event(ESP_OPENCLAW_NODE_EVENT_CONNECT_FAILED, pdMS_TO_TICKS(2000)));
+    TEST_ASSERT_EQUAL(0, s_event_recorder.connected_count);
+    TEST_ASSERT_EQUAL(1, s_event_recorder.connect_failed_count);
     TEST_ASSERT_EQUAL(0, s_event_recorder.disconnected_count);
-    TEST_ASSERT_TRUE(esp_openclaw_node_has_saved_session(node));
+    TEST_ASSERT_EQUAL(
+        ESP_OPENCLAW_NODE_CONNECT_FAILURE_CANCELED,
+        s_event_recorder.connect_failed_reason);
+    TEST_ASSERT_FALSE(esp_openclaw_node_has_saved_session(node));
 
     TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_destroy(node));
     vSemaphoreDelete(s_transport_state.send_text_entered);

--- a/examples/common/esp_openclaw_node_example_saved_session_reconnect.c
+++ b/examples/common/esp_openclaw_node_example_saved_session_reconnect.c
@@ -30,16 +30,17 @@ static void esp_openclaw_node_example_saved_session_reconnect_task(void *arg)
         if (!esp_openclaw_node_wifi_wait_for_connection(portMAX_DELAY)) {
             continue;
         }
-        if (!esp_openclaw_node_has_saved_session(state->node)) {
-            ESP_LOGI(TAG, "saved-session reconnect skipped because no saved session is available");
-            continue;
-        }
 
         vTaskDelay(pdMS_TO_TICKS(1000));
 
+        /* No has_saved_session precheck: it reads a possibly stale in-memory
+         * snapshot, while the component reloads NVS on every saved-session
+         * request and answers NOT_FOUND itself. */
         esp_err_t err = esp_openclaw_node_request_connect(state->node, &request);
         if (err == ESP_OK) {
             ESP_LOGI(TAG, "requested saved-session reconnect");
+        } else if (err == ESP_ERR_NOT_FOUND) {
+            ESP_LOGI(TAG, "saved-session reconnect skipped because no saved session is available");
         } else if (err != ESP_ERR_INVALID_STATE) {
             ESP_LOGW(TAG, "saved-session reconnect request failed: %s", esp_err_to_name(err));
         }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -47,7 +47,6 @@ static bool talk_closing;
 /* Set by talk.stop while the worker is still dialing; the worker must abandon
  * the session before the microphone path goes live. */
 static bool talk_cancel_requested;
-static bool operator_start_scheduled;
 static bool node_reconnect_scheduled;
 
 typedef struct {
@@ -55,10 +54,12 @@ typedef struct {
     bool failed;
 } talk_teardown_request_t;
 
-static void start_operator_task(void *arg);
 static void start_talk_once(void);
 static esp_err_t register_talk_node_commands(esp_openclaw_node_handle_t node);
 static TaskHandle_t talk_start_worker;
+static TaskHandle_t operator_start_worker;
+/* Pending delay for the next operator start; guarded by state_lock. */
+static uint32_t operator_start_delay_ms;
 
 /*
  * The Talk starter is a persistent worker created at boot, when internal RAM
@@ -208,28 +209,17 @@ static char *derive_gateway_http_base(void)
 
 static bool schedule_operator_start(uint32_t delay_ms)
 {
-    xSemaphoreTake(state_lock, portMAX_DELAY);
-    bool schedule = !operator_start_scheduled;
-    if (schedule) {
-        operator_start_scheduled = true;
-    }
-    xSemaphoreGive(state_lock);
-    if (!schedule) {
-        return true;
-    }
-    if (xTaskCreate(
-            start_operator_task,
-            "operator_start",
-            6144,
-            (void *)(uintptr_t)delay_ms,
-            6,
-            NULL) == pdPASS) {
-        return true;
+    /* Persistent PSRAM worker (like talk_start): a per-attempt xTaskCreate
+     * here needed contiguous internal RAM at the busiest boot moment and
+     * failed exactly when the operator session was about to come up. */
+    if (operator_start_worker == NULL) {
+        return false;
     }
     xSemaphoreTake(state_lock, portMAX_DELAY);
-    operator_start_scheduled = false;
+    operator_start_delay_ms = delay_ms;
     xSemaphoreGive(state_lock);
-    return false;
+    xTaskNotifyGive(operator_start_worker);
+    return true;
 }
 
 static void media_thread_scheduler(const char *name, media_lib_thread_cfg_t *config)
@@ -552,9 +542,10 @@ static esp_err_t start_operator_client(void)
     esp_openclaw_node_handle_t existing = operator_client;
     xSemaphoreGive(state_lock);
     if (existing != NULL) {
-        if (!esp_openclaw_node_has_saved_session(existing)) {
-            return ESP_ERR_NOT_FOUND;
-        }
+        /* No has_saved_session precheck: the component reloads NVS on every
+         * saved-session connect, so a handoff token persisted later by the
+         * node client (console re-pair) is picked up here. The precheck read
+         * a stale in-memory snapshot and wedged this loop forever. */
         const esp_openclaw_node_connect_request_t reconnect = {
             .source = ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION,
         };
@@ -589,36 +580,49 @@ static esp_err_t start_operator_client(void)
     return esp_openclaw_node_request_connect(created, &request);
 }
 
-static void start_operator_task(void *arg)
+static void operator_start_worker_task(void *arg)
 {
-    uint32_t delay_ms = (uint32_t)(uintptr_t)arg;
-    if (delay_ms > 0) {
-        vTaskDelay(pdMS_TO_TICKS(delay_ms));
+    (void)arg;
+    for (;;) {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        xSemaphoreTake(state_lock, portMAX_DELAY);
+        uint32_t delay_ms = operator_start_delay_ms;
+        xSemaphoreGive(state_lock);
+        if (delay_ms > 0) {
+            vTaskDelay(pdMS_TO_TICKS(delay_ms));
+            /* A newer request may have arrived while sleeping; its notify is
+             * pending and the next loop iteration handles it immediately. */
+        }
+        esp_err_t err = start_operator_client();
+        if (err != ESP_OK) {
+            // Every retry logs: the display alone cannot say WHY the operator
+            // session is down, and a silent loop here cost a debugging session.
+            ESP_LOGW(TAG, "operator client start failed: %s (retrying)", esp_err_to_name(err));
+            room_ui_set(
+                ROOM_UI_ERROR,
+                err == ESP_ERR_NOT_FOUND ? "No operator session\nre-pair via console" : "Operator token");
+            (void)schedule_operator_start(5000);
+        }
     }
-    // A synchronous/fast connect failure must be able to schedule the next retry.
-    xSemaphoreTake(state_lock, portMAX_DELAY);
-    operator_start_scheduled = false;
-    xSemaphoreGive(state_lock);
-    esp_err_t err = start_operator_client();
-    if (err != ESP_OK) {
-        room_ui_set(ROOM_UI_ERROR, "Operator token");
-        (void)schedule_operator_start(5000);
-    }
-    vTaskDelete(NULL);
 }
 
 static esp_err_t request_node_connection(void)
 {
-    esp_openclaw_node_connect_request_t request = {0};
-    if (esp_openclaw_node_has_saved_session(node_client)) {
-        request.source = ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION;
-    } else {
-        if (CONFIG_OPENCLAW_ROOM_SETUP_CODE[0] == '\0') {
-            return ESP_ERR_NOT_FOUND;
-        }
-        request.source = ESP_OPENCLAW_NODE_CONNECT_SOURCE_SETUP_CODE;
-        request.value = CONFIG_OPENCLAW_ROOM_SETUP_CODE;
+    /* Saved session first (the component reloads it from NVS per request);
+     * only a NOT_FOUND answer falls back to the baked setup code so a live
+     * console-provisioned session is never clobbered by stale Kconfig. */
+    esp_openclaw_node_connect_request_t request = {
+        .source = ESP_OPENCLAW_NODE_CONNECT_SOURCE_SAVED_SESSION,
+    };
+    esp_err_t err = esp_openclaw_node_request_connect(node_client, &request);
+    if (err != ESP_ERR_NOT_FOUND) {
+        return err;
     }
+    if (CONFIG_OPENCLAW_ROOM_SETUP_CODE[0] == '\0') {
+        return ESP_ERR_NOT_FOUND;
+    }
+    request.source = ESP_OPENCLAW_NODE_CONNECT_SOURCE_SETUP_CODE;
+    request.value = CONFIG_OPENCLAW_ROOM_SETUP_CODE;
     return esp_openclaw_node_request_connect(node_client, &request);
 }
 
@@ -685,9 +689,9 @@ static void node_event(
         char *gateway_http_base = derive_gateway_http_base();
         room_canvas_set_gateway_http_base(gateway_http_base);
         free(gateway_http_base);
-        if (!schedule_operator_start(0)) {
-            room_ui_set(ROOM_UI_ERROR, "Operator token");
-        }
+        /* The persistent worker exists before the node client starts, so this
+         * cannot fail; the worker loop owns all retry/error reporting. */
+        (void)schedule_operator_start(0);
     } else {
         room_ui_set(ROOM_UI_ERROR, "Node offline");
         schedule_node_reconnect(2000);
@@ -904,6 +908,17 @@ void app_main(void)
         &talk_start_worker,
         MALLOC_CAP_SPIRAM);
     ESP_ERROR_CHECK(starter_task == pdPASS ? ESP_OK : ESP_ERR_NO_MEM);
+    /* Internal stack (NOT PSRAM like talk_start): this worker calls
+     * esp_openclaw_node_create, whose NVS reads run flash operations, and
+     * flash ops assert unless every running stack is cache-safe internal RAM. */
+    BaseType_t operator_task = xTaskCreate(
+        operator_start_worker_task,
+        "operator_start",
+        6144,
+        NULL,
+        6,
+        &operator_start_worker);
+    ESP_ERROR_CHECK(operator_task == pdPASS ? ESP_OK : ESP_ERR_NO_MEM);
     BaseType_t teardown_task = xTaskCreate(
         talk_teardown_task,
         "talk_teardown",


### PR DESCRIPTION
## What Problem This Solves

Two silent-failure classes around gateway re-pairing on live devices:

1. **Console re-provisioning race**: `gateway setup-code` (and token/password/no-auth) returned `ESP_ERR_INVALID_STATE` whenever the auto-reconnect loop held the client out of idle — which is precisely the state a device is stuck in when its gateway is dead and it *needs* re-provisioning. `gateway disconnect` also refused while connecting, so there was no console escape hatch at all; the only workaround was firing the command inside the ~2s idle gap between retries.

2. **Stale operator session after re-pair**: each client handle snapshots its NVS session once at create. When the node-role client re-pairs and the gateway hands off a fresh operator token (`deviceTokens` in hello-ok), the already-running operator client keeps retrying its stale token forever — the room-node display shows "Error / Operator token" with zero serial output.

## Why This Change Was Made

Ownership fix at the source-kind boundary: saved-session connects are automatic reconnect traffic (idle-only, never displace anything); explicit sources are operator decisions and preempt — an in-flight attempt ends `CONNECT_FAILED(CANCELED)`, a live session ends `DISCONNECTED(REQUESTED)`, then the new attempt starts. `request_disconnect` now cancels a connecting attempt. Saved-session connects reload NVS at request time so sibling-role handoffs become visible without recreating handles; missing session is now `ESP_ERR_NOT_FOUND` (distinct from busy). Room-node example: operator start failures log + retry instead of painting a dead-end error.

## User Impact

`gateway setup-code` works whenever an operator types it, including mid-retry against an unreachable gateway. Re-pairing to a new gateway heals the operator/Talk session automatically. No more silent "Operator token" display dead-end.

## Evidence

Proven live on the Waveshare AMOLED room node against a real gateway (clawstudio):
- pointed the node at a dead gateway (`ws://192.0.2.1`), fired a real setup-code mid-retry → preempted instantly, `bootstrap-token` handshake complete (previously `ESP_ERR_INVALID_STATE`)
- fired setup-code while CONNECTED → session torn down, re-paired in one command
- reboot after re-pair → `operator Talk session ready; ambient WakeNet armed` ~7s after boot; face.set/talk verified via node.invoke
- component unity-test app + room-node example build clean (ESP-IDF 5.5, esp32s3); the two disconnect-while-connecting unity tests updated to the new cancel contract, saved-session NOT_FOUND test updated
- new failure enum value is additive; existing reason values unchanged
