### PR TITLE
fix(talk): require gateway-owned realtime control

### DIFF
--- a/components/esp-openclaw-node/CHANGELOG.md
+++ b/components/esp-openclaw-node/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Require Gateway-owned realtime control for room Talk and fail visibly before peer creation when the Gateway contract is unavailable.
 - Add authoritative Gateway URI inspection and bound assembled inbound WebSocket messages to 2 MiB by default.
 
 - Add `esp_openclaw_node_store_plugin_surface_url()` so applications can adopt refreshed capability-scoped surface URLs (for example from a `plugin.surface.refresh` RPC) into the component's canonical store.

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/README.md
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/README.md
@@ -28,6 +28,8 @@ not require a live OpenClaw gateway.
 - destroy-path notification safety
 - transport-state edge cases around challenge ping, clean close, and disconnect
   rejection while still connecting
+- Gateway-owned Talk negotiation, strict descriptor rejection, bounded close,
+  late-create cancellation, and second-call recovery
 
 ## Build and run
 

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/CMakeLists.txt
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/CMakeLists.txt
@@ -1,7 +1,11 @@
 idf_component_register(
-    SRCS "test_esp_openclaw_node.c"
-    INCLUDE_DIRS "."
+    SRCS
+        "test_esp_openclaw_node.c"
+        "../../../../esp-openclaw-talk/tests/test_esp_openclaw_talk.c"
+    INCLUDE_DIRS "." "../../../../esp-openclaw-talk/include"
     REQUIRES
+        esp_http_client
+        json
         mbedtls
         nvs_flash
         esp-openclaw-node
@@ -10,3 +14,8 @@ idf_component_register(
 
 idf_component_get_property(esp_openclaw_node_dir esp-openclaw-node COMPONENT_DIR)
 target_include_directories(${COMPONENT_LIB} PRIVATE "${esp_openclaw_node_dir}/private_include")
+target_include_directories(
+    ${COMPONENT_LIB}
+    PRIVATE
+        "../../../../../third_party/esp-webrtc-solution/components/esp_webrtc/include"
+        "../../../../../third_party/esp-webrtc-solution/components/esp_peer/include")

--- a/components/esp-openclaw-room-node/README.md
+++ b/components/esp-openclaw-room-node/README.md
@@ -49,6 +49,9 @@ Room endpoints request 400 ms of provider server-VAD post-speech silence for
 each Talk session. The player uses the pinned 4 KiB raw and 6 KiB render queue
 capacities: they start playback immediately and bound stale audio backlog under
 stalls, but they do not measure or promise total speech-to-response time.
+Talk WebRTC is audio-only. A compatible Gateway must own realtime control and
+return the negotiated Gateway-control descriptor; older Gateways fail visibly
+before the room creates a peer.
 
 The USB REPL also exposes one local-only command with four exact forms:
 `diagnostics open`, `diagnostics close`, `diagnostics tone`, and

--- a/components/esp-openclaw-room-node/esp_openclaw_room_node.c
+++ b/components/esp-openclaw-room-node/esp_openclaw_room_node.c
@@ -57,14 +57,15 @@ static bool talk_closing;
 /* Set by talk.stop while the worker is still dialing; the worker must abandon
  * the session before the microphone path goes live. */
 static bool talk_cancel_requested;
-static bool talk_cancel_failed;
+static const char *talk_cancel_message;
+static uint32_t talk_generation;
 static bool node_reconnect_scheduled;
 static bool camera_active;
 static char *gateway_http_base;
 
 typedef struct {
     esp_webrtc_handle_t session;
-    bool failed;
+    const char *failure_message;
 } talk_teardown_request_t;
 
 static void media_scheduler(const char *name, media_lib_thread_cfg_t *cfg)
@@ -226,9 +227,14 @@ static void seed_wifi_credentials_from_kconfig(void)
     }
 }
 
-static void request_talk_teardown(esp_webrtc_handle_t session, bool failed)
+static void request_talk_teardown(
+    esp_webrtc_handle_t session,
+    const char *failure_message)
 {
-    talk_teardown_request_t request = {.session = session, .failed = failed};
+    talk_teardown_request_t request = {
+        .session = session,
+        .failure_message = failure_message,
+    };
     if (xQueueSend(talk_teardown_queue, &request, 0) != pdTRUE) {
         ESP_LOGW(TAG, "Talk teardown already queued");
     }
@@ -247,7 +253,9 @@ static void talk_teardown_task(void *arg)
         bool defer_to_worker = owns_session && talk_start_in_flight;
         if (defer_to_worker) {
             talk_cancel_requested = true;
-            talk_cancel_failed = talk_cancel_failed || request.failed;
+            if (request.failure_message != NULL) {
+                talk_cancel_message = request.failure_message;
+            }
         } else if (owns_session) {
             talk_closing = true;
         }
@@ -260,11 +268,11 @@ static void talk_teardown_task(void *arg)
         esp_err_t ambient_err = room_media_set_ambient_wake(true);
         if (ambient_err != ESP_OK) {
             ESP_LOGE(TAG, "failed to restore ambient WakeNet after Talk: %s", esp_err_to_name(ambient_err));
-            request.failed = true;
+            request.failure_message = "Talk failed";
         }
         room_ui_set(
-            request.failed ? ROOM_UI_ERROR : ROOM_UI_IDLE,
-            request.failed ? "Talk failed" : NULL);
+            request.failure_message != NULL ? ROOM_UI_ERROR : ROOM_UI_IDLE,
+            request.failure_message);
         xSemaphoreTake(state_lock, portMAX_DELAY);
         if (webrtc == request.session) {
             webrtc = NULL;
@@ -285,7 +293,26 @@ static void call_timeout(TimerHandle_t timer)
     bool active = session != NULL && !talk_closing;
     xSemaphoreGive(state_lock);
     if (active) {
-        request_talk_teardown(session, false);
+        request_talk_teardown(session, NULL);
+    }
+}
+
+static void talk_setup_failed(
+    esp_openclaw_talk_setup_result_t result,
+    void *ctx)
+{
+    uint32_t generation = (uint32_t)(uintptr_t)ctx;
+    xSemaphoreTake(state_lock, portMAX_DELAY);
+    esp_webrtc_handle_t session = generation == talk_generation && !talk_closing
+        ? webrtc
+        : NULL;
+    xSemaphoreGive(state_lock);
+    if (session != NULL) {
+        request_talk_teardown(
+            session,
+            result == ESP_OPENCLAW_TALK_GATEWAY_UPGRADE_REQUIRED
+                ? "Gateway upgrade required"
+                : "Talk setup failed");
     }
 }
 
@@ -308,7 +335,7 @@ static int webrtc_event(esp_webrtc_event_t *event, void *ctx)
                event->type == ESP_WEBRTC_EVENT_DISCONNECTED) {
         request_talk_teardown(
             session,
-            event->type == ESP_WEBRTC_EVENT_CONNECT_FAILED);
+            event->type == ESP_WEBRTC_EVENT_CONNECT_FAILED ? "Talk failed" : NULL);
     }
     return 0;
 }
@@ -317,22 +344,22 @@ static void start_talk_once(void)
 {
     xSemaphoreTake(state_lock, portMAX_DELAY);
     bool cancelled_early = talk_cancel_requested;
-    bool cancelled_early_failed = talk_cancel_failed;
+    const char *cancelled_early_message = talk_cancel_message;
     esp_openclaw_node_handle_t signaling_client = operator_client;
     char *http_base = gateway_http_base != NULL ? strdup(gateway_http_base) : NULL;
     if (cancelled_early || signaling_client == NULL || http_base == NULL) {
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
         talk_start_in_flight = false;
     }
     xSemaphoreGive(state_lock);
     if (cancelled_early || signaling_client == NULL || http_base == NULL) {
         free(http_base);
         room_ui_set(
-            cancelled_early_failed || (!cancelled_early && signaling_client != NULL)
+            cancelled_early_message != NULL || (!cancelled_early && signaling_client != NULL)
                 ? ROOM_UI_ERROR
                 : ROOM_UI_IDLE,
-            cancelled_early_failed ? "Talk failed" :
+            cancelled_early_message != NULL ? cancelled_early_message :
             (!cancelled_early && signaling_client != NULL) ? "Gateway URL" : NULL);
         return;
     }
@@ -342,10 +369,10 @@ static void start_talk_once(void)
     room_media_begin_talk();
     xSemaphoreTake(state_lock, portMAX_DELAY);
     bool cancelled_while_waiting = talk_cancel_requested || !talk_start_in_flight;
-    bool cancelled_while_waiting_failed = talk_cancel_failed;
+    const char *cancelled_while_waiting_message = talk_cancel_message;
     if (cancelled_while_waiting) {
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
         talk_start_in_flight = false;
     }
     xSemaphoreGive(state_lock);
@@ -353,14 +380,17 @@ static void start_talk_once(void)
         room_media_end_talk(true);
         free(http_base);
         room_ui_set(
-            cancelled_while_waiting_failed ? ROOM_UI_ERROR : ROOM_UI_IDLE,
-            cancelled_while_waiting_failed ? "Talk failed" : NULL);
+            cancelled_while_waiting_message != NULL ? ROOM_UI_ERROR : ROOM_UI_IDLE,
+            cancelled_while_waiting_message);
         return;
     }
     esp_peer_default_cfg_t peer = {
         .agent_recv_timeout = 500,
         .ice_use_lite_mode = true,
     };
+    xSemaphoreTake(state_lock, portMAX_DELAY);
+    uint32_t generation = ++talk_generation;
+    xSemaphoreGive(state_lock);
     esp_openclaw_talk_signaling_config_t signaling = {
         .operator_node = signaling_client,
         .gateway_http_base_url = http_base,
@@ -368,6 +398,8 @@ static void start_talk_once(void)
         .provider = CONFIG_OPENCLAW_ROOM_TALK_PROVIDER,
         .model = CONFIG_OPENCLAW_ROOM_TALK_MODEL,
         .voice = CONFIG_OPENCLAW_ROOM_TALK_VOICE,
+        .setup_failed_cb = talk_setup_failed,
+        .setup_failed_ctx = (void *)(uintptr_t)generation,
         .silence_duration_ms = ROOM_TALK_VAD_SILENCE_MS,
     };
     esp_webrtc_cfg_t config = {
@@ -378,7 +410,7 @@ static void start_talk_once(void)
                 .channel = 1,
             },
             .audio_dir = ESP_PEER_MEDIA_DIR_SEND_RECV,
-            .enable_data_channel = true,
+            .enable_data_channel = false,
             .extra_cfg = &peer,
             .extra_size = sizeof(peer),
         },
@@ -395,7 +427,7 @@ static void start_talk_once(void)
         talk_start_in_flight = false;
         bool cancelled = talk_cancel_requested;
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
         xSemaphoreGive(state_lock);
         room_media_end_talk(true);
         free(http_base);
@@ -412,7 +444,7 @@ static void start_talk_once(void)
         talk_start_in_flight = false;
         bool cancelled = talk_cancel_requested;
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
         xSemaphoreGive(state_lock);
         room_media_end_talk(true);
         free(http_base);
@@ -429,7 +461,7 @@ static void start_talk_once(void)
     }
     if (cancelled) {
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
         talk_start_in_flight = false;
     }
     xSemaphoreGive(state_lock);
@@ -451,17 +483,17 @@ static void start_talk_once(void)
         ESP_LOGE(TAG, "failed to transfer capture ownership to Talk: %s", esp_err_to_name(ambient_err));
         xSemaphoreTake(state_lock, portMAX_DELAY);
         talk_cancel_requested = true;
-        talk_cancel_failed = true;
+        talk_cancel_message = "Talk setup failed";
         xSemaphoreGive(state_lock);
     } else if (esp_webrtc_start(session) != 0) {
         xSemaphoreTake(state_lock, portMAX_DELAY);
         talk_cancel_requested = true;
-        talk_cancel_failed = true;
+        talk_cancel_message = "Talk setup failed";
         xSemaphoreGive(state_lock);
     } else if (xTimerStart(talk_timeout_timer, 0) != pdPASS) {
         xSemaphoreTake(state_lock, portMAX_DELAY);
         talk_cancel_requested = true;
-        talk_cancel_failed = true;
+        talk_cancel_message = "Talk setup failed";
         xSemaphoreGive(state_lock);
     }
     /* A stop that landed while esp_webrtc_start was in flight was recorded as
@@ -469,14 +501,14 @@ static void start_talk_once(void)
      * that start has returned. */
     xSemaphoreTake(state_lock, portMAX_DELAY);
     bool cancel_after_start = talk_cancel_requested;
-    bool cancel_after_start_failed = talk_cancel_failed;
+    const char *cancel_after_start_message = talk_cancel_message;
     talk_cancel_requested = false;
-    talk_cancel_failed = false;
+    talk_cancel_message = NULL;
     talk_start_in_flight = false;
     xSemaphoreGive(state_lock);
     free(http_base);
     if (cancel_after_start) {
-        request_talk_teardown(session, cancel_after_start_failed);
+        request_talk_teardown(session, cancel_after_start_message);
     }
 }
 
@@ -490,7 +522,7 @@ static void on_wake(const char *wake_word, void *ctx)
     if (start) {
         talk_start_in_flight = true;
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
     }
     xSemaphoreGive(state_lock);
     if (!start) {
@@ -860,7 +892,7 @@ static esp_err_t handle_talk_start(
     if (start) {
         talk_start_in_flight = true;
         talk_cancel_requested = false;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
     }
     bool operator_offline = !operator_ready;
     xSemaphoreGive(state_lock);
@@ -913,11 +945,11 @@ static esp_err_t handle_talk_stop(
     bool active = !cancelling && session != NULL && !talk_closing;
     if (cancelling) {
         talk_cancel_requested = true;
-        talk_cancel_failed = false;
+        talk_cancel_message = NULL;
     }
     xSemaphoreGive(state_lock);
     if (active) {
-        request_talk_teardown(session, false);
+        request_talk_teardown(session, NULL);
     }
     *out_payload_json = strdup(
         active || cancelling ? "{\"stopped\":true}" : "{\"stopped\":false}");

--- a/components/esp-openclaw-talk/README.md
+++ b/components/esp-openclaw-talk/README.md
@@ -1,8 +1,8 @@
 # esp-openclaw-talk
 
-`esp-openclaw-talk` adapts OpenClaw's client-owned Talk API to Espressif's `esp_webrtc` signaling interface. Firmware asks the Gateway for a provider session with `talk.client.create`, then posts its local SDP to the returned offer URL with the returned short-lived credential.
+`esp-openclaw-talk` adapts OpenClaw's Gateway-owned Talk API to Espressif's `esp_webrtc` signaling interface. Firmware requests `gateway-control-v1` with `talk.client.create`, then posts its local SDP to the returned Gateway offer URL with the returned single-use broker token.
 
-The component is intentionally provider-neutral. OpenAI API keys and ChatGPT OAuth credentials stay on the Gateway. Standard OpenAI Realtime sessions return the direct `/v1/realtime/calls` offer URL. GPT-Live sessions return a Gateway-relative offer URL; the Gateway exchanges SDP with `/v1/live` and owns the agent-consult sideband.
+The response must contain the exact descriptor `clientControl: { owner: "gateway" }`. Missing or different descriptors fail before peer creation, with no fallback to client-owned tool handling. Provider credentials and the agent-consult sideband stay on the Gateway.
 
 Configure `esp_openclaw_talk_signaling_config_t` as `esp_webrtc_cfg_t.signaling_cfg.extra_cfg`, and use `esp_openclaw_talk_signaling_impl()` as the signaling implementation. The referenced `operator_node` must already be connected with `operator.talk`. `gateway_http_base_url` is required only for relative offer URLs.
 

--- a/components/esp-openclaw-talk/include/esp_openclaw_talk.h
+++ b/components/esp-openclaw-talk/include/esp_openclaw_talk.h
@@ -15,6 +15,15 @@
 extern "C" {
 #endif
 
+typedef enum {
+    ESP_OPENCLAW_TALK_SETUP_FAILED = 0,
+    ESP_OPENCLAW_TALK_GATEWAY_UPGRADE_REQUIRED,
+} esp_openclaw_talk_setup_result_t;
+
+typedef void (*esp_openclaw_talk_setup_failed_cb_t)(
+    esp_openclaw_talk_setup_result_t result,
+    void *user_ctx);
+
 /** Configuration copied by the signaling implementation at start. */
 typedef struct {
     /** Ready operator-role client with operator.talk scope. */
@@ -29,6 +38,9 @@ typedef struct {
     const char *model;
     /** Optional provider voice override. */
     const char *voice;
+    /** Optional notification for failures before peer creation. */
+    esp_openclaw_talk_setup_failed_cb_t setup_failed_cb;
+    void *setup_failed_ctx;
     /**
      * Optional provider server-VAD post-speech silence override in milliseconds.
      * Zero omits the field and preserves the Gateway configuration or default.
@@ -39,9 +51,9 @@ typedef struct {
 /**
  * Provider-neutral ESP WebRTC signaling implementation backed by OpenClaw Talk.
  *
- * `talk.client.create` supplies a short-lived offer credential. The ESP32 then
- * posts its SDP to the returned URL; media flows directly to the provider while
- * the Gateway retains credentials, provider policy, and agent delegation.
+ * `talk.client.create` supplies a single-use Gateway broker credential. The
+ * ESP32 posts its SDP to the returned URL while the Gateway owns realtime
+ * control, provider policy, and agent delegation.
  */
 const esp_peer_signaling_impl_t *esp_openclaw_talk_signaling_impl(void);
 

--- a/components/esp-openclaw-talk/src/esp_openclaw_talk.c
+++ b/components/esp-openclaw-talk/src/esp_openclaw_talk.c
@@ -21,6 +21,8 @@
 
 #define TAG "esp_openclaw_talk"
 #define MAX_SDP_RESPONSE_BYTES (256U * 1024U)
+#define MAX_VOICE_SESSION_ID_BYTES 128U
+#define GATEWAY_CONTROL_CAPABILITY "gateway-control-v1"
 
 typedef struct {
     char *name;
@@ -36,6 +38,8 @@ typedef struct {
     char *model;
     char *voice;
     uint16_t silence_duration_ms;
+    esp_openclaw_talk_setup_failed_cb_t setup_failed_cb;
+    void *setup_failed_ctx;
     char *offer_url;
     char *client_secret;
     char *voice_session_id;
@@ -43,9 +47,9 @@ typedef struct {
     size_t offer_header_count;
     portMUX_TYPE state_lock;
     size_t refs;
-    bool create_pending;
     bool stopped;
     bool close_notified;
+    bool gateway_owned;
 } talk_signaling_t;
 
 typedef struct {
@@ -66,8 +70,6 @@ static void free_offer_headers(talk_signaling_t *talk)
         free(talk->offer_headers[i].value);
     }
     free(talk->offer_headers);
-    talk->offer_headers = NULL;
-    talk->offer_header_count = 0;
 }
 
 static void free_talk_signaling(talk_signaling_t *talk)
@@ -179,15 +181,73 @@ static bool copy_offer_headers(talk_signaling_t *talk, cJSON *headers)
         offer_header_t *dst = &talk->offer_headers[talk->offer_header_count];
         dst->name = strdup(entry->string);
         dst->value = strdup(entry->valuestring);
+        ++talk->offer_header_count;
         if (dst->name == NULL || dst->value == NULL) {
             return false;
         }
-        ++talk->offer_header_count;
     }
     return true;
 }
 
-static void signal_failed(talk_signaling_t *talk, const char *message)
+static void ignore_close_result(
+    esp_openclaw_node_handle_t node,
+    const esp_openclaw_node_gateway_result_t *result,
+    void *user_ctx);
+
+static void close_voice_session(
+    esp_openclaw_node_handle_t operator_node,
+    const char *session_key,
+    const char *voice_session_id)
+{
+    if (voice_session_id == NULL || voice_session_id[0] == '\0' ||
+        strlen(voice_session_id) > MAX_VOICE_SESSION_ID_BYTES) {
+        return;
+    }
+    cJSON *params = cJSON_CreateObject();
+    if (params == NULL) {
+        return;
+    }
+    cJSON_AddStringToObject(params, "sessionKey", session_key);
+    cJSON_AddStringToObject(params, "voiceSessionId", voice_session_id);
+    char *params_json = cJSON_PrintUnformatted(params);
+    cJSON_Delete(params);
+    if (params_json != NULL) {
+        (void)esp_openclaw_node_gateway_request(
+            operator_node,
+            "talk.client.close",
+            params_json,
+            ignore_close_result,
+            NULL);
+        free(params_json);
+    }
+}
+
+static char *duplicate_voice_session_id(cJSON *value)
+{
+    if (!cJSON_IsString(value) || value->valuestring == NULL) {
+        return NULL;
+    }
+    size_t len = strlen(value->valuestring);
+    return len > 0 && len <= MAX_VOICE_SESSION_ID_BYTES
+        ? strdup(value->valuestring)
+        : NULL;
+}
+
+static bool has_gateway_control_descriptor(cJSON *payload)
+{
+    cJSON *control = cJSON_IsObject(payload)
+        ? cJSON_GetObjectItemCaseSensitive(payload, "clientControl")
+        : NULL;
+    cJSON *owner = cJSON_IsObject(control) ? control->child : NULL;
+    return owner != NULL && owner->next == NULL && owner->string != NULL &&
+           strcmp(owner->string, "owner") == 0 && cJSON_IsString(owner) &&
+           owner->valuestring != NULL && strcmp(owner->valuestring, "gateway") == 0;
+}
+
+static void signal_failed(
+    talk_signaling_t *talk,
+    esp_openclaw_talk_setup_result_t result,
+    const char *message)
 {
     ESP_LOGE(TAG, "%s", message);
     bool notify = false;
@@ -197,8 +257,13 @@ static void signal_failed(talk_signaling_t *talk, const char *message)
         notify = true;
     }
     portEXIT_CRITICAL(&talk->state_lock);
-    if (notify && talk->signaling.on_close != NULL) {
-        talk->signaling.on_close(talk->signaling.ctx);
+    if (notify) {
+        if (talk->setup_failed_cb != NULL) {
+            talk->setup_failed_cb(result, talk->setup_failed_ctx);
+        }
+        if (talk->signaling.on_close != NULL) {
+            talk->signaling.on_close(talk->signaling.ctx);
+        }
     }
 }
 
@@ -209,21 +274,9 @@ static void handle_talk_create(
 {
     (void)node;
     talk_signaling_t *talk = user_ctx;
-    portENTER_CRITICAL(&talk->state_lock);
-    talk->create_pending = false;
-    bool stopped = talk->stopped;
-    portEXIT_CRITICAL(&talk->state_lock);
-    if (stopped) {
-        release_talk_signaling(talk);
-        return;
-    }
-    if (!result->ok || result->payload_json == NULL) {
-        signal_failed(talk, "Gateway rejected talk.client.create");
-        release_talk_signaling(talk);
-        return;
-    }
-
-    cJSON *payload = cJSON_Parse(result->payload_json);
+    cJSON *payload = result->ok && result->payload_json != NULL
+        ? cJSON_Parse(result->payload_json)
+        : NULL;
     cJSON *transport = cJSON_IsObject(payload)
         ? cJSON_GetObjectItemCaseSensitive(payload, "transport")
         : NULL;
@@ -239,24 +292,54 @@ static void handle_talk_create(
     cJSON *offer_headers = cJSON_IsObject(payload)
         ? cJSON_GetObjectItemCaseSensitive(payload, "offerHeaders")
         : NULL;
-    bool valid = cJSON_IsString(transport) &&
+    bool gateway_control = has_gateway_control_descriptor(payload);
+    char *session_id = duplicate_voice_session_id(voice_session_id);
+    bool valid = gateway_control && cJSON_IsString(transport) &&
                  strcmp(transport->valuestring, "webrtc") == 0 &&
                  cJSON_IsString(offer_url) &&
+                 offer_url->valuestring[0] == '/' &&
                  cJSON_IsString(client_secret) &&
-                 cJSON_IsString(voice_session_id);
+                 session_id != NULL;
     if (valid) {
         talk->offer_url = resolve_offer_url(
             talk->gateway_http_base_url,
             offer_url->valuestring);
         talk->client_secret = duplicate_optional(client_secret->valuestring);
-        talk->voice_session_id = duplicate_optional(voice_session_id->valuestring);
+        talk->voice_session_id = session_id;
+        session_id = NULL;
         valid = talk->offer_url != NULL && talk->client_secret != NULL &&
-                talk->voice_session_id != NULL &&
                 copy_offer_headers(talk, offer_headers);
     }
     cJSON_Delete(payload);
     if (!valid) {
-        signal_failed(talk, "talk.client.create returned an invalid WebRTC offer");
+        close_voice_session(
+            talk->operator_node,
+            talk->session_key,
+            session_id != NULL ? session_id : talk->voice_session_id);
+        free(session_id);
+        bool upgrade_required = result->ok && !gateway_control;
+        if (!result->ok && result->error_code != NULL) {
+            upgrade_required = strcmp(result->error_code, "INVALID_REQUEST") == 0 ||
+                               strcmp(result->error_code, "NOT_SUPPORTED") == 0;
+        }
+        signal_failed(
+            talk,
+            upgrade_required
+                ? ESP_OPENCLAW_TALK_GATEWAY_UPGRADE_REQUIRED
+                : ESP_OPENCLAW_TALK_SETUP_FAILED,
+            upgrade_required ? "Gateway upgrade required" : "Talk setup failed");
+        release_talk_signaling(talk);
+        return;
+    }
+
+    portENTER_CRITICAL(&talk->state_lock);
+    bool stopped = talk->stopped;
+    if (!stopped) {
+        talk->gateway_owned = true;
+    }
+    portEXIT_CRITICAL(&talk->state_lock);
+    if (stopped) {
+        close_voice_session(talk->operator_node, talk->session_key, talk->voice_session_id);
         release_talk_signaling(talk);
         return;
     }
@@ -300,6 +383,8 @@ static int talk_signaling_start(
     talk->model = duplicate_optional(config->model);
     talk->voice = duplicate_optional(config->voice);
     talk->silence_duration_ms = config->silence_duration_ms;
+    talk->setup_failed_cb = config->setup_failed_cb;
+    talk->setup_failed_ctx = config->setup_failed_ctx;
     if (talk->session_key == NULL) {
         free_talk_signaling(talk);
         return ESP_PEER_ERR_NO_MEM;
@@ -325,6 +410,15 @@ static int talk_signaling_start(
             "silenceDurationMs",
             talk->silence_duration_ms);
     }
+    cJSON *capabilities = cJSON_AddArrayToObject(params, "capabilities");
+    cJSON *gateway_control = cJSON_CreateString(GATEWAY_CONTROL_CAPABILITY);
+    if (capabilities == NULL || gateway_control == NULL ||
+        !cJSON_AddItemToArray(capabilities, gateway_control)) {
+        cJSON_Delete(gateway_control);
+        cJSON_Delete(params);
+        free_talk_signaling(talk);
+        return ESP_PEER_ERR_NO_MEM;
+    }
     char *params_json = cJSON_PrintUnformatted(params);
     cJSON_Delete(params);
     if (params_json == NULL) {
@@ -332,9 +426,6 @@ static int talk_signaling_start(
         return ESP_PEER_ERR_NO_MEM;
     }
 
-    portENTER_CRITICAL(&talk->state_lock);
-    talk->create_pending = true;
-    portEXIT_CRITICAL(&talk->state_lock);
     retain_talk_signaling(talk);
     esp_err_t err = esp_openclaw_node_gateway_request(
         talk->operator_node,
@@ -462,7 +553,8 @@ static int talk_signaling_send_msg(
         release_talk_signaling(talk);
         return ESP_PEER_ERR_NONE;
     }
-    if (message->type != ESP_PEER_SIGNALING_MSG_SDP || talk->offer_url == NULL ||
+    if (message->type != ESP_PEER_SIGNALING_MSG_SDP || !talk->gateway_owned ||
+        talk->offer_url == NULL ||
         talk->client_secret == NULL) {
         release_talk_signaling(talk);
         return ESP_PEER_ERR_FAIL;
@@ -501,23 +593,11 @@ static int talk_signaling_stop(esp_peer_signaling_handle_t handle)
     }
     talk->stopped = true;
     bool notify = !talk->close_notified;
+    bool close = talk->gateway_owned;
     talk->close_notified = true;
     portEXIT_CRITICAL(&talk->state_lock);
-    if (talk->voice_session_id != NULL) {
-        cJSON *params = cJSON_CreateObject();
-        cJSON_AddStringToObject(params, "sessionKey", talk->session_key);
-        cJSON_AddStringToObject(params, "voiceSessionId", talk->voice_session_id);
-        char *params_json = cJSON_PrintUnformatted(params);
-        cJSON_Delete(params);
-        if (params_json != NULL) {
-            (void)esp_openclaw_node_gateway_request(
-                talk->operator_node,
-                "talk.client.close",
-                params_json,
-                ignore_close_result,
-                NULL);
-            free(params_json);
-        }
+    if (close) {
+        close_voice_session(talk->operator_node, talk->session_key, talk->voice_session_id);
     }
     if (notify && talk->signaling.on_close != NULL) {
         talk->signaling.on_close(talk->signaling.ctx);

--- a/components/esp-openclaw-talk/tests/test_esp_openclaw_talk.c
+++ b/components/esp-openclaw-talk/tests/test_esp_openclaw_talk.c
@@ -1,0 +1,196 @@
+#include <string.h>
+
+#include "unity.h"
+
+#define esp_openclaw_node_gateway_request test_talk_gateway_request
+#include "../src/esp_openclaw_talk.c"
+#undef esp_openclaw_node_gateway_request
+
+typedef struct {
+    esp_openclaw_node_gateway_request_cb_t create_cb;
+    void *create_ctx;
+    char create_params[512];
+    char close_params[256];
+    int close_count;
+    int ice_count;
+    int connected_count;
+    int signaling_close_count;
+    int setup_failed_count;
+    esp_openclaw_talk_setup_result_t setup_result;
+} talk_test_state_t;
+
+static talk_test_state_t s_talk;
+
+esp_err_t test_talk_gateway_request(
+    esp_openclaw_node_handle_t node,
+    const char *method,
+    const char *params_json,
+    esp_openclaw_node_gateway_request_cb_t callback,
+    void *user_ctx)
+{
+    (void)node;
+    if (strcmp(method, "talk.client.create") == 0) {
+        s_talk.create_cb = callback;
+        s_talk.create_ctx = user_ctx;
+        snprintf(s_talk.create_params, sizeof(s_talk.create_params), "%s", params_json);
+    } else {
+        TEST_ASSERT_EQUAL_STRING("talk.client.close", method);
+        ++s_talk.close_count;
+        snprintf(s_talk.close_params, sizeof(s_talk.close_params), "%s", params_json);
+    }
+    return ESP_OK;
+}
+
+static int record_ice(esp_peer_signaling_ice_info_t *info, void *ctx)
+{
+    (void)ctx;
+    TEST_ASSERT_TRUE(info->is_initiator);
+    ++s_talk.ice_count;
+    return 0;
+}
+
+static int record_connected(void *ctx)
+{
+    (void)ctx;
+    ++s_talk.connected_count;
+    return 0;
+}
+
+static int record_close(void *ctx)
+{
+    (void)ctx;
+    ++s_talk.signaling_close_count;
+    return 0;
+}
+
+static void record_setup_failed(esp_openclaw_talk_setup_result_t result, void *ctx)
+{
+    (void)ctx;
+    ++s_talk.setup_failed_count;
+    s_talk.setup_result = result;
+}
+
+static esp_peer_signaling_handle_t start_signaling(void)
+{
+    memset(&s_talk, 0, sizeof(s_talk));
+    const esp_openclaw_talk_signaling_config_t extra = {
+        .operator_node = (esp_openclaw_node_handle_t)1,
+        .gateway_http_base_url = "https://gateway.example/",
+        .session_key = "main",
+        .setup_failed_cb = record_setup_failed,
+    };
+    esp_peer_signaling_cfg_t config = {
+        .on_ice_info = record_ice,
+        .on_connected = record_connected,
+        .on_close = record_close,
+        .extra_cfg = (void *)&extra,
+    };
+    esp_peer_signaling_handle_t handle = NULL;
+    TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_start(&config, &handle));
+    TEST_ASSERT_NOT_NULL(handle);
+    TEST_ASSERT_NOT_NULL(s_talk.create_cb);
+    return handle;
+}
+
+static void respond_to_create(bool ok, const char *payload, const char *error_code)
+{
+    esp_openclaw_node_gateway_request_cb_t callback = s_talk.create_cb;
+    void *ctx = s_talk.create_ctx;
+    s_talk.create_cb = NULL;
+    s_talk.create_ctx = NULL;
+    const esp_openclaw_node_gateway_result_t result = {
+        .ok = ok,
+        .payload_json = payload,
+        .error_code = error_code,
+    };
+    callback(NULL, &result, ctx);
+}
+
+static const char *valid_response(void)
+{
+    return "{\"transport\":\"webrtc\",\"offerUrl\":\"/talk/offer\","
+           "\"clientSecret\":\"broker-token\",\"voiceSessionId\":\"voice-1\","
+           "\"offerHeaders\":{\"X-Talk\":\"one\"},"
+           "\"clientControl\":{\"owner\":\"gateway\"}}";
+}
+
+TEST_CASE("Gateway-owned Talk create preserves the broker offer", "[esp_openclaw_talk]")
+{
+    esp_peer_signaling_handle_t handle = start_signaling();
+    TEST_ASSERT_NOT_NULL(strstr(s_talk.create_params, "\"capabilities\":[\"gateway-control-v1\"]"));
+    respond_to_create(true, valid_response(), NULL);
+    talk_signaling_t *talk = handle;
+    TEST_ASSERT_TRUE(talk->gateway_owned);
+    TEST_ASSERT_EQUAL_STRING("https://gateway.example/talk/offer", talk->offer_url);
+    TEST_ASSERT_EQUAL_STRING("broker-token", talk->client_secret);
+    TEST_ASSERT_EQUAL_STRING("X-Talk", talk->offer_headers[0].name);
+    TEST_ASSERT_EQUAL(1, s_talk.ice_count);
+    TEST_ASSERT_EQUAL(1, s_talk.connected_count);
+    TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_stop(handle));
+    TEST_ASSERT_EQUAL(1, s_talk.close_count);
+    TEST_ASSERT_NOT_NULL(strstr(s_talk.close_params, "\"voiceSessionId\":\"voice-1\""));
+}
+
+TEST_CASE("Talk rejects non-Gateway control before peer creation", "[esp_openclaw_talk]")
+{
+    const char *responses[] = {
+        "{\"transport\":\"webrtc\",\"offerUrl\":\"/o\",\"clientSecret\":\"t\",\"voiceSessionId\":\"missing\"}",
+        "{\"transport\":\"webrtc\",\"offerUrl\":\"/o\",\"clientSecret\":\"t\",\"voiceSessionId\":\"client\",\"clientControl\":{\"owner\":\"client\"}}",
+        "{\"transport\":\"webrtc\",\"offerUrl\":\"/o\",\"clientSecret\":\"t\",\"voiceSessionId\":\"extra\",\"clientControl\":{\"owner\":\"gateway\",\"version\":1}}",
+    };
+    for (size_t i = 0; i < sizeof(responses) / sizeof(responses[0]); ++i) {
+        esp_peer_signaling_handle_t handle = start_signaling();
+        respond_to_create(true, responses[i], NULL);
+        TEST_ASSERT_EQUAL(ESP_OPENCLAW_TALK_GATEWAY_UPGRADE_REQUIRED, s_talk.setup_result);
+        TEST_ASSERT_EQUAL(1, s_talk.setup_failed_count);
+        TEST_ASSERT_EQUAL(1, s_talk.signaling_close_count);
+        TEST_ASSERT_EQUAL(0, s_talk.ice_count);
+        TEST_ASSERT_EQUAL(1, s_talk.close_count);
+        TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_stop(handle));
+        TEST_ASSERT_EQUAL(1, s_talk.setup_failed_count);
+    }
+}
+
+TEST_CASE("late Talk create closes after stop and ignores stale failure", "[esp_openclaw_talk]")
+{
+    esp_peer_signaling_handle_t handle = start_signaling();
+    TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_stop(handle));
+    respond_to_create(true, valid_response(), NULL);
+    TEST_ASSERT_EQUAL(1, s_talk.close_count);
+    TEST_ASSERT_EQUAL(0, s_talk.ice_count);
+    TEST_ASSERT_EQUAL(0, s_talk.setup_failed_count);
+    TEST_ASSERT_EQUAL(1, s_talk.signaling_close_count);
+}
+
+TEST_CASE("Talk close bounds voice session ids", "[esp_openclaw_talk]")
+{
+    char accepted[129];
+    char rejected[130];
+    memset(accepted, 'a', sizeof(accepted) - 1U);
+    accepted[sizeof(accepted) - 1U] = '\0';
+    memset(rejected, 'b', sizeof(rejected) - 1U);
+    rejected[sizeof(rejected) - 1U] = '\0';
+    cJSON *accepted_json = cJSON_CreateString(accepted);
+    cJSON *rejected_json = cJSON_CreateString(rejected);
+    char *copy = duplicate_voice_session_id(accepted_json);
+    TEST_ASSERT_EQUAL_STRING(accepted, copy);
+    TEST_ASSERT_NULL(duplicate_voice_session_id(rejected_json));
+    free(copy);
+    cJSON_Delete(accepted_json);
+    cJSON_Delete(rejected_json);
+}
+
+TEST_CASE("Talk setup failure is actionable and a second call recovers", "[esp_openclaw_talk]")
+{
+    esp_peer_signaling_handle_t failed = start_signaling();
+    respond_to_create(false, NULL, "UNAVAILABLE");
+    TEST_ASSERT_EQUAL(ESP_OPENCLAW_TALK_SETUP_FAILED, s_talk.setup_result);
+    TEST_ASSERT_EQUAL(1, s_talk.setup_failed_count);
+    TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_stop(failed));
+
+    esp_peer_signaling_handle_t recovered = start_signaling();
+    respond_to_create(true, valid_response(), NULL);
+    TEST_ASSERT_EQUAL(1, s_talk.connected_count);
+    TEST_ASSERT_EQUAL(0, s_talk.setup_failed_count);
+    TEST_ASSERT_EQUAL(ESP_PEER_ERR_NONE, talk_signaling_stop(recovered));
+}


### PR DESCRIPTION
## What Problem This Solves

ESP Talk sessions advertised agent consult and control tools, but the firmware had no complete provider data-channel loop: it did not create or consume the required channel, handle terminal function calls, return tool output, or request the follow-up response. A consult-routed turn could therefore end silently.

Closes #25.

Dependency: https://github.com/openclaw/openclaw/pull/121054 (merged as `7dcb4fb76032c91bf248d9bc87e3c405bb539d91`).

## Why This Change Was Made

The final ownership boundary keeps the ESP as a thin audio-only WebRTC client. Firmware requests `gateway-control-v1`, requires the exact `clientControl: { owner: "gateway" }` result, and sends its SDP to the Gateway's single-use offer broker. Media remains direct between the device and provider; the Gateway owns tools, agent consultation, status, steering, cancellation, transcripts, credentials, response continuation, and cleanup.

The earlier embedded-control direction was deliberately not landed. It put provider event parsing, function-call correlation, bounded buffering, deduplication, tool routing, response continuation, and cancellation into constrained firmware even though the Gateway already owns agent policy and credentials. It also retained the WebRTC SCTP cost and introduced lifecycle/concurrency failure modes around start, stop, late create callbacks, and cleanup. Centralizing the control plane in the Gateway removes duplicate ownership and leaves one observable lifecycle.

Unsupported or older Gateways now fail visibly before peer creation instead of falling back to an incomplete client-owned path. The room UI distinguishes the upgrade-required case from generic Talk setup failure, and late create results are closed safely.

## Size and Memory

- Production: `+205/-81` (net `+124`). The positive delta implements the negotiated ownership contract, strict response validation, visible setup failure, and safe session cleanup.
- Tests and test harness: `+209/-2` (net `+207`).
- Documentation and component changelog: `+6/-2` (net `+4`).
- The room client changes `enable_data_channel` from `true` to `false`. Under the pinned Espressif peer contract this prevents the default SCTP send and receive caches (`100 KiB` each) from being activated, removing about `200 KiB` of per-call cache pressure. No ESP provider-JSON/tool controller is added.

## Evidence

- Exact firmware head: `53131d07e1a162b72c7754f52c31410aa3236626`.
- Pinned WebRTC dependency: `espressif/esp-webrtc-solution@4135993ac537730cfa96c407b8a02e59c0f46922`; pinned Opus component: `espressif/esp_audio_codec@2.5.0` (`16e2880dbdd5a72264051f750f33a6e5a38fd25621c83e3a32a85a152d2d2643`).
- Unity application, Waveshare room-node build, M5Stack Tab5 build, host tests, analyzer, static-size checks, `git diff --check`, and secret scans passed.
- Fresh full-branch autoreview at this head: clean, confidence `0.98`; exact-bundle TruffleHog scan: clean.
- Fresh Tab5 proof build used ESP-IDF `5.5.5` and the checked-in early-P4 defaults. App image: `4,136,528` bytes, SHA-256 `2f5e84b761b4072a98785275591cd830d0cc568c2ca4e834dbfd436e1159754f`.
- Real M5Stack Tab5: the candidate negotiated `gateway-control-v1`, remained audio-only with no runtime SCTP/data-channel states or ESP provider JSON loop, and connected through the merged Gateway architecture. After the Gateway's PCM16 24 kHz correction, the device produced normal intelligible assistant speech, physically confirmed by the user. Response volume was quiet; loudness is a separate board/audio-tuning concern.
- Restoration was byte-for-byte verified after the physical run. Original app SHA-256 `d8b3a0e74a5f2eaedb32fd311a668029f0cc9385fb222639a9a41b4a8bee88ce` and NVS SHA-256 `53202129f7a6ff16f15dbabec918f360765f39f5bd5a9d5dbb7e23f0f709ef01` matched post-write readback. Original firmware `515e6f8-dirty` booted and reconnected both node and operator roles; protected backups and scratch runtime were then removed.

## Physical Proof Gap and Privacy

The six-hour restoration deadline interrupted the complete five-turn/context/status/steer/cancel/teardown physical suite. This PR does **not** claim those scenarios completed. The proof establishes ownership negotiation, audio-only operation, merged-Gateway connectivity, and normal intelligible physical assistant audio; the remaining multi-turn/control scenarios retain deterministic coverage across the paired repositories.

Physical validation used synthetic prompts and private local audio only. No personal speech, raw recording, private transcript, token, setup code, device identifier, or network detail is attached.
