### PR TITLE
chore(deps): refresh ESP-SR and pin the CI toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Host file validation tests
+      - name: Host unit tests
         if: matrix.name == 'component-test-app-build'
         run: |
           cc -std=c11 -Wall -Wextra -Werror \
@@ -47,11 +47,18 @@ jobs:
             components/esp-openclaw-room-node/tests/test_room_file_validation.c \
             -o /tmp/room_file_validation_test
           /tmp/room_file_validation_test
+          cc -std=c11 -Wall -Wextra -Werror \
+            -I components/esp-openclaw-room-node \
+            components/esp-openclaw-room-node/room_diagnostics_metrics.c \
+            components/esp-openclaw-room-node/tests/test_room_diagnostics_metrics.c \
+            -lm -o /tmp/room_diagnostics_metrics_test
+          /tmp/room_diagnostics_metrics_test
 
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: release-v5.5
+          # Match the Tab5 manifest's exact framework requirement.
+          esp_idf_version: v5.5.5
           target: ${{ matrix.target }}
           path: ${{ matrix.path }}
           command: idf.py reconfigure && ninja -C build -j2

--- a/components/esp-openclaw-node/CHANGELOG.md
+++ b/components/esp-openclaw-node/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Refresh both room nodes to ESP-SR 2.5.2 for the upstream WakeNet and direction-of-arrival improvements.
 - Update ESP-IDF component dependencies and the CI checkout action while preserving the vendored WebRTC stack and Tab5 firmware compatibility pins.
 - Require Gateway-owned realtime control for room Talk and fail visibly before peer creation when the Gateway contract is unavailable.
 - Add authoritative Gateway URI inspection and bound assembled inbound WebSocket messages to 2 MiB by default.

--- a/examples/m5stack-tab5-room-node/main/idf_component.yml
+++ b/examples/m5stack-tab5-room-node/main/idf_component.yml
@@ -2,7 +2,7 @@ dependencies:
   idf: "==5.5.5"
   espressif/esp_hosted: "1.4.0"
   espressif/esp_wifi_remote: "0.8.5"
-  espressif/esp-sr: "^2.5.1"
+  espressif/esp-sr: "^2.5.2"
   espressif/esp_new_jpeg: "^1.0.2"
   espressif/esp_video: "^2.1"
   espressif/esp_io_expander: "^1.2"

--- a/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/idf_component.yml
+++ b/examples/waveshare-esp32-s3-touch-amoled-2.06-room-node/main/idf_component.yml
@@ -1,6 +1,6 @@
 dependencies:
   waveshare/esp32_s3_touch_amoled_2_06: "^2.0.0"
-  espressif/esp-sr: "^2.5.1"
+  espressif/esp-sr: "^2.5.2"
   espressif/esp_new_jpeg: "^1.0.2"
   esp_webrtc:
     override_path: ../../../third_party/esp-webrtc-solution/components/esp_webrtc


### PR DESCRIPTION
Updates the two room-node examples to ESP-SR 2.5.2 and keeps CI on the exact ESP-IDF version required by Tab5. This is a draft while local firmware build and on-device/QEMU validation remain incomplete.

## Dependency changes

- Both room nodes: ESP-SR minimum `^2.5.1` → `^2.5.2`. Upstream adds WakeNet10 w8a16 support and direction-of-arrival improvements; its ESP-DL minimum moves from 3.3.9 to 3.3.10. [Upstream changelog](https://components.espressif.com/components/espressif/esp-sr/versions/2.5.2/changelog).
- CI image: moving `release-v5.5` → stable `v5.5.5`, matching the Tab5 manifest's `==5.5.5` contract. 5.5.5 is still the latest stable 5.5 patch.
- Run the existing diagnostics-metrics host test alongside the existing file-validation test in CI. No assertions or jobs removed; no new project dependencies.
- Existing GitHub Action refs already include their latest releases: checkout 7.0.1, create-github-app-token 3.2.0, ESP-IDF CI action 1.2.0 and upload-components action 2.2.1.

## Held upgrades

| Dependency | Available upgrade | Reason and recommendation |
| --- | --- | --- |
| ESP-IDF 5.5.5 | 6.1 | Requires a separate framework/board migration, including changed LCD APIs and P4 silicon defaults. Retain the documented 5.5.5 contract. |
| esp_hosted 1.4.0 / esp_wifi_remote 0.8.5 | 3.0.6 / 1.6.4 | Coordinate with the Tab5 C6 firmware; do not silently break the documented coprocessor pairing. |
| esp_websocket_client 1.6.1 / esp-protocols | 1.8.0 | Registry and vendored source must stay aligned. Required autoreview rejects submodule changes because referenced dependency content is absent from its bundle. Use a review workflow that can validate the upstream source delta. |
| esp-webrtc-solution 4135993 | c57e51b (esp_peer 1.5.4) | Same submodule-review limitation, plus binary peer-library updates. Retain current revision pending source/binary and hardware validation. |

Existing transitive holds remain owned by upstream constraints: esp-dsp 1.8.0 (ESP-SR exact pin), codec-device ~1.5, media_lib_sal ~0.9, nghttp ~1.65.0, esp_audio_codec ~2.5, esp_audio_effects ~1.3, esp_asrc ~1.0, sensor_hub ^0.1.4, and cmake_utilities 0.*. Newer esp_capture 1.0.3~1 requires ESP-SR ~2.4 and codec-device 2.0 beta, incompatible with this graph. The Tab5 BSP registry release remains 1.2.0~1.

## Local proof

Both existing host suites pass:

```sh
cc -std=c11 -Wall -Wextra -Werror -I components/esp-openclaw-room-node \
  components/esp-openclaw-room-node/room_file_validation.c \
  components/esp-openclaw-room-node/tests/test_room_file_validation.c \
  -o build-maintenance-20260830/room_file_validation_test
build-maintenance-20260830/room_file_validation_test
# room file validation tests passed

cc -std=c11 -Wall -Wextra -Werror -I components/esp-openclaw-room-node \
  components/esp-openclaw-room-node/room_diagnostics_metrics.c \
  components/esp-openclaw-room-node/tests/test_room_diagnostics_metrics.c \
  -lm -o build-maintenance-20260830/room_diagnostics_metrics_test
build-maintenance-20260830/room_diagnostics_metrics_test
# room diagnostics metric tests passed
```

Live host integration loads the compiled production library and validates the actual repository banner PNG:

```sh
cc -std=c11 -Wall -Wextra -Werror -shared -fPIC \
  -I components/esp-openclaw-room-node \
  components/esp-openclaw-room-node/room_file_validation.c \
  -o build-maintenance-20260830/libroom_file_validation.dylib
python3 build-maintenance-20260830/live-file-check.py
```

Actual output:

```text
docs/assets/esp-openclaw-node-banner.png: PNG, 229561 bytes, base64 accepted, destination /sd/banner.png
/sd/../escape.png: rejected
```

The temporary integration driver uses Python ctypes to call `room_file_inspect_base64` on `base64.b64encode(Path('docs/assets/esp-openclaw-node-banner.png').read_bytes())`, checks the returned length against the actual file size, and calls `room_file_normalize_public_path` for both displayed paths. This proves host integration only; it does not establish firmware or acoustic behavior.

`actionlint` and `git diff --check` pass. Codex autoreview completed scoped-clean at the requested default P0 threshold, with no accepted/actionable findings.

## CI and remaining validation

The orchestrator reported NORUNS, but the actual latest default-branch [CI run passed all five firmware builds](https://github.com/openclaw/esp-openclaw-node/actions/runs/33160279835). [Component upload](https://github.com/openclaw/esp-openclaw-node/actions/runs/33160279949) also passed; it is publication automation, while ClawSweeper Dispatch is operational automation. No default-branch test failure was found.

All five candidate [CI builds passed](https://github.com/openclaw/esp-openclaw-node/actions/runs/33371166509), including both room nodes and the Unity test firmware. The Linux host-test step also passed.

Local firmware validation remains blocked by Docker setup: `docker pull espressif/idf:v5.5.5` downloaded all layers but the image was still unavailable after more than 30 minutes; starting the already-present Ubuntu image also stalled for several minutes. Both task-owned attempts were stopped. Native `idf.py` and a physical ESP board are unavailable. No Docker restart or unrelated cache removal was performed. Full local firmware builds, the Unity device suite, and speech hardware checks are not claimed. CI proves all five builds, but this draft should remain unmerged until the missing local/runtime proof is resolved or explicitly accepted by the maintainer.
