### PR TITLE
fix(node): centralize connect source ownership moves

### DIFF
--- a/components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h
+++ b/components/esp-openclaw-node/private_include/esp_openclaw_node_internal.h
@@ -243,6 +243,9 @@ bool esp_openclaw_node_is_node_task_context(esp_openclaw_node_handle_t node);
 
 void esp_openclaw_node_clear_connect_source_struct(
     esp_openclaw_node_connect_request_source_t *source);
+void esp_openclaw_node_move_connect_source_struct(
+    esp_openclaw_node_connect_request_source_t *destination,
+    esp_openclaw_node_connect_request_source_t *source);
 esp_err_t esp_openclaw_node_build_connect_source_from_request(
     const esp_openclaw_node_connect_request_t *request,
     esp_openclaw_node_connect_request_source_t *out_source);

--- a/components/esp-openclaw-node/src/esp_openclaw_node_connect_source.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_connect_source.c
@@ -33,6 +33,21 @@ void esp_openclaw_node_clear_connect_source_struct(
     source->kind = ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE;
 }
 
+void esp_openclaw_node_move_connect_source_struct(
+    esp_openclaw_node_connect_request_source_t *destination,
+    esp_openclaw_node_connect_request_source_t *source)
+{
+    if (destination == NULL || source == NULL || destination == source) {
+        return;
+    }
+
+    esp_openclaw_node_clear_connect_source_struct(destination);
+    *destination = *source;
+    source->gateway_uri = NULL;
+    source->secret = NULL;
+    source->kind = ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE;
+}
+
 static esp_err_t validate_connect_source(
     const esp_openclaw_node_connect_request_source_t *source)
 {

--- a/components/esp-openclaw-node/src/esp_openclaw_node_runtime.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_runtime.c
@@ -171,9 +171,9 @@ static void handle_request_connect(
         }
     }
     esp_openclaw_node_clear_pending_control_locked(node);
-    esp_openclaw_node_clear_connect_source_struct(&node->active_connect_source);
-    node->active_connect_source = message->connect_source;
-    memset(&message->connect_source, 0, sizeof(message->connect_source));
+    esp_openclaw_node_move_connect_source_struct(
+        &node->active_connect_source,
+        &message->connect_source);
     node->state = ESP_OPENCLAW_NODE_INTERNAL_CONNECTING;
     node->connect_started_ms = esp_timer_get_time() / 1000LL;
     esp_openclaw_node_unlock_state(node);
@@ -520,9 +520,10 @@ esp_err_t esp_openclaw_node_submit_connect_request(
 
     esp_openclaw_node_work_message_t message = {
         .type = ESP_OPENCLAW_NODE_WORK_MSG_REQUEST_CONNECT,
-        .connect_source = *connect_source,
     };
-    memset(connect_source, 0, sizeof(*connect_source));
+    esp_openclaw_node_move_connect_source_struct(
+        &message.connect_source,
+        connect_source);
 
     err = submit_pending_request(
         node,

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
@@ -979,18 +979,39 @@ TEST_CASE("password auth is excluded from the signed device payload", "[esp_open
     esp_openclaw_node_connect_material_t password_material = {0};
     esp_openclaw_node_connect_material_t token_material = {0};
 
+    char *password_gateway_uri = password_source.gateway_uri;
+    char *password_secret = password_source.secret;
     esp_openclaw_node_lock_state(node);
-    node->active_connect_source = password_source;
-    memset(&password_source, 0, sizeof(password_source));
+    esp_openclaw_node_move_connect_source_struct(
+        &node->active_connect_source,
+        &password_source);
+    TEST_ASSERT_EQUAL(
+        ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_PASSWORD,
+        node->active_connect_source.kind);
+    TEST_ASSERT_EQUAL_PTR(password_gateway_uri, node->active_connect_source.gateway_uri);
+    TEST_ASSERT_EQUAL_PTR(password_secret, node->active_connect_source.secret);
+    TEST_ASSERT_EQUAL(ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE, password_source.kind);
+    TEST_ASSERT_NULL(password_source.gateway_uri);
+    TEST_ASSERT_NULL(password_source.secret);
     TEST_ASSERT_EQUAL(
         ESP_OK,
         esp_openclaw_node_resolve_active_connect_material_locked(
             node,
             &password_material));
 
-    esp_openclaw_node_clear_connect_source_struct(&node->active_connect_source);
-    node->active_connect_source = token_source;
-    memset(&token_source, 0, sizeof(token_source));
+    char *token_gateway_uri = token_source.gateway_uri;
+    char *token_secret = token_source.secret;
+    esp_openclaw_node_move_connect_source_struct(
+        &node->active_connect_source,
+        &token_source);
+    TEST_ASSERT_EQUAL(
+        ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_SHARED_TOKEN,
+        node->active_connect_source.kind);
+    TEST_ASSERT_EQUAL_PTR(token_gateway_uri, node->active_connect_source.gateway_uri);
+    TEST_ASSERT_EQUAL_PTR(token_secret, node->active_connect_source.secret);
+    TEST_ASSERT_EQUAL(ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE, token_source.kind);
+    TEST_ASSERT_NULL(token_source.gateway_uri);
+    TEST_ASSERT_NULL(token_source.secret);
     TEST_ASSERT_EQUAL(
         ESP_OK,
         esp_openclaw_node_resolve_active_connect_material_locked(
@@ -1529,9 +1550,20 @@ TEST_CASE("device token source signs auth material", "[esp_openclaw_node][auth]"
     TEST_ASSERT_EQUAL(ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_DEVICE_TOKEN, source.kind);
 
     esp_openclaw_node_connect_material_t material = {0};
+    char *gateway_uri = source.gateway_uri;
+    char *secret = source.secret;
     esp_openclaw_node_lock_state(node);
-    node->active_connect_source = source;
-    memset(&source, 0, sizeof(source));
+    esp_openclaw_node_move_connect_source_struct(
+        &node->active_connect_source,
+        &source);
+    TEST_ASSERT_EQUAL(
+        ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_DEVICE_TOKEN,
+        node->active_connect_source.kind);
+    TEST_ASSERT_EQUAL_PTR(gateway_uri, node->active_connect_source.gateway_uri);
+    TEST_ASSERT_EQUAL_PTR(secret, node->active_connect_source.secret);
+    TEST_ASSERT_EQUAL(ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE, source.kind);
+    TEST_ASSERT_NULL(source.gateway_uri);
+    TEST_ASSERT_NULL(source.secret);
     TEST_ASSERT_EQUAL(
         ESP_OK,
         esp_openclaw_node_resolve_active_connect_material_locked(node, &material));


### PR DESCRIPTION
## Root cause

`esp_openclaw_node_connect_request_source_t` privately owns its allocated
`gateway_uri` and `secret` pointers. Five handoffs transferred that ownership
with a raw struct assignment followed by `memset` on the donor. The transfers
were intentional, but the ownership contract was implicit and matched
CodeQL's deleted-`memset` pattern.

## Architectural owner

The private connect-source module and header already own allocation,
validation, and destruction of this struct. They are the canonical owner for
its move semantics as well.

## Canonical fix

Add the private `esp_openclaw_node_move_connect_source_struct` helper. It:

- treats null and self moves as no-ops;
- clears an initialized destination;
- transfers the complete struct;
- explicitly resets the donor pointers to `NULL` and kind to `NONE`.

## Removed paths

- request source to queued work message raw copy plus donor `memset`;
- queued message to active node source raw copy plus donor `memset`;
- password, shared-token, and device-token test raw copies plus donor `memset`;
- the redundant explicit active-source clear before the shared-token test move.

No public API, dependency, settings, or changelog changes are included.

## Scope and coverage

- Production: `+24/-5` lines, net `+19`.
- Tests: `+39/-7` lines, net `+32`.
- Total: net `+51` lines.
- Sibling production coverage: request-to-message and message-to-active-source.
- Focused test coverage: password, shared-token, and device-token moves assert
  destination kind, exact pointer identity, and an empty donor.

## Validation

- `git diff --check`
- CI host file validation test: passed
- Exact call-site audit: two production moves and three test moves; no targeted
  raw-copy-plus-`memset` handoff remains
- Local `idf.py`/ESP-IDF is unavailable, so the firmware Unity app was not
  built locally
- On-device Unity was not run

## CodeQL provenance

- Default-setup run:
  https://github.com/openclaw/esp-openclaw-node/actions/runs/32460565790
- Alert 1:
  https://github.com/openclaw/esp-openclaw-node/security/code-scanning/1
- Alert 2:
  https://github.com/openclaw/esp-openclaw-node/security/code-scanning/2
- Alert 3:
  https://github.com/openclaw/esp-openclaw-node/security/code-scanning/3
