### PR TITLE
ci: publish traceable example firmware bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
             -lm -o /tmp/room_pcm_gain_test
           /tmp/room_pcm_gain_test
 
+      - name: Firmware packaging tests
+        if: matrix.name == 'component-test-app-build'
+        run: python3 -m unittest discover -s scripts/tests -p 'test_package_firmware.py' -v
+
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
         with:
@@ -76,8 +80,28 @@ jobs:
             ninja -C build -j2 &&
             if [ "${{ matrix.name }}" = "component-test-app-build" ]; then
               python3 ../../../esp-openclaw-talk/tests/run_host_tests.py --sanitize &&
-              python3 ../../../esp-openclaw-talk/tests/run_threaded_tests.py
+              python3 ../../../esp-openclaw-talk/tests/run_threaded_tests.py &&
+              python3 -m unittest discover -s ../../../../scripts/tests -p test_package_firmware.py -k lock_reader -v
             fi &&
             if [ "${{ matrix.name }}" = "waveshare-amoled-room-node" ]; then
               python3 ../../components/esp-openclaw-room-node/tests/run_lifecycle_host_tests.py --managed-components managed_components
+            fi &&
+            if [ "${{ matrix.name }}" != "component-test-app-build" ]; then
+              python3 ../../scripts/package_firmware.py \
+                --target "${{ matrix.target }}" \
+                --repository "${{ github.repository }}" \
+                --event "${{ github.event_name }}" \
+                --event-sha "${{ github.sha }}" \
+                --pr-head-sha "${{ github.event.pull_request.head.sha }}" \
+                --run-id "${{ github.run_id }}" \
+                --run-attempt "${{ github.run_attempt }}" \
+                --idf-image "espressif/idf:release-v5.5"
             fi
+
+      - name: Upload firmware
+        if: matrix.name != 'component-test-app-build'
+        uses: actions/upload-artifact@v7
+        with:
+          name: firmware-${{ matrix.name }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_attempt }}
+          path: ${{ matrix.path }}/build/firmware/
+          if-no-files-found: error

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,59 @@ This directory contains thin board applications. Reusable provisioning and room-
 - [Waveshare AMOLED Room Node](./waveshare-esp32-s3-touch-amoled-2.06-room-node/README.md) An always-on room client with WakeNet, device AEC, WebRTC Talk, an A2UI/image Canvas, separate node/operator sessions, and an AMOLED-off idle state.
 - [M5Stack Tab5 Room Node](./m5stack-tab5-room-node/README.md) An ESP32-P4 room client using the Tab5 display revisions, C6 remote Wi-Fi, four-slot TDM audio, camera, sensors, SD, and USB-host/RS-485 status.
 
+## CI Firmware Downloads
+
+Successful example jobs in the repository's **Actions > CI** runs upload a
+`firmware-<example>-<target>-<event-sha>-<attempt>` artifact. Download and extract
+the artifact for your exact board. These are CI builds, not releases or
+hardware-qualified images. The generic `esp32-node` CI image targets ESP32-S3;
+the Unity test application is not distributed as device firmware.
+
+Each bundle includes all images from ESP-IDF's flash map, including model
+partitions, relocated flash arguments, `FLASHING.md`, `manifest.json`, and
+`SHA256SUMS`. No source checkout or ESP-IDF installation is needed to flash.
+Install the exact esptool version shown in `FLASHING.md` in a Python virtual
+environment and use its command with an explicitly selected serial port.
+Verify the extracted files before flashing:
+
+```sh
+# Linux
+sha256sum -c SHA256SUMS
+# macOS
+shasum -a 256 -c SHA256SUMS
+```
+
+The manifest records the actual checked-out source commit separately from the
+GitHub event SHA and PR head SHA. A PR build can be a test merge, not the PR head.
+It also records the actual IDF commit/build revision, requested Docker image,
+esptool and component-manager versions, submodule commits, and payload hashes.
+Selected defaults (including target-specific companions) and the selected custom
+or IDF built-in partition CSV are identified by normalized paths and SHA-256
+hashes. Their source contents are not duplicated into the bundle; the referenced
+repository/IDF commits identify them.
+Tab5 includes the upstream BSP archive pin/hash and the repository-local bridge
+identity; it is not described as an unmodified upstream BSP component.
+
+Sanitized configuration, resolved dependency lock, and build metadata are
+provenance records, **not exact rebuild inputs**. The manifest also hashes the
+original generated inputs, which packaging leaves untouched. Floating IDF
+image tags and dependency ranges still prevent an exact-rebuild guarantee.
+Checksums detect corruption; they do not independently authenticate a build.
+Only use artifacts from a trusted source commit and workflow run.
+
+Public artifacts use CI defaults. Packaging rejects known credential-bearing
+configuration and secure-boot/encrypted builds. Metadata sanitization cannot
+remove secrets already compiled into a binary and is not a binary secret scan.
+Provision Wi-Fi and the Gateway through the board's serial console after
+flashing. Do not add `--force` or erase-all; back up device data before changing
+firmware or partition layouts.
+
+The Tab5 bundle flashes the **P4 only**. Its C6 must already run compatible
+`esp_hosted` 1.4.0 / `esp_wifi_remote` 0.8.5 firmware, as described in the
+[Tab5 prerequisites](./m5stack-tab5-room-node/README.md#c6-wi-fi-prerequisite).
+Artifacts expire according to repository retention settings; this workflow does
+not publish releases or deploy Pages.
+
 ## Directory Structure
 
 - `esp32-node/` The generic ESP32 example.

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Package an existing CI example build; never build or access a device."""
+
+import argparse
+import copy
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+from urllib.parse import urlsplit
+
+
+EXAMPLES = {
+    "esp32-node": "esp32s3",
+    "esp-box-3-display": "esp32s3",
+    "waveshare-esp32-s3-touch-amoled-2.06-room-node": "esp32s3",
+    "m5stack-tab5-room-node": "esp32p4",
+}
+SECURITY_CONFIG = {
+    "CONFIG_SECURE_BOOT",
+    "CONFIG_SECURE_FLASH_ENC_ENABLED",
+    "CONFIG_SECURE_SIGNED_APPS_NO_SECURE_BOOT",
+    "CONFIG_SECURE_SIGNED_APPS",
+    "CONFIG_SECURE_BOOT_BUILD_SIGNED_BINARIES",
+}
+PROVENANCE_NOTE = (
+    "Sanitized metadata is provenance, not exact rebuild input. Original input "
+    "hashes identify the generated files before sanitization. Floating SDK and "
+    "dependency selectors do not guarantee reproducible rebuilds."
+)
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git(root, *arguments):
+    return subprocess.check_output(
+        ["git", "-C", str(root), *arguments], text=True, stderr=subprocess.PIPE
+    ).rstrip("\n")
+
+
+def checked_file(path, roots):
+    resolved = path.resolve(strict=True)
+    if not resolved.is_file() or not any(resolved.is_relative_to(root) for root in roots):
+        raise ValueError("Input file is outside the approved project/build roots")
+    return resolved
+
+
+def sanitize(value, roots):
+    if isinstance(value, dict):
+        return {key: sanitize(item, roots) for key, item in value.items()}
+    if isinstance(value, list):
+        return [sanitize(item, roots) for item in value]
+    if not isinstance(value, str):
+        return value
+    for root, label in roots:
+        value = value.replace(str(root), label)
+    if re.match(r"^(?:/|[A-Za-z]:[\\/]|~[/\\])", value):
+        return "<external-path>"
+    if "://" in value:
+        url = urlsplit(value)
+        if (
+            url.scheme != "https"
+            or url.hostname not in {
+                "github.com", "api.github.com", "components.espressif.com",
+                "api.components.espressif.com", "dl.espressif.com",
+            }
+            or url.username or url.password or url.query or url.fragment
+        ):
+            return "<private-url>"
+    return value
+
+
+def sdkconfig_values(text):
+    values = {}
+    for line in text.splitlines():
+        if line.startswith("CONFIG_") and "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = json.loads(value) if value.startswith('"') else value
+    for key, value in values.items():
+        if key in SECURITY_CONFIG and value == "y":
+            raise ValueError("Secure boot/encrypted builds are not supported")
+        credential = re.search(r"(?:SSID|PASSWORD|PASSPHRASE|TOKEN|SECRET|API_KEY|SETUP_CODE)$", key)
+        if (credential or key == "CONFIG_OPENCLAW_ROOM_GATEWAY_HTTP_BASE_URL") and value != "":
+            raise ValueError("Credential-bearing configuration must be empty for public firmware")
+    return values
+
+
+def read_dependency_lock(path):
+    # Use the same safe YAML reader as ESP-IDF's component manager.
+    from ruamel.yaml import YAML
+    dependencies = YAML(typ="safe").load(path.read_text())
+    if not isinstance(dependencies, dict):
+        raise ValueError("Resolved dependency lock must be a mapping")
+    return dependencies
+
+
+def configuration_inputs(project, build, idf, description, config, normalize):
+    selected = []
+    # IDF applies each defaults file, then its target-specific companion if present.
+    for name in filter(None, description["config_defaults"].split(";")):
+        defaults = project / name
+        selected.append(("defaults", checked_file(defaults, (project, build))))
+        companion = defaults.with_name(defaults.name + "." + description["target"])
+        if companion.exists():
+            selected.append(("target_defaults", checked_file(companion, (project, build))))
+    partition_root = project if config.get("CONFIG_PARTITION_TABLE_CUSTOM") == "y" else idf / "components/partition_table"
+    partition = checked_file(partition_root / config["CONFIG_PARTITION_TABLE_FILENAME"], (project, build, idf))
+    selected.append(("partition_table", partition))
+    return [
+        {"kind": kind, "path": sanitize(str(path), normalize), "sha256": sha256(path)}
+        for kind, path in selected
+    ]
+
+
+def submodule_provenance(repo):
+    result = []
+    for line in git(repo, "submodule", "status", "--recursive").splitlines():
+        if line[0] != " ":
+            raise ValueError("Submodules must be initialized at their pinned commits")
+        commit, path, *_ = line[1:].split()
+        if git(repo / path, "status", "--porcelain", "--untracked-files=normal"):
+            raise ValueError("Submodule contains modified source")
+        result.append({"path": path, "commit": commit})
+    return result
+
+
+def tab5_provenance(project, build):
+    bridge = project / "components/m5stack_tab5/CMakeLists.txt"
+    text = bridge.read_text()
+    pin = re.search(
+        r"URL (https://github\.com/espressif/esp-bsp/archive/([0-9a-f]{40})\.tar\.gz)"
+        r"\s+URL_HASH SHA256=([0-9a-f]{64})", text,
+    )
+    if not pin:
+        raise ValueError("Cannot identify the Tab5 BSP source pin")
+    cache = (build / "CMakeCache.txt").read_text()
+    if os.environ.get("OPENCLAW_TAB5_BSP_LOCAL_PATH") or re.search(
+        r"^OPENCLAW_TAB5_BSP_LOCAL_PATH:[^=]+=.+$", cache, re.MULTILINE
+    ):
+        raise ValueError("CI artifacts require the pinned Tab5 archive, not a local BSP override")
+    return {
+        "upstream_url": pin[1],
+        "upstream_commit": pin[2],
+        "upstream_archive_sha256": pin[3],
+        "integration": "Repository-local source-only BSP bridge; not an unmodified upstream component",
+        "bridge": "components/m5stack_tab5/CMakeLists.txt",
+        "bridge_sha256": sha256(bridge),
+    }
+
+
+def package_firmware(project, build, output, target, provenance, dependencies):
+    project, build, output = project.resolve(), build.resolve(), output.resolve()
+    repo = Path(git(project, "rev-parse", "--show-toplevel")).resolve()
+    if project.parent != repo / "examples" or EXAMPLES.get(project.name) != target:
+        raise ValueError("Only the four CI example/target combinations may be packaged")
+    if output.exists() or not output.is_relative_to(build):
+        raise ValueError("Output must be a new directory inside the build directory")
+    roots = (project, build)
+    description_file = checked_file(build / "project_description.json", roots)
+    flash_file = checked_file(build / "flasher_args.json", roots)
+    description = json.loads(description_file.read_text())
+    flash = json.loads(flash_file.read_text())
+    config_file = checked_file(Path(description["config_file"]), roots)
+    config = sdkconfig_values(config_file.read_text())
+    if (
+        description["version"] != "1.2"
+        or description["target"] != target
+        or config.get("CONFIG_IDF_TARGET") != target
+        or dependencies.get("target") != target
+        or flash["extra_esptool_args"]["chip"] != target
+        or Path(description["project_path"]).resolve() != project
+        or Path(description["build_dir"]).resolve() != build
+    ):
+        raise ValueError("Build metadata schema, project or target mismatch")
+    idf = Path(description["idf_path"]).resolve()
+    if idf != Path(os.environ["IDF_PATH"]).resolve():
+        raise ValueError("Build metadata does not match the active IDF")
+    if git(repo, "status", "--porcelain", "--untracked-files=normal"):
+        raise ValueError("Repository contains modified source")
+    if git(idf, "status", "--porcelain", "--untracked-files=normal"):
+        raise ValueError("IDF contains modified source")
+    if not dependencies.get("dependencies"):
+        raise ValueError("Resolved dependency lock is empty")
+    normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
+    lock_file = checked_file(project / "dependencies.lock", roots)
+    manifest = {
+        "schema_version": 1,
+        "example": project.name,
+        "target": target,
+        "source": {
+            "repository": provenance["repository"],
+            "commit": git(repo, "rev-parse", "HEAD"),
+            "submodules": submodule_provenance(repo),
+        },
+        "idf": {
+            "commit": git(idf, "rev-parse", "HEAD"),
+            "build_revision": description["git_revision"],
+            "image_requested": provenance["idf_image"],
+        },
+        "tools": {
+            "esptool": importlib.metadata.version("esptool"),
+            "idf_component_manager": importlib.metadata.version("idf-component-manager"),
+        },
+        "ci": {key: value for key, value in provenance.items() if key not in ("repository", "idf_image")},
+        "metadata_note": PROVENANCE_NOTE,
+        "configuration_inputs": configuration_inputs(project, build, idf, description, config, normalize),
+        "original_input_sha256": {
+            "sdkconfig": sha256(config_file),
+            "dependencies.lock": sha256(lock_file),
+            "project_description.json": sha256(description_file),
+            "flasher_args.json": sha256(flash_file),
+        },
+    }
+    if project.name == "m5stack-tab5-room-node":
+        manifest["tab5_bsp"] = tab5_provenance(project, build)
+    extra = flash["extra_esptool_args"]
+    if type(extra["stub"]) is not bool:
+        raise ValueError("Invalid esptool stub setting")
+    if extra["before"] not in ("default_reset", "no_reset", "no_reset_no_sync") or extra["after"] not in ("hard_reset", "no_reset", "no_reset_stub"):
+        raise ValueError("Unsupported esptool reset mode")
+    settings = flash["flash_settings"]
+    expected_args = [
+        "--flash_mode", settings["flash_mode"], "--flash_size", settings["flash_size"],
+        "--flash_freq", settings["flash_freq"],
+    ]
+    if flash["write_flash_args"] != expected_args:
+        raise ValueError("Unsupported write_flash arguments")
+    if any(not re.fullmatch(r"[A-Za-z0-9]+", item) for item in settings.values()):
+        raise ValueError("Invalid flash setting")
+    images = []
+    for offset, filename in flash["flash_files"].items():
+        if not re.fullmatch(r"0x[0-9a-fA-F]+", offset):
+            raise ValueError("Invalid image offset")
+        source = checked_file(build / filename, roots)
+        if source.suffix != ".bin" or source.stat().st_size == 0:
+            raise ValueError("Flash images must be nonempty .bin files")
+        images.append((int(offset, 16), source, offset, f"images/{int(offset, 16):08x}.bin"))
+    images.sort()
+    if not images:
+        raise ValueError("Empty flash image map")
+    for previous, current in zip(images, images[1:]):
+        if previous[0] + previous[1].stat().st_size > current[0]:
+            raise ValueError("Overlapping flash images")
+    relocated = copy.deepcopy(flash)
+    relocated["flash_files"] = {offset: name for _, _, offset, name in images}
+    for key, entry in flash.items():
+        if isinstance(entry, dict) and "encrypted" in entry:
+            if entry["encrypted"] is not False and entry["encrypted"] != "false":
+                raise ValueError("Encrypted image entries are not supported")
+            offset = entry["offset"]
+            if flash["flash_files"].get(offset) != entry["file"]:
+                raise ValueError("Named image does not match the flash map")
+            relocated[key]["file"] = relocated["flash_files"][offset]
+        elif key not in ("flash_files", "flash_settings", "write_flash_args", "extra_esptool_args"):
+            raise ValueError("Unsupported flash metadata entry")
+    for name in ("bootloader", "partition-table", "app"):
+        if name not in relocated:
+            raise ValueError("Missing required bootloader, partition table or app image")
+    arguments = expected_args + [item for _, _, offset, name in images for item in (offset, name)]
+    global_args = ["--chip", target, "--before", extra["before"], "--after", extra["after"]]
+    if not extra["stub"]:
+        global_args.append("--no-stub")
+    command = "python -m esptool " + shlex.join(global_args) + ' --port PORT write_flash "@flash_args"'
+    instructions = (
+        f"# {project.name} ({target})\n\n"
+        f"Source commit: {manifest['source']['commit']}\n\n"
+        "Verify SHA256SUMS before flashing. From this extracted directory, install "
+        "the recorded esptool version in a Python virtual environment:\n\n"
+        f"    python -m pip install esptool=={manifest['tools']['esptool']}\n\n"
+        "Replace PORT with the explicitly selected serial port, then run:\n\n"
+        f"    {command}\n\n"
+        "No source checkout or ESP-IDF installation is needed. Do not add --force "
+        "or erase-all. Existing device data may be incompatible with this partition "
+        "layout; back it up before changing firmware. Provision Wi-Fi and the Gateway "
+        "through the serial console; no credentials are supplied here.\n\n"
+        "Tab5 bundles contain P4 firmware only; the C6 must already have compatible "
+        "esp_hosted 1.4.0 / esp_wifi_remote 0.8.5 firmware.\n\n"
+        f"{PROVENANCE_NOTE}\n"
+    )
+    # Stage only after validation; failed packaging must not leave an uploadable partial bundle.
+    with tempfile.TemporaryDirectory(prefix=".firmware-", dir=build) as temporary:
+        stage = Path(temporary) / "firmware"
+        (stage / "images").mkdir(parents=True)
+        for _, source, _, name in images:
+            shutil.copyfile(source, stage / name)
+        files = {
+            "flasher_args.json": relocated,
+            "project_description.sanitized.json": sanitize({
+                key: description[key] for key in (
+                    "version", "project_name", "project_version", "git_revision", "target",
+                    "min_rev", "max_rev", "monitor_baud", "app_bin", "build_components",
+                )
+            }, normalize),
+            "sdkconfig.sanitized.json": sanitize(config, normalize),
+            "dependencies.lock.sanitized.json": sanitize(dependencies, normalize),
+        }
+        for name, value in files.items():
+            (stage / name).write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+        (stage / "flash_args").write_text(shlex.join(arguments) + "\n")
+        (stage / "FLASHING.md").write_text(instructions)
+        manifest["files"] = {
+            path.relative_to(stage).as_posix(): {"sha256": sha256(path), "size": path.stat().st_size}
+            for path in sorted(stage.rglob("*")) if path.is_file()
+        }
+        (stage / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+        (stage / "SHA256SUMS").write_text("".join(
+            f"{sha256(path)}  {path.relative_to(stage).as_posix()}\n"
+            for path in sorted(stage.rglob("*")) if path.is_file()
+        ))
+        stage.rename(output)
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, choices=("esp32s3", "esp32p4"))
+    for name in ("repository", "event", "event-sha", "run-id", "run-attempt", "idf-image"):
+        parser.add_argument("--" + name, required=True)
+    parser.add_argument("--pr-head-sha", default="")
+    args = parser.parse_args()
+    provenance = vars(args).copy()
+    provenance.pop("target")
+    project = Path.cwd()
+    # ruamel.yaml is already part of ESP-IDF's component-manager environment.
+    try:
+        from ruamel.yaml import YAMLError
+    except ImportError:
+        parser.exit(1, "Run packaging inside the configured ESP-IDF Python environment.\n")
+    try:
+        dependencies = read_dependency_lock(project / "dependencies.lock")
+        output = package_firmware(
+            project, project / "build", project / "build/firmware",
+            args.target, provenance, dependencies,
+        )
+    except ValueError as error:
+        parser.exit(1, f"Firmware packaging failed: {error}\n")
+    except (YAMLError, KeyError, TypeError, OSError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"Firmware packaging failed: {type(error).__name__}. Check build metadata and public defaults.\n")
+    print(f"Firmware bundle: {output.relative_to(project)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -1,0 +1,333 @@
+"""Exercise firmware bundle contents and rejection boundaries without ESP-IDF."""
+
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "package_firmware.py"
+SPEC = importlib.util.spec_from_file_location("package_firmware", SCRIPT)
+firmware = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(firmware)
+HAS_YAML = importlib.util.find_spec("ruamel") is not None
+
+
+class FirmwareBundleTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="firmware-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.repo = self.root / "repository"
+        self.idf = self.root / "idf"
+        self.project = self.repo / "examples/esp32-node"
+        self.build = self.project / "build"
+        self.output = self.build / "firmware"
+        self.build.mkdir(parents=True)
+        self.idf.mkdir()
+        partition = self.idf / "components/partition_table/partitions_singleapp_large.csv"
+        partition.parent.mkdir(parents=True)
+        partition.write_text("factory,app,factory,0x10000,3M,\n")
+        self.environment = patch.dict(os.environ, {
+            "IDF_PATH": str(self.idf),
+            "OPENCLAW_TAB5_BSP_LOCAL_PATH": "",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+        })
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.versions = patch.object(
+            firmware.importlib.metadata, "version",
+            side_effect=lambda name: {"esptool": "4.11.0", "idf-component-manager": "2.4.3"}[name],
+        )
+        self.versions.start()
+        self.addCleanup(self.versions.stop)
+        for repo in (self.repo, self.idf):
+            self.git(repo, "init", "-q")
+            (repo / ".gitignore").write_text("examples/\n")
+            self.git(repo, "add", ".")
+            self.git(repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.com",
+                     "-c", "commit.gpgsign=false", "commit", "-qm", "fixture")
+        self.config = (
+            'CONFIG_IDF_TARGET="esp32s3"\nCONFIG_OPENCLAW_ROOM_WIFI_PASSWORD=""\n'
+            'CONFIG_PARTITION_TABLE_FILENAME="partitions_singleapp_large.csv"\n'
+        )
+        (self.project / "sdkconfig.defaults").write_text("CONFIG_LOG_DEFAULT_LEVEL_INFO=y\n")
+        (self.project / "sdkconfig.defaults.esp32s3").write_text("CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y\n")
+        # Contract fields from ESP-IDF v5.5.5 tools/cmake/project_description.json.in
+        # and components/esptool_py/flasher_args.json.in, not a captured device build.
+        self.description = {
+            "version": "1.2",
+            "project_name": "test_node",
+            "project_version": "1.0.0",
+            "project_path": str(self.project),
+            "build_dir": str(self.build),
+            "config_file": str(self.project / "sdkconfig"),
+            "config_defaults": str(self.project / "sdkconfig.defaults"),
+            "idf_path": str(self.idf),
+            "git_revision": "v5.5.5",
+            "target": "esp32s3",
+            "min_rev": "0",
+            "max_rev": "199",
+            "monitor_baud": "115200",
+            "app_bin": "app.bin",
+            "build_components": ["main", "esp-sr"],
+        }
+        self.flash = {
+            "write_flash_args": ["--flash_mode", "dio", "--flash_size", "16MB", "--flash_freq", "80m"],
+            "flash_settings": {"flash_mode": "dio", "flash_size": "16MB", "flash_freq": "80m"},
+            "extra_esptool_args": {
+                "chip": "esp32s3", "before": "default_reset", "after": "hard_reset", "stub": True,
+            },
+            "flash_files": {
+                "0x0": "bootloader/bootloader.bin",
+                "0x8000": "partition_table/partition-table.bin",
+                "0x10000": "app.bin",
+                "0x810000": "../managed_components/speech models/model.bin",
+            },
+        }
+        for name, offset in (("bootloader", "0x0"), ("partition-table", "0x8000"), ("app", "0x10000"), ("model", "0x810000")):
+            filename = self.flash["flash_files"][offset]
+            self.flash[name] = {"offset": offset, "file": filename, "encrypted": "false"}
+            path = self.build / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes((name + "-fixture").encode())
+        self.dependencies = {
+            "version": "2.0.0",
+            "target": "esp32s3",
+            "dependencies": {
+                "espressif/example": {
+                    "version": "1.2.3", "component_hash": "a" * 64,
+                    "source": {"type": "service", "service_url": "https://api.components.espressif.com/"},
+                },
+                "local": {"version": "*", "source": {"type": "local", "path": str(self.project)}},
+            },
+        }
+        self.provenance = {
+            "repository": "openclaw/esp-openclaw-node", "idf_image": "espressif/idf:release-v5.5",
+            "event": "pull_request", "event_sha": "1" * 40, "pr_head_sha": "2" * 40,
+            "run_id": "123", "run_attempt": "2",
+        }
+
+    def git(self, repo, *arguments):
+        return subprocess.check_output(
+            ["git", "-C", str(repo), *arguments], text=True, stderr=subprocess.PIPE
+        ).strip()
+
+    def write_metadata(self):
+        (self.project / "sdkconfig").write_text(self.config)
+        (self.project / "dependencies.lock").write_text(json.dumps(self.dependencies))
+        (self.build / "project_description.json").write_text(json.dumps(self.description))
+        (self.build / "flasher_args.json").write_text(json.dumps(self.flash))
+
+    def package(self):
+        self.write_metadata()
+        return firmware.package_firmware(
+            self.project, self.build, self.output, self.description["target"],
+            self.provenance, self.dependencies,
+        )
+
+    def test_relocated_bundle_preserves_every_image_and_original_inputs(self):
+        self.write_metadata()
+        originals = {path: path.read_bytes() for path in self.project.rglob("*") if path.is_file()}
+        self.package()
+        for path, content in originals.items():
+            self.assertEqual(path.read_bytes(), content)
+        relocated = self.root / "extracted bundle"
+        shutil.copytree(self.output, relocated)
+        metadata = json.loads((relocated / "flasher_args.json").read_text())
+        self.assertEqual(set(metadata["flash_files"]), set(self.flash["flash_files"]))
+        for offset, filename in metadata["flash_files"].items():
+            self.assertEqual(
+                (relocated / filename).read_bytes(),
+                (self.build / self.flash["flash_files"][offset]).read_bytes(),
+            )
+        self.assertEqual(metadata["model"]["file"], metadata["flash_files"]["0x810000"])
+        arguments = shlex.split((relocated / "flash_args").read_text())
+        self.assertEqual(arguments[:6], self.flash["write_flash_args"])
+        self.assertEqual(dict(zip(arguments[6::2], arguments[7::2])), metadata["flash_files"])
+        checksummed = set()
+        for line in (relocated / "SHA256SUMS").read_text().splitlines():
+            digest, name = line.split("  ", 1)
+            self.assertEqual(hashlib.sha256((relocated / name).read_bytes()).hexdigest(), digest)
+            checksummed.add(name)
+        self.assertEqual(checksummed, {
+            path.relative_to(relocated).as_posix() for path in relocated.rglob("*")
+            if path.is_file() and path.name != "SHA256SUMS"
+        })
+        manifest = json.loads((relocated / "manifest.json").read_text())
+        self.assertEqual(manifest["source"]["commit"], self.git(self.repo, "rev-parse", "HEAD"))
+        self.assertEqual(manifest["idf"]["commit"], self.git(self.idf, "rev-parse", "HEAD"))
+        self.assertEqual(manifest["idf"]["build_revision"], "v5.5.5")
+        self.assertEqual(manifest["ci"]["pr_head_sha"], "2" * 40)
+        self.assertEqual(manifest["ci"]["event_sha"], "1" * 40)
+        inputs = manifest["configuration_inputs"]
+        self.assertEqual([item["kind"] for item in inputs], [
+            "defaults", "target_defaults", "partition_table",
+        ])
+        self.assertEqual(inputs[1]["sha256"], firmware.sha256(self.project / "sdkconfig.defaults.esp32s3"))
+        self.assertEqual(inputs[2]["path"], "<idf>/components/partition_table/partitions_singleapp_large.csv")
+        for path in relocated.glob("*"):
+            if path.is_file():
+                self.assertNotIn(str(self.root), path.read_text())
+        for name, record in manifest["files"].items():
+            self.assertEqual(record["sha256"], firmware.sha256(relocated / name))
+            self.assertEqual(record["size"], (relocated / name).stat().st_size)
+        (relocated / metadata["app"]["file"]).write_bytes(b"damaged")
+        self.assertNotEqual(
+            firmware.sha256(relocated / metadata["app"]["file"]),
+            manifest["files"][metadata["app"]["file"]]["sha256"],
+        )
+
+    def test_invalid_inputs_never_leave_uploadable_output(self):
+        cases = (
+            ("missing", lambda: (self.build / "app.bin").unlink()),
+            ("escape", lambda: self.flash["flash_files"].update({"0x900000": str(self.root / "outside.bin")})),
+            ("target", lambda: self.flash["extra_esptool_args"].update(chip="esp32p4")),
+            ("config target", lambda: setattr(self, "config", 'CONFIG_IDF_TARGET="esp32p4"\n')),
+            ("lock target", lambda: self.dependencies.update(target="esp32p4")),
+            ("encrypted", lambda: self.flash["app"].update(encrypted="true")),
+            ("signed config", lambda: setattr(self, "config", self.config + "CONFIG_SECURE_BOOT=y\n")),
+            ("credentials", lambda: setattr(self, "config", self.config + 'CONFIG_OPENCLAW_ROOM_SETUP_CODE="synthetic-secret"\n')),
+            ("overlap", lambda: self.flash["flash_files"].update({"0x1": "app.bin"})),
+            ("named entry", lambda: self.flash["app"].update(file="other.bin")),
+            ("unsupported args", lambda: self.flash["write_flash_args"].append("--force")),
+            ("dirty source", lambda: (self.repo / ".gitignore").write_text("changed\n")),
+        )
+        baseline = copy.deepcopy((self.flash, self.config, self.dependencies))
+        (self.root / "outside.bin").write_bytes(b"outside")
+        for name, change in cases:
+            with self.subTest(name=name):
+                self.flash, self.config, self.dependencies = copy.deepcopy(baseline)
+                (self.build / "app.bin").write_bytes(b"app-fixture")
+                (self.repo / ".gitignore").write_text("examples/\n")
+                change()
+                with self.assertRaises((ValueError, FileNotFoundError)):
+                    self.package()
+                self.assertFalse(self.output.exists())
+
+    def test_symlink_escape_is_rejected(self):
+        external = self.root / "outside.bin"
+        external.write_bytes(b"outside")
+        (self.build / "app.bin").unlink()
+        (self.build / "app.bin").symlink_to(external)
+        with self.assertRaises(ValueError):
+            self.package()
+        self.assertFalse(self.output.exists())
+
+    def test_in_root_symlink_is_relocated_as_a_regular_image(self):
+        (self.build / "app.bin").rename(self.build / "actual.bin")
+        (self.build / "app.bin").symlink_to("actual.bin")
+        self.package()
+        image = self.output / "images/00010000.bin"
+        self.assertFalse(image.is_symlink())
+        self.assertEqual(image.read_bytes(), b"app-fixture")
+
+    @unittest.skipUnless(HAS_YAML, "real lock reader runs in the existing IDF environment")
+    def test_lock_reader_preserves_yaml_dependency_identity(self):
+        lock = self.project / "dependencies.lock"
+        lock.write_text(
+            "# IDF component-manager 2.x lock schema\n"
+            "version: 2.0.0\ntarget: esp32s3\nmanifest_hash: abcdef\n"
+            "dependencies:\n"
+            "  espressif/example:\n"
+            "    version: 1.2.3\n"
+            "    component_hash: abcdef\n"
+            "    source:\n"
+            "      type: service\n"
+            "      service_url: https://api.components.espressif.com/\n"
+            "  local:\n"
+            "    version: '*'\n"
+            "    source:\n"
+            "      type: local\n"
+            "      path: ../../components/local\n"
+        )
+        original = lock.read_bytes()
+        dependencies = firmware.read_dependency_lock(lock)
+        self.assertEqual(dependencies["target"], "esp32s3")
+        self.assertEqual(dependencies["dependencies"]["espressif/example"]["version"], "1.2.3")
+        self.assertEqual(dependencies["dependencies"]["local"]["source"]["path"], "../../components/local")
+        self.assertEqual(lock.read_bytes(), original)
+        lock.write_text("- not-a-lock\n")
+        with self.assertRaises(ValueError):
+            firmware.read_dependency_lock(lock)
+
+    def test_reset_and_no_stub_settings_reach_flash_command(self):
+        self.flash["extra_esptool_args"].update(stub=False, before="no_reset", after="no_reset")
+        self.package()
+        instructions = (self.output / "FLASHING.md").read_text()
+        self.assertIn("--before no_reset --after no_reset --no-stub", instructions)
+        self.assertIn('write_flash "@flash_args"', instructions)
+
+    def test_metadata_sanitization_keeps_dependency_identity(self):
+        source = self.dependencies["dependencies"]["local"]["source"]
+        source["path"] = "/private/build-owner/components/example"
+        source["url"] = "https://fixture:synthetic-secret@github.com/example/repo"
+        self.config += 'CONFIG_EXAMPLE_PATH="/private/build-owner/config"\n'
+        self.package()
+        text = (self.output / "dependencies.lock.sanitized.json").read_text()
+        self.assertNotIn("build-owner", text)
+        self.assertNotIn("synthetic-secret", text)
+        resolved = json.loads(text)["dependencies"]["espressif/example"]
+        self.assertEqual(resolved, self.dependencies["dependencies"]["espressif/example"])
+
+    def test_pinned_submodule_commit_is_recorded(self):
+        module = self.repo / "third_party/sdk"
+        module.parent.mkdir()
+        self.git(self.repo, "-c", "protocol.file.allow=always", "submodule", "add", "-q", str(self.idf), "third_party/sdk")
+        self.git(self.repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.com",
+                 "-c", "commit.gpgsign=false", "commit", "-qam", "submodule fixture")
+        self.package()
+        source = json.loads((self.output / "manifest.json").read_text())["source"]
+        self.assertEqual(source["submodules"], [
+            {"path": "third_party/sdk", "commit": self.git(self.idf, "rev-parse", "HEAD")}
+        ])
+
+    def test_tab5_records_upstream_and_local_bridge_identity(self):
+        destination = self.repo / "examples/m5stack-tab5-room-node"
+        self.project.rename(destination)
+        self.project = destination
+        self.build = destination / "build"
+        self.output = self.build / "firmware"
+        self.description.update(
+            target="esp32p4", project_path=str(destination), build_dir=str(self.build),
+            config_file=str(destination / "sdkconfig"),
+            config_defaults=str(destination / "sdkconfig.defaults"),
+        )
+        self.dependencies["target"] = "esp32p4"
+        self.config = (
+            'CONFIG_IDF_TARGET="esp32p4"\nCONFIG_PARTITION_TABLE_CUSTOM=y\n'
+            'CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"\n'
+        )
+        (destination / "partitions.csv").write_text("factory,app,factory,0x10000,8M,\n")
+        self.flash["extra_esptool_args"]["chip"] = "esp32p4"
+        bridge = destination / "components/m5stack_tab5/CMakeLists.txt"
+        bridge.parent.mkdir(parents=True)
+        bridge.write_text(
+            "FetchContent_Declare(tab5_bsp_source\n"
+            f" URL https://github.com/espressif/esp-bsp/archive/{'a' * 40}.tar.gz\n"
+            f" URL_HASH SHA256={'b' * 64})\n"
+        )
+        (self.build / "CMakeCache.txt").write_text("OPENCLAW_TAB5_BSP_LOCAL_PATH:PATH=\n")
+        self.package()
+        manifest = json.loads((self.output / "manifest.json").read_text())
+        self.assertEqual(manifest["tab5_bsp"]["upstream_commit"], "a" * 40)
+        self.assertEqual(manifest["tab5_bsp"]["upstream_archive_sha256"], "b" * 64)
+        self.assertEqual(manifest["tab5_bsp"]["bridge_sha256"], firmware.sha256(bridge))
+        self.assertIn("not an unmodified upstream", manifest["tab5_bsp"]["integration"])
+        self.assertEqual(manifest["configuration_inputs"][-1], {
+            "kind": "partition_table", "path": "<project>/partitions.csv",
+            "sha256": firmware.sha256(destination / "partitions.csv"),
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The example CI jobs build firmware but do not retain downloadable bundles with enough provenance to distinguish the built source, SDK, and board configuration.

## Changes

- Package and upload four example build bundles: generic ESP32-S3, ESP-BOX-3, Waveshare AMOLED room node, and M5Stack Tab5. The Unity test application is excluded.
- Include every image in the ESP-IDF flash map, relocated flash arguments, flashing instructions, metadata, and SHA-256 checksums.
- Record checked-out source, event, and PR-head commits separately from the actual SDK commit/build revision and requested image. Include dependency, submodule, selected defaults, partition, and Tab5 BSP bridge identities.
- Reject unsupported targets, missing or overlapping images, path escapes, known credential-bearing configuration, and signed/encrypted builds before leaving uploadable output.
- Document download, checksum verification, provenance limits, and explicit-device flashing precautions.

## Checks

- Focused host suite: eight tests passed; one real YAML-reader test was skipped locally because the IDF parser is absent. That test is wired into the existing IDF CI environment.
- `actionlint` and `git diff --check` passed.
- Independent scoped review and final implementation/source-contract review found no blocker.
- Final diff and publication text checked for private data.
- Hosted CI for PR head `c3867131285ecd0f3ddc6c7c644b4d71282f5a84`: all five builds passed in https://github.com/openclaw/esp-openclaw-node/actions/runs/34130585677.
- Downloaded Tab5 artifact `10022176321` (2.75 MiB): the artifact digest, all 11 file checksums, and four offset-mapped flash images were verified. Download verification is limited to this Tab5 bundle.
- The Tab5 manifest records checked-out source test merge `e37937d8b3b796a5f4c64d7207d729371f49f3fd`, distinct from the PR head. Its actual IDF commit is `362a1776ec212788fda95f75b733bfdde3a0c394`, build revision `v5.5.5-648-g362a1776ec2`, with esptool `4.12.0`.

The observed SDK comes from the existing moving `release-v5.5` image, not the pristine `v5.5.5` tag. SDK-selection changes remain separate from this PR: https://github.com/openclaw/esp-openclaw-node/pull/34.

## Hardware Smoke Evidence

The actual test-merge image identified above was flashed onto an M5Stack Tab5 with ESP32-P4 revision 1.3 and 16 MiB flash. A full-flash erase and four image writes completed with hash verification. ST7121 LCD selection and readable local diagnostics rendering were observed. External Osmo Pocket 3 measurement confirmed approximately one second of 1 kHz speaker output.

Microphone/AFE activity was observed, but controlled speech response was inconclusive. Physical touch, the Tab5 camera, network pairing, Canvas RPC, and provider Talk were not run. No provider API calls were made and no provider key was loaded.

The initial diagnostics-close attempt hit a display-lock `TIMEOUT`. UI progress was verified, then one explicit retry closed diagnostics. This intermittent failure remains unresolved; no source fix was made. These observations are not clean, complete GUI or board qualification.

The other three bundles have not been download-verified here. These are traceable CI bundles, not reproducible-build guarantees, authenticated release artifacts, or security/hardware-qualified firmware. Checksums do not authenticate the publisher, and metadata sanitization is not a binary secret scan. The Tab5 bundle contains P4 firmware only; compatible C6 firmware is a separate prerequisite and is not included. No release or Pages deployment was performed for this change.

## Landing Disposition

The manual-only release guard landed first in https://github.com/openclaw/esp-openclaw-node/pull/38. This firmware-packaging change does not dispatch a component release or change a component version.

The original reviewed head and its evidence identities remain unchanged. The landing tree is checked against current main plus this PR's exact original delta; tree equivalence is not additional build or hardware coverage.

Voice remains unverified. A separate later preclaim device-status request ended with a disconnected node before Talk or provider startup. That outcome is not a timeout finding or a firmware-packaging defect, and it does not qualify voice for this PR.
