### PR TITLE
fix(room-node): room-audible speaker volume; keep the face during call-time control drops

### DIFF
--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/main.c
@@ -747,7 +747,12 @@ static void node_event(
         }
     } else {
         room_ui_set_gateway(NULL);
-        room_ui_set(ROOM_UI_ERROR, "Node offline");
+        /* The Talk call is client-owned WebRTC straight to the provider; the
+         * control channel dropping (common under call load) must not stomp
+         * the speaking face with an error. Reconnect quietly instead. */
+        if (!room_ui_talk_face_active()) {
+            room_ui_set(ROOM_UI_ERROR, "Node offline");
+        }
         schedule_node_reconnect(2000);
     }
 }

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/room_media.c
@@ -264,7 +264,9 @@ esp_err_t room_media_init(room_wake_callback_t callback, void *ctx)
         room_audio_codecs_init(&record, &playback),
         TAG,
         "audio codec init");
-    if (esp_codec_dev_set_out_vol(playback, 65) != 0) {
+    /* Codec curve is quiet at the bottom: 65 was whisper-level, 85 barely
+     * room-audible. 100 with the 5V PA is the usable speakerphone level; AEC still tracks echo (verified by mic loop measurement). */
+    if (esp_codec_dev_set_out_vol(playback, 100) != 0) {
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Two operator-reported issues from real desk use: the assistant's voice was barely audible ("I was hearing something but it's not loud at all"), and the display painted "Error / Node offline" mid-call, stomping the speaking face.

## Why This Change Was Made

**Volume**: the ES8311 volume curve is far from linear — out_vol 65 is whisper-level and 85 is still weak. Measured with a closed acoustic loop (Studio Display mic ~1m away, 1-second RMS windows): quiet room = 33, call at vol 85 peaked at 61, call at vol 100 peaked at 338 — clearly room-audible speech, above the local `say` reference (293). AEC still converges (wake word fires during playback; no echo runaway).

**Call-time error paint**: the gateway control websocket can drop while a call saturates core 1 + Wi-Fi. The Talk session is client-owned WebRTC straight to the provider and keeps running, so the error text was both wrong and destructive (replaced the animated face). The node client already reconnects automatically; now it does so silently during calls and only paints the error outside them.

## User Impact

You can hear the assistant across the room, and the face stays up for the whole call.

## Evidence

- Closed-loop mic measurement per-second RMS during "count one to ten": vol 85 → max 61; vol 100 → `[31,30,51,338,40,179,169,246,114,162,75,143,145,266,148,239,165,270,85,205,...]` — sustained ~150-270 across the answer
- Wake word still detected during playback at 100 (AEC path intact); talk.start/stop round-trips verified after the change
- 0 "Node offline" paints across a full call with control-drop injection window (previous captures showed the drop reliably)
- room-node example builds clean (ESP-IDF 5.5, esp32s3); flashed and live on the device
- Codex autoreview (gpt-5.6-sol, high): clean
