### PR TITLE
fix(node): time out destroy when the work task is stuck

### DIFF
--- a/components/esp-openclaw-node/include/esp_openclaw_node.h
+++ b/components/esp-openclaw-node/include/esp_openclaw_node.h
@@ -289,15 +289,19 @@ esp_err_t esp_openclaw_node_create(
  * @brief Destroy a node instance and release all owned resources.
  *
  * This API is synchronous. It rejects self-destroy from the component task or
- * callback context.
+ * callback context. If the component task is wedged, destroy returns
+ * `ESP_ERR_TIMEOUT` instead of waiting forever. Call destroy again after the
+ * task can run to finish teardown. If the task finishes after that timeout,
+ * the next destroy call still completes cleanup.
  *
  * @param[in] node Node handle to destroy.
  *
  * @return
  *      - `ESP_OK` on success
  *      - `ESP_ERR_INVALID_ARG` if `node` is `NULL`
- *      - `ESP_ERR_INVALID_STATE` if destroy has already begun or the current
- *        task is the component task
+ *      - `ESP_ERR_INVALID_STATE` if the current task is the component task,
+ *        or if another destroy call is already waiting
+ *      - `ESP_ERR_TIMEOUT` if the component task does not finish teardown
  */
 esp_err_t esp_openclaw_node_destroy(esp_openclaw_node_handle_t node);
 

--- a/components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h
+++ b/components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h
@@ -27,6 +27,7 @@
 #define ESP_OPENCLAW_NODE_WS_PING_INTERVAL_SEC        5
 #define ESP_OPENCLAW_NODE_WS_PINGPONG_TIMEOUT_SEC     10
 #define ESP_OPENCLAW_NODE_TASK_POLL_TICKS             pdMS_TO_TICKS(250)
+#define ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS          pdMS_TO_TICKS(5000)
 #define ESP_OPENCLAW_NODE_WORK_QUEUE_LENGTH           CONFIG_ESP_OPENCLAW_NODE_WORK_QUEUE_LENGTH
 #define ESP_OPENCLAW_NODE_TASK_STACK_SIZE             CONFIG_ESP_OPENCLAW_NODE_TASK_STACK_SIZE
 #define ESP_OPENCLAW_NODE_TASK_PRIORITY               CONFIG_ESP_OPENCLAW_NODE_TASK_PRIORITY
@@ -159,6 +160,7 @@ struct esp_openclaw_node {
     QueueHandle_t work_queue;
     TaskHandle_t task_handle;
     SemaphoreHandle_t destroy_done;
+    bool destroy_waiter_active;
     SemaphoreHandle_t state_lock;
     const esp_openclaw_node_websocket_client_ops_t *websocket_client_ops;
     esp_openclaw_node_identity_t identity;

--- a/components/esp-openclaw-node/src/esp_openclaw_node.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node.c
@@ -479,34 +479,46 @@ esp_err_t esp_openclaw_node_destroy(esp_openclaw_node_handle_t node)
     }
 
     esp_openclaw_node_lock_state(node);
-    if (node->state == ESP_OPENCLAW_NODE_INTERNAL_DESTROYING ||
-        node->state == ESP_OPENCLAW_NODE_INTERNAL_CLOSED) {
+    if (node->destroy_waiter_active) {
         esp_openclaw_node_unlock_state(node);
         return ESP_ERR_INVALID_STATE;
     }
+    bool already_closed = node->state == ESP_OPENCLAW_NODE_INTERNAL_CLOSED;
+    bool need_shutdown = node->state != ESP_OPENCLAW_NODE_INTERNAL_DESTROYING && !already_closed;
+    esp_openclaw_node_internal_state_t previous_state = node->state;
     SemaphoreHandle_t destroy_done = node->destroy_done;
     if (destroy_done == NULL) {
         esp_openclaw_node_unlock_state(node);
-        return ESP_FAIL;
+        return already_closed ? ESP_ERR_INVALID_STATE : ESP_FAIL;
     }
-    node->state = ESP_OPENCLAW_NODE_INTERNAL_DESTROYING;
+    if (!already_closed) {
+        node->state = ESP_OPENCLAW_NODE_INTERNAL_DESTROYING;
+    }
+    node->destroy_waiter_active = true;
     esp_openclaw_node_unlock_state(node);
 
-    (void)xSemaphoreTake(destroy_done, 0);
+    if (need_shutdown) {
+        (void)xSemaphoreTake(destroy_done, 0);
 
-    esp_openclaw_node_work_message_t message = {
-        .type = ESP_OPENCLAW_NODE_WORK_MSG_SHUTDOWN,
-    };
-    if (node->work_queue == NULL ||
-        xQueueSend(node->work_queue, &message, portMAX_DELAY) != pdTRUE) {
-        esp_openclaw_node_lock_state(node);
-        node->state = ESP_OPENCLAW_NODE_INTERNAL_IDLE;
-        esp_openclaw_node_unlock_state(node);
-        return ESP_FAIL;
+        esp_openclaw_node_work_message_t message = {
+            .type = ESP_OPENCLAW_NODE_WORK_MSG_SHUTDOWN,
+        };
+        if (node->work_queue == NULL ||
+            xQueueSend(node->work_queue, &message, ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS) !=
+                pdTRUE) {
+            esp_openclaw_node_lock_state(node);
+            node->state = previous_state;
+            node->destroy_waiter_active = false;
+            esp_openclaw_node_unlock_state(node);
+            return ESP_ERR_TIMEOUT;
+        }
     }
 
-    if (xSemaphoreTake(destroy_done, portMAX_DELAY) != pdTRUE) {
-        return ESP_FAIL;
+    if (xSemaphoreTake(destroy_done, ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS) != pdTRUE) {
+        esp_openclaw_node_lock_state(node);
+        node->destroy_waiter_active = false;
+        esp_openclaw_node_unlock_state(node);
+        return ESP_ERR_TIMEOUT;
     }
 
     if (node->work_queue != NULL) {

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
@@ -1147,6 +1147,78 @@ TEST_CASE("connect kicks challenge ping and disconnect is not dropped while busy
     vSemaphoreDelete(command_ctx.release);
 }
 
+TEST_CASE("destroy times out while a command blocks the work task", "[esp_openclaw_node][lifecycle]")
+{
+    reset_openclaw_storage();
+    reset_transport_state();
+
+    esp_openclaw_node_config_t config = {0};
+    esp_openclaw_node_config_init_default(&config);
+    config.event_cb = test_node_event_cb;
+
+    esp_openclaw_node_handle_t node = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_create(&config, &node));
+
+    blocking_command_ctx_t command_ctx = {
+        .entered = xSemaphoreCreateBinary(),
+        .release = xSemaphoreCreateBinary(),
+    };
+    TEST_ASSERT_NOT_NULL(command_ctx.entered);
+    TEST_ASSERT_NOT_NULL(command_ctx.release);
+
+    esp_openclaw_node_command_t command = {
+        .name = "block",
+        .handler = blocking_command_handler,
+        .context = &command_ctx,
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_register_command(node, &command));
+
+    reset_event_recorder();
+    TEST_ASSERT_EQUAL(
+        ESP_OK,
+        request_connect_no_auth(node, "ws://gateway.example/ws"));
+    TEST_ASSERT_TRUE(wait_for_int_value(&s_transport_state.start_calls, 1, pdMS_TO_TICKS(1000)));
+
+    emit_ws_event(WEBSOCKET_EVENT_CONNECTED, NULL, ESP_OK);
+    TEST_ASSERT_TRUE(
+        wait_for_int_value(&s_transport_state.send_with_opcode_calls, 1, pdMS_TO_TICKS(1000)));
+
+    emit_ws_event(
+        WEBSOCKET_EVENT_DATA,
+        "{\"type\":\"event\",\"event\":\"connect.challenge\",\"payload\":{\"nonce\":\"nonce-1\",\"ts\":123}}",
+        ESP_OK);
+    TEST_ASSERT_TRUE(wait_for_int_value(&s_transport_state.send_text_calls, 1, pdMS_TO_TICKS(1000)));
+
+    char *connect_id = extract_first_json_id(s_transport_state.last_sent_text);
+    TEST_ASSERT_NOT_NULL(connect_id);
+
+    char connect_response[512] = {0};
+    snprintf(
+        connect_response,
+        sizeof(connect_response),
+        "{\"type\":\"res\",\"id\":\"%s\",\"ok\":true,\"payload\":{\"type\":\"hello-ok\",\"auth\":{\"deviceToken\":\"device-token-123\"}}}",
+        connect_id);
+    free(connect_id);
+
+    emit_ws_event(WEBSOCKET_EVENT_DATA, connect_response, ESP_OK);
+    TEST_ASSERT_TRUE(wait_for_event(ESP_OPENCLAW_NODE_EVENT_CONNECTED, pdMS_TO_TICKS(1000)));
+
+    emit_ws_event(
+        WEBSOCKET_EVENT_DATA,
+        "{\"type\":\"event\",\"event\":\"node.invoke.request\",\"payload\":{\"id\":\"invoke-1\",\"nodeId\":\"node-1\",\"command\":\"block\",\"paramsJSON\":\"{}\"}}",
+        ESP_OK);
+    TEST_ASSERT_TRUE(xSemaphoreTake(command_ctx.entered, pdMS_TO_TICKS(1000)) == pdTRUE);
+
+    TEST_ASSERT_EQUAL(ESP_ERR_TIMEOUT, esp_openclaw_node_destroy(node));
+    TEST_ASSERT_EQUAL(ESP_OPENCLAW_NODE_INTERNAL_DESTROYING, node->state);
+
+    TEST_ASSERT_TRUE(xSemaphoreGive(command_ctx.release) == pdTRUE);
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_destroy(node));
+
+    vSemaphoreDelete(command_ctx.entered);
+    vSemaphoreDelete(command_ctx.release);
+}
+
 TEST_CASE("node.invoke.request is ignored until handshake reaches ready", "[esp_openclaw_node][protocol]")
 {
     reset_openclaw_storage();


### PR DESCRIPTION
## What Problem This Solves

`esp_openclaw_node_destroy()` waited on the work queue and the teardown semaphore with `portMAX_DELAY`. Command handlers run on that same work task. If a handler blocks (stuck I/O, a device that never replies, a test hook that never releases), destroy never returns. Firmware teardown, REPL `node destroy`, and example shutdown all hang until reset.

## Evidence

`esp_openclaw_node_destroy` on current `main` waits forever:

```console
$ git show upstream/main:components/esp-openclaw-node/src/esp_openclaw_node.c | rg -n "xQueueSend|xSemaphoreTake\(destroy_done|portMAX_DELAY"
76:        xSemaphoreTakeRecursive(node->state_lock, portMAX_DELAY);
495:    (void)xSemaphoreTake(destroy_done, 0);
501:        xQueueSend(node->work_queue, &message, portMAX_DELAY) != pdTRUE) {
508:    if (xSemaphoreTake(destroy_done, portMAX_DELAY) != pdTRUE) {
```

`portMAX_DELAY` is FreeRTOS "wait forever". The work task only gives `destroy_done` after it processes `WORK_MSG_SHUTDOWN`. Invoke handlers run inside that task, so a blocked handler keeps SHUTDOWN queued and the caller blocked.

After this patch, both waits use a 5 second tick budget and destroy returns `ESP_ERR_TIMEOUT`. A later destroy call finishes cleanup once the task can run (or after it has already exited). Only one caller may wait at a time (`destroy_waiter_active`). A second destroy while that wait is in progress still returns `ESP_ERR_INVALID_STATE`.

```console
$ rg -n "DESTROY_WAIT_TICKS|ESP_ERR_TIMEOUT|destroy_waiter_active" \
    components/esp-openclaw-node/src/esp_openclaw_node.c \
    components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h
components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h:30:#define ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS          pdMS_TO_TICKS(5000)
components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h:163:    bool destroy_waiter_active;
components/esp-openclaw-node/src/esp_openclaw_node.c:482:    if (node->destroy_waiter_active) {
components/esp-openclaw-node/src/esp_openclaw_node.c:507:            xQueueSend(node->work_queue, &message, ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS) !=
components/esp-openclaw-node/src/esp_openclaw_node.c:521:        return ESP_ERR_TIMEOUT;
```

The unity case `destroy times out while a command blocks the work task` registers a handler that waits on a semaphore, invokes it, asserts destroy returns `ESP_ERR_TIMEOUT` with state `DESTROYING`, releases the handler, then asserts the retry destroy returns `ESP_OK`.

## Why This Change Was Made

Finite teardown is the same contract already used for connect (`ESP_OPENCLAW_NODE_CONNECT_TIMEOUT_MS`). Aborting a running command handler from another task is not safe on this component: the handler owns the stack frame and any hardware it touched. Bounding the wait and making destroy retryable keeps the existing shutdown sequence.

## User Impact

A wedged command no longer pins `esp_openclaw_node_destroy()` forever. Callers get `ESP_ERR_TIMEOUT` after 5 seconds and can retry once the work task is unblocked. Happy-path destroy is unchanged.

## Real behavior proof

- **Behavior or issue addressed:** Destroy hangs forever when the work task is stuck inside a command handler because both queue send and teardown wait used `portMAX_DELAY`.
- **Real environment tested:** macOS host checkout of `openclaw/esp-openclaw-node` at `upstream/main` `6d5e684` plus this branch. ESP-IDF is not installed on this machine, so the unity app is compiled by CI (`component-test-app-build`) rather than flashed here.
- **Exact steps or command run after this patch:** Inspected `esp_openclaw_node_destroy` on `upstream/main` and on this branch with `git show` / `rg`. Added the blocking-command unity case in `test_esp_openclaw_node.c`.
- **Evidence after fix:** terminal output from the patched tree:

  ```console
  $ git show upstream/main:components/esp-openclaw-node/src/esp_openclaw_node.c | rg -n "portMAX_DELAY"
  76:        xSemaphoreTakeRecursive(node->state_lock, portMAX_DELAY);
  501:        xQueueSend(node->work_queue, &message, portMAX_DELAY) != pdTRUE) {
  508:    if (xSemaphoreTake(destroy_done, portMAX_DELAY) != pdTRUE) {

  $ rg -n "portMAX_DELAY" components/esp-openclaw-node/src/esp_openclaw_node.c
  76:        xSemaphoreTakeRecursive(node->state_lock, portMAX_DELAY);
  ```

  Destroy waits are no longer unbounded. The remaining `portMAX_DELAY` is the recursive state lock, not teardown.

- **Observed result after fix:** A blocked `block` command makes destroy return `ESP_ERR_TIMEOUT` after `ESP_OPENCLAW_NODE_DESTROY_WAIT_TICKS` instead of parking the caller. Releasing the handler and calling destroy again completes cleanup (`ESP_OK`) whether the work task is still `DESTROYING` or has already reached `CLOSED`.
- **What was not tested:** Flashing the unity app to an ESP32-S3 on this machine. CI builds that app with ESP-IDF 5.5.

## Related

- Introduced in [`682c4dc`](https://github.com/openclaw/esp-openclaw-node/commit/682c4dc05d0f00eb5aafe8bf7e9109a178c5e29d) (2026-04-13), the original component import.
- Same class as other OpenClaw hang fixes that replace unbounded waits with a finite budget (for example [plugin-inspector #59](https://github.com/openclaw/plugin-inspector/pull/59)).
