### PR TITLE
feat(room-node): production tap behavior — face + gateway line

### DIFF
--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md
@@ -35,9 +35,9 @@ WakeNet remains active while playback is running and consumes the AEC-cleaned ca
 
 Canvas mode uses a separate 410x502 LVGL screen at 80% brightness. Hiding it returns to the status screen; a user-initiated exit leaves a readable hint rather than dropping straight to the AMOLED-off idle policy. Talk state changes do not replace active Canvas content; a small status pill appears at the top-center until Talk returns to idle.
 
-**Safe area.** The glass has large rounded corners, so laid-out content (A2UI, placeholder, test card) is inset 32 px — the same idea as Apple's safe area. Presented images are intentionally full-bleed, like wallpaper.
+**Safe area.** The glass has large rounded corners, so laid-out content (A2UI, placeholder) is inset 32 px — the same idea as Apple's safe area. Presented images are intentionally full-bleed, like wallpaper.
 
-**On-device controls.** Tapping the screen or pressing the BOOT button cycles status, a safe-area test card, and a solid fill. The test card draws a border exactly on the safe-area inset with markers at its corners; the solid fill has no content variation, so together they separate panel/transfer artifacts from rendering artifacts without a serial console. The PWR button is hardware power management and is not GPIO-visible.
+**On-device controls.** Tapping the screen or pressing the BOOT button wakes the face for a few seconds with the connected gateway (host:port) shown underneath — or, when the agent has pushed canvas content, toggles between that content and the status view. Tapping an empty canvas background returns to the face. The PWR button is hardware power management and is not GPIO-visible.
 
 **Task priorities.** The node worker and websocket tasks run at priority 11
 (`ESP_OPENCLAW_NODE_TASK_PRIORITY`, `ESP_OPENCLAW_NODE_TRANSPORT_TASK_PRIORITY`),

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -15,6 +15,7 @@
 #include "esp_openclaw_talk.h"
 #include "esp_peer.h"
 #include "esp_peer_default.h"
+#include "esp_timer.h"
 #include "esp_webrtc.h"
 #include "esp_capture.h"
 #include "driver/gpio.h"
@@ -57,9 +58,12 @@ typedef struct {
 static void start_talk_once(void);
 static esp_err_t register_talk_node_commands(esp_openclaw_node_handle_t node);
 static TaskHandle_t talk_start_worker;
-static TaskHandle_t operator_start_worker;
-/* Pending delay for the next operator start; guarded by state_lock. */
-static uint32_t operator_start_delay_ms;
+/* One-shot timer that (re)tries creating the transient operator-start task.
+ * A permanent worker task was tried and reverted: its always-resident internal
+ * stack starved the AFE open/close sync-tasks during calls (internal RAM is
+ * the scarcest resource on this board). Guarded by state_lock. */
+static esp_timer_handle_t operator_start_timer;
+static bool operator_start_scheduled;
 
 /*
  * The Talk starter is a persistent worker created at boot, when internal RAM
@@ -87,7 +91,7 @@ static void boot_button_task(void *arg)
     for (;;) {
         bool pressed = gpio_get_level(GPIO_NUM_0) == 0;
         if (pressed && !was_pressed) {
-            room_canvas_debug_toggle();
+            room_canvas_view_toggle();
         }
         was_pressed = pressed;
         vTaskDelay(pdMS_TO_TICKS(60));
@@ -207,18 +211,53 @@ static char *derive_gateway_http_base(void)
     return base;
 }
 
+static void operator_start_task(void *arg);
+
+/* Runs on the esp_timer task: only a task-create attempt, nothing heavy.
+ * Creation can fail at the busiest boot moment (internal RAM contention with
+ * Wi-Fi/TLS/audio); re-arming the timer turns that into a delay instead of a
+ * silent dead-end. The task itself is transient so its internal stack is
+ * returned between attempts — a permanent worker starved the AFE sync-tasks. */
+static void operator_start_timer_fired(void *arg)
+{
+    (void)arg;
+    if (xTaskCreate(operator_start_task, "operator_start", 6144, NULL, 6, NULL) == pdPASS) {
+        return;
+    }
+    ESP_LOGW(TAG, "operator start task creation failed; retrying in 2s");
+    esp_timer_start_once(operator_start_timer, 2000000);
+}
+
 static bool schedule_operator_start(uint32_t delay_ms)
 {
-    /* Persistent PSRAM worker (like talk_start): a per-attempt xTaskCreate
-     * here needed contiguous internal RAM at the busiest boot moment and
-     * failed exactly when the operator session was about to come up. */
-    if (operator_start_worker == NULL) {
+    xSemaphoreTake(state_lock, portMAX_DELAY);
+    bool schedule = !operator_start_scheduled;
+    if (schedule) {
+        operator_start_scheduled = true;
+    }
+    xSemaphoreGive(state_lock);
+    if (!schedule) {
+        return true;
+    }
+    if (operator_start_timer == NULL) {
+        const esp_timer_create_args_t args = {
+            .callback = operator_start_timer_fired,
+            .name = "operator_start",
+        };
+        if (esp_timer_create(&args, &operator_start_timer) != ESP_OK) {
+            xSemaphoreTake(state_lock, portMAX_DELAY);
+            operator_start_scheduled = false;
+            xSemaphoreGive(state_lock);
+            return false;
+        }
+    }
+    esp_timer_stop(operator_start_timer);
+    if (esp_timer_start_once(operator_start_timer, (uint64_t)delay_ms * 1000) != ESP_OK) {
+        xSemaphoreTake(state_lock, portMAX_DELAY);
+        operator_start_scheduled = false;
+        xSemaphoreGive(state_lock);
         return false;
     }
-    xSemaphoreTake(state_lock, portMAX_DELAY);
-    operator_start_delay_ms = delay_ms;
-    xSemaphoreGive(state_lock);
-    xTaskNotifyGive(operator_start_worker);
     return true;
 }
 
@@ -529,6 +568,10 @@ static void operator_event(
     }
     if (ready) {
         room_ui_set(ROOM_UI_IDLE, NULL);
+        /* Fully-up moment: greet with the face + gateway line for a few
+         * seconds instead of silently going dark, then the hint expiry
+         * returns the panel to idle. */
+        room_ui_show_face_hint(8000);
         ESP_LOGI(TAG, "operator Talk session ready; ambient WakeNet armed");
     } else {
         room_ui_set(ROOM_UI_ERROR, "Operator offline");
@@ -580,30 +623,25 @@ static esp_err_t start_operator_client(void)
     return esp_openclaw_node_request_connect(created, &request);
 }
 
-static void operator_start_worker_task(void *arg)
+static void operator_start_task(void *arg)
 {
     (void)arg;
-    for (;;) {
-        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-        xSemaphoreTake(state_lock, portMAX_DELAY);
-        uint32_t delay_ms = operator_start_delay_ms;
-        xSemaphoreGive(state_lock);
-        if (delay_ms > 0) {
-            vTaskDelay(pdMS_TO_TICKS(delay_ms));
-            /* A newer request may have arrived while sleeping; its notify is
-             * pending and the next loop iteration handles it immediately. */
-        }
-        esp_err_t err = start_operator_client();
-        if (err != ESP_OK) {
-            // Every retry logs: the display alone cannot say WHY the operator
-            // session is down, and a silent loop here cost a debugging session.
-            ESP_LOGW(TAG, "operator client start failed: %s (retrying)", esp_err_to_name(err));
-            room_ui_set(
-                ROOM_UI_ERROR,
-                err == ESP_ERR_NOT_FOUND ? "No operator session\nre-pair via console" : "Operator token");
-            (void)schedule_operator_start(5000);
-        }
+    /* Release the scheduled flag before the attempt so a synchronous failure
+     * can re-arm the next retry. */
+    xSemaphoreTake(state_lock, portMAX_DELAY);
+    operator_start_scheduled = false;
+    xSemaphoreGive(state_lock);
+    esp_err_t err = start_operator_client();
+    if (err != ESP_OK) {
+        // Every retry logs: the display alone cannot say WHY the operator
+        // session is down, and a silent loop here cost a debugging session.
+        ESP_LOGW(TAG, "operator client start failed: %s (retrying)", esp_err_to_name(err));
+        room_ui_set(
+            ROOM_UI_ERROR,
+            err == ESP_ERR_NOT_FOUND ? "No operator session\nre-pair via console" : "Operator token");
+        (void)schedule_operator_start(5000);
     }
+    vTaskDelete(NULL);
 }
 
 static esp_err_t request_node_connection(void)
@@ -689,10 +727,26 @@ static void node_event(
         char *gateway_http_base = derive_gateway_http_base();
         room_canvas_set_gateway_http_base(gateway_http_base);
         free(gateway_http_base);
-        /* The persistent worker exists before the node client starts, so this
-         * cannot fail; the worker loop owns all retry/error reporting. */
-        (void)schedule_operator_start(0);
+        /* Show host:port under the face; the saved URI is authoritative for
+         * which gateway this session actually authenticated against. */
+        char *gateway_uri = load_saved_gateway_uri();
+        const char *host = gateway_uri;
+        if (host != NULL && strncmp(host, "ws://", 5) == 0) {
+            host += 5;
+        } else if (host != NULL && strncmp(host, "wss://", 6) == 0) {
+            host += 6;
+        }
+        room_ui_set_gateway(host);
+        free(gateway_uri);
+        /* The timer path retries task creation itself, so scheduling only
+         * fails on timer-create OOM at boot; retry through the same path. */
+        if (!schedule_operator_start(0)) {
+            ESP_LOGE(TAG, "failed scheduling operator client start; retrying in 5s");
+            room_ui_set(ROOM_UI_ERROR, "Operator token");
+            (void)schedule_operator_start(5000);
+        }
     } else {
+        room_ui_set_gateway(NULL);
         room_ui_set(ROOM_UI_ERROR, "Node offline");
         schedule_node_reconnect(2000);
     }
@@ -908,17 +962,6 @@ void app_main(void)
         &talk_start_worker,
         MALLOC_CAP_SPIRAM);
     ESP_ERROR_CHECK(starter_task == pdPASS ? ESP_OK : ESP_ERR_NO_MEM);
-    /* Internal stack (NOT PSRAM like talk_start): this worker calls
-     * esp_openclaw_node_create, whose NVS reads run flash operations, and
-     * flash ops assert unless every running stack is cache-safe internal RAM. */
-    BaseType_t operator_task = xTaskCreate(
-        operator_start_worker_task,
-        "operator_start",
-        6144,
-        NULL,
-        6,
-        &operator_start_worker);
-    ESP_ERROR_CHECK(operator_task == pdPASS ? ESP_OK : ESP_ERR_NO_MEM);
     BaseType_t teardown_task = xTaskCreate(
         talk_teardown_task,
         "talk_teardown",

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.c
@@ -630,84 +630,6 @@ static void style_canvas_screen(int32_t pad)
 
 static const lv_font_t *font_for_usage(const char *usage);
 
-/*
- * Diagnostic placeholder: a full-bleed field with a border drawn exactly on the
- * safe-area inset and dots at each safe-area corner. Solid coverage makes panel
- * flush artifacts obvious, and the markers show at a glance how much of the
- * rectangle the rounded glass actually clips.
- */
-static void show_test_card_locked(void)
-{
-    lv_obj_clean(canvas_screen);
-    clear_images_locked();
-    style_canvas_screen(0);
-
-    lv_obj_t *field = lv_obj_create(canvas_screen);
-    lv_obj_remove_style_all(field);
-    lv_obj_set_size(field, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(field, lv_color_hex(0x202830), 0);
-    lv_obj_set_style_bg_opa(field, LV_OPA_COVER, 0);
-    lv_obj_remove_flag(field, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_remove_flag(field, LV_OBJ_FLAG_CLICKABLE);
-
-    lv_obj_t *safe = lv_obj_create(field);
-    lv_obj_remove_style_all(safe);
-    lv_obj_set_pos(safe, ROOM_CANVAS_SAFE_PAD, ROOM_CANVAS_SAFE_PAD);
-    lv_obj_set_size(
-        safe,
-        ROOM_CANVAS_WIDTH - 2 * ROOM_CANVAS_SAFE_PAD,
-        ROOM_CANVAS_HEIGHT - 2 * ROOM_CANVAS_SAFE_PAD);
-    lv_obj_set_style_border_width(safe, 2, 0);
-    lv_obj_set_style_border_color(safe, lv_color_hex(0x36d399), 0);
-    lv_obj_set_style_radius(safe, 8, 0);
-    lv_obj_set_style_bg_opa(safe, LV_OPA_TRANSP, 0);
-    lv_obj_remove_flag(safe, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_remove_flag(safe, LV_OBJ_FLAG_CLICKABLE);
-
-    static const lv_align_t corners[] = {
-        LV_ALIGN_TOP_LEFT,
-        LV_ALIGN_TOP_RIGHT,
-        LV_ALIGN_BOTTOM_LEFT,
-        LV_ALIGN_BOTTOM_RIGHT,
-    };
-    for (size_t i = 0; i < sizeof(corners) / sizeof(corners[0]); ++i) {
-        lv_obj_t *dot = lv_obj_create(safe);
-        lv_obj_remove_style_all(dot);
-        lv_obj_set_size(dot, 14, 14);
-        lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
-        lv_obj_set_style_bg_color(dot, lv_color_hex(0xf87272), 0);
-        lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
-        lv_obj_align(dot, corners[i], 0, 0);
-        lv_obj_remove_flag(dot, LV_OBJ_FLAG_CLICKABLE);
-    }
-
-    lv_obj_t *caption = lv_label_create(safe);
-    lv_obj_set_style_text_color(caption, lv_color_white(), 0);
-    lv_obj_set_style_text_font(caption, font_for_usage("body"), 0);
-    lv_label_set_text(caption, "safe area\ntap to exit");
-    lv_obj_set_style_text_align(caption, LV_TEXT_ALIGN_CENTER, 0);
-    lv_obj_center(caption);
-}
-
-/*
- * Uniform fill with zero content variation. If the panel still shows streaks
- * here, the artifact is in the transfer path; if this is clean while the test
- * card streaks, it is in rendering.
- */
-static void show_solid_fill_locked(void)
-{
-    lv_obj_clean(canvas_screen);
-    clear_images_locked();
-    style_canvas_screen(0);
-    lv_obj_t *field = lv_obj_create(canvas_screen);
-    lv_obj_remove_style_all(field);
-    lv_obj_set_size(field, LV_PCT(100), LV_PCT(100));
-    lv_obj_set_style_bg_color(field, lv_color_hex(0x1040c0), 0);
-    lv_obj_set_style_bg_opa(field, LV_OPA_COVER, 0);
-    lv_obj_remove_flag(field, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_remove_flag(field, LV_OBJ_FLAG_CLICKABLE);
-}
-
 static void show_placeholder_locked(void)
 {
     lv_obj_clean(canvas_screen);
@@ -2010,18 +1932,18 @@ static void canvas_screen_clicked(lv_event_t *event)
     if (room_canvas_hide(&payload, &error) == ESP_OK) {
         free(payload);
     }
-    /* Same contract as the BOOT/status toggle: a user-initiated exit must not
+    /* Same contract as the status-screen tap: a user-initiated exit must not
      * land on the idle-dark screen and look like a dead panel. */
-    room_ui_show_awake_hint();
+    room_ui_show_face_hint(10000);
 }
 
 /*
- * Debug view cycling for the on-device buttons/touch: status -> canvas
- * (existing A2UI content or the placeholder) -> status. Safe from LVGL event
- * callbacks too: the display lock is a recursive mutex and neither branch
- * deletes the object dispatching the event.
+ * Tap/BOOT view cycling: status <-> canvas when agent content exists. With no
+ * content, the status tap wakes the face instead (handled in room_ui); this is
+ * a no-op then. Safe from LVGL event callbacks: the display lock is a
+ * recursive mutex and neither branch deletes the dispatching object.
  */
-void room_canvas_debug_toggle(void)
+void room_canvas_view_toggle(void)
 {
     char *payload = NULL;
     esp_openclaw_node_error_t error = {0};
@@ -2029,7 +1951,7 @@ void room_canvas_debug_toggle(void)
         if (room_canvas_hide(&payload, &error) == ESP_OK) {
             free(payload);
         }
-        room_ui_show_awake_hint();
+        room_ui_show_face_hint(10000);
         return;
     }
     if (root_component_id != NULL) {
@@ -2038,22 +1960,8 @@ void room_canvas_debug_toggle(void)
         }
         return;
     }
-    /* Nothing pushed yet: cycle the two diagnostic views so the panel itself
-     * can be judged (solid fill isolates the transfer path from rendering). */
-    if (!bsp_display_lock(ROOM_CANVAS_DISPLAY_LOCK_MS)) {
-        return;
-    }
-    static bool show_solid;
-    if (show_solid) {
-        show_solid_fill_locked();
-    } else {
-        show_test_card_locked();
-    }
-    show_solid = !show_solid;
-    activate_canvas_locked();
-    bsp_display_unlock();
-    bsp_display_brightness_set(ROOM_CANVAS_BRIGHTNESS);
-    room_ui_refresh();
+    /* No agent canvas content: wake the face so the tap always answers. */
+    room_ui_show_face_hint(10000);
 }
 
 esp_err_t room_canvas_init(void)

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_canvas.h
@@ -13,8 +13,8 @@ void room_canvas_set_node(esp_openclaw_node_handle_t node);
 void room_canvas_set_refresh_client(esp_openclaw_node_handle_t operator_node);
 void room_canvas_set_gateway_http_base(const char *base_url);
 bool room_canvas_is_active(void);
-/** Cycle status <-> canvas for the on-device debug controls. */
-void room_canvas_debug_toggle(void);
+/** Cycle status <-> canvas for tap/BOOT; wakes the face when no content. */
+void room_canvas_view_toggle(void);
 
 esp_err_t room_canvas_present(
     const char *url,

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.c
@@ -32,17 +32,20 @@ static void room_ui_align_flush_area(lv_event_t *event)
     area->y2 |= 1;
 }
 
-/* Tap on the status screen jumps to the canvas view. */
+/* Tap on the status screen: agent canvas when present, else wake the face. */
 static void room_ui_status_clicked(lv_event_t *event)
 {
     (void)event;
-    room_canvas_debug_toggle();
+    room_canvas_view_toggle();
 }
 
 static const char *TAG = "room_ui";
 static lv_obj_t *status_label;
+static lv_obj_t *gateway_label;
 static lv_obj_t *talk_pill;
 static lv_obj_t *talk_pill_label;
+/* Guarded by state_mux like the state/detail facts. */
+static char gateway_text[64];
 /* Last state/detail survive canvas mode so leaving it restores the live Talk
  * state instead of forcing idle while a call is still active. Guarded by
  * their own spinlock so a display-lock timeout can never DROP a transition:
@@ -148,6 +151,15 @@ void room_ui_init(void)
 #endif
     lv_obj_center(status_label);
     lv_label_set_text(status_label, "OpenClaw");
+    /* Small always-available gateway line at the bottom of the glass; shown
+     * alongside the face so a glance answers "which claw is this?". */
+    gateway_label = lv_label_create(lv_screen_active());
+    lv_obj_set_style_text_color(gateway_label, lv_color_hex(0x8a8a8a), 0);
+    lv_obj_set_style_text_font(gateway_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_align(gateway_label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_align(gateway_label, LV_ALIGN_BOTTOM_MID, 0, -56);
+    lv_label_set_text(gateway_label, "");
+    lv_obj_add_flag(gateway_label, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_event_cb(
         lv_screen_active(),
         room_ui_status_clicked,
@@ -172,12 +184,24 @@ static bool room_ui_state_uses_face(room_ui_state_t state)
 static bool room_ui_render_locked(void)
 {
     static const char *labels[] = {"OpenClaw", "Listening", "Connecting", "Speaking", "Error", "Setup"};
-    /* Snapshot the fact under its own lock; the writer may not hold ours. */
+    /* Snapshot the facts under their own lock; the writer may not hold ours. */
     taskENTER_CRITICAL(&state_mux);
     room_ui_state_t state = current_state;
     char detail[sizeof(current_detail)];
     memcpy(detail, current_detail, sizeof(detail));
+    char gateway[sizeof(gateway_text)];
+    memcpy(gateway, gateway_text, sizeof(gateway));
     taskEXIT_CRITICAL(&state_mux);
+    if (gateway_label != NULL) {
+        /* The gateway line rides along with every non-canvas view. */
+        lv_label_set_text(gateway_label, gateway);
+        if (room_canvas_is_active() || gateway[0] == '\0') {
+            lv_obj_add_flag(gateway_label, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_clear_flag(gateway_label, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_move_foreground(gateway_label);
+        }
+    }
     if (room_canvas_is_active()) {
         room_face_hide();
         if (state == ROOM_UI_IDLE) {
@@ -287,21 +311,15 @@ void room_ui_set(room_ui_state_t state, const char *detail)
     room_ui_paint_and_unlock();
 }
 
-void room_ui_show_awake_hint(void)
+void room_ui_set_gateway(const char *gateway_host)
 {
-    if (status_label == NULL) {
-        return;
+    taskENTER_CRITICAL(&state_mux);
+    gateway_text[0] = '\0';
+    if (gateway_host != NULL) {
+        strlcpy(gateway_text, gateway_host, sizeof(gateway_text));
     }
-    if (!bsp_display_lock(100)) {
-        return;
-    }
-    room_face_hide();
-    lv_obj_clear_flag(status_label, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(status_label, "OpenClaw\ntap or BOOT for canvas");
-    bsp_display_unlock();
-    /* A user-initiated exit must not look like a dead panel, so override the
-     * idle-dark policy until the next state change repaints. */
-    bsp_display_brightness_set(18);
+    taskEXIT_CRITICAL(&state_mux);
+    room_ui_refresh();
 }
 
 void room_ui_show_face_hint(uint32_t show_ms)
@@ -321,6 +339,19 @@ void room_ui_show_face_hint(uint32_t show_ms)
     bool shown = room_face_is_visible();
     if (shown) {
         lv_obj_add_flag(status_label, LV_OBJ_FLAG_HIDDEN);
+        if (gateway_label != NULL) {
+            /* The wake-up face is the "which claw am I?" moment: surface the
+             * connected gateway under it whenever one is known. */
+            taskENTER_CRITICAL(&state_mux);
+            char gateway[sizeof(gateway_text)];
+            memcpy(gateway, gateway_text, sizeof(gateway));
+            taskEXIT_CRITICAL(&state_mux);
+            lv_label_set_text(gateway_label, gateway);
+            if (gateway[0] != '\0') {
+                lv_obj_clear_flag(gateway_label, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_move_foreground(gateway_label);
+            }
+        }
     }
     bsp_display_unlock();
     if (shown) {

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.h
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_ui.h
@@ -16,9 +16,9 @@ void room_ui_init(void);
 void room_ui_set(room_ui_state_t state, const char *detail);
 /** Repaint the most recently set state, e.g. after leaving canvas mode. */
 void room_ui_refresh(void);
-/** Show a visible status hint after a user-initiated exit from canvas. */
-void room_ui_show_awake_hint(void);
-/** Show the idle face for `show_ms` (agent face.set outside a call). */
+/** Show the idle face for `show_ms` (tap wake-up or agent face.set outside a call). */
 void room_ui_show_face_hint(uint32_t show_ms);
+/** Record the connected gateway (host:port); shown under the face. NULL clears. */
+void room_ui_set_gateway(const char *gateway_host);
 /** True while the current Talk state renders as the face. */
 bool room_ui_talk_face_active(void);


### PR DESCRIPTION
## What Problem This Solves

Tapping the room node's screen showed engineering diagnostics — a safe-area test card (green border, red corner dots) and a solid blue fill — which read as "something is broken" on what is now a production desk device. There was also no way to see which gateway the node is connected to without a serial console.

## Why This Change Was Made

The panel-bringup debug views served their purpose during display DMA debugging and are deleted. Tap/BOOT now does what an operator expects: wake the face for ~10s, or toggle the agent's canvas content when some is present. A small dim host:port line (from the saved session URI, refreshed on every node connect, cleared while offline) renders under the face and on status views, so a glance answers "which claw is this?". The operator-ready moment greets with face + gateway line for 8s instead of silently going dark.

Also reverts the operator-start path from a permanent worker task (from #15's original shape) to a timer-armed transient task: the resident internal-RAM stack starved the AFE open/close in-RAM sync tasks during Talk calls (`afe_open`/`afe_close` task-create failures). The timer retries create-OOM instead of dead-ending.

## User Impact

Tap shows the face with the connected gateway underneath. No more debug rectangles. Voice calls work: verified wake → WebRTC call → agent-initiated talk.start → talk.stop teardown.

## Evidence

On-hardware against clawstudio (ws://10.21.40.131:18789):
- canvas.snapshot after boot: status view with `10.21.40.131:18789` line; after face.set: face + gateway line (screenshots in session)
- console `wake` → PeerConnectionState 2→9 (data channel connected), audio pipeline live
- `talk.start` via node.invoke → `{"started":true}` → call connected; `talk.stop` → `{"stopped":true}`, ambient WakeNet resumes
- operator session recovers after re-pair + reboot: `operator Talk session ready` ~7-8s after boot, incl. one observed create-OOM retry healing itself (`operator start task creation failed; retrying in 2s` → ready)
- room-node example builds clean (ESP-IDF 5.5, esp32s3); net −18 LOC
