### PR TITLE
ci: require explicit verified component releases

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,22 +1,83 @@
-name: Push esp-openclaw-node to IDF Component Registry
+name: Release esp-openclaw-node to IDF Component Registry
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    paths:
+      - ".github/workflows/upload_component.yml"
+      - "scripts/check_component_release.py"
+      - "scripts/tests/test_check_component_release.py"
+      - "docs/component-releases.md"
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: Component manifest version to release (must not already exist)
+        required: true
+        type: string
+
+permissions: {}
 
 jobs:
-  upload_components:
+  validate:
     permissions:
-      id-token: write
+      contents: read
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:
-          submodules: "recursive"
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Test release checker
+        run: |
+          python3 -m venv "$RUNNER_TEMP/component-release-check"
+          "$RUNNER_TEMP/component-release-check/bin/python" -m pip install \
+            --disable-pip-version-check "PyYAML==6.0.3"
+          "$RUNNER_TEMP/component-release-check/bin/python" -B -m unittest discover \
+            -s scripts/tests -p 'test_check_component_release.py' -v
+
+  upload_components:
+    needs: validate
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    concurrency:
+      group: esp-openclaw-node-component-release
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      EXPECTED_VERSION: ${{ inputs.expected_version }}
+      RELEASE_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Prepare isolated release checker
+        run: |
+          python3 -m venv "$RUNNER_TEMP/component-release-check"
+          "$RUNNER_TEMP/component-release-check/bin/python" -m pip install \
+            --disable-pip-version-check "PyYAML==6.0.3"
+
+      - name: Check source version and refuse existing releases
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          "$RUNNER_TEMP/component-release-check/bin/python" scripts/check_component_release.py \
+            preflight --expected-version "$EXPECTED_VERSION"
 
       - name: Upload esp-openclaw-node to IDF Component Registry
         uses: espressif/upload-components-ci-action@v2
         with:
           components: "esp-openclaw-node:components/esp-openclaw-node"
           namespace: "espressif"
+          repository_url: "https://github.com/openclaw/esp-openclaw-node.git"
+          commit_sha: ${{ github.sha }}
+
+      - name: Verify registry artifact identity
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          "$RUNNER_TEMP/component-release-check/bin/python" scripts/check_component_release.py \
+            verify --expected-version "$EXPECTED_VERSION" --commit-sha "$RELEASE_SHA"

--- a/docs/component-releases.md
+++ b/docs/component-releases.md
@@ -1,0 +1,73 @@
+# Component releases
+
+The registry upload workflow is manual. A push to `main` does not publish a
+component. Release authority and a separately reviewed version change are
+prerequisites; this workflow does not change the component version.
+
+Pull requests changing the release workflow, checker, tests, or this guide run
+the focused host tests with read-only repository access and no OIDC permission.
+Manual releases must pass the same tests before the upload job can run.
+
+## Release an approved version
+
+1. Review the intended `main` commit, component manifest, and release notes.
+   `components/esp-openclaw-node/idf_component.yml` must contain the intended
+   string version, this repository, and `repository_info.path:
+   components/esp-openclaw-node`.
+2. Dispatch **Release esp-openclaw-node to IDF Component Registry** on `main`.
+   Supply `expected_version` exactly as written in the manifest. Dispatches on
+   other refs do not run the upload job.
+3. The workflow checks out the immutable dispatch SHA, not a moving `main`
+   reference. A public registry read must succeed, identify the component, and
+   show that the version does not already exist. Existing versions, including
+   yanked versions, are refused. Network errors and malformed responses are not
+   treated as absence.
+4. The existing `espressif/upload-components-ci-action@v2` uploads through
+   GitHub OIDC. No stored registry token is required. The repository URL and
+   dispatch commit SHA are supplied explicitly.
+5. The final read-only check downloads the registered ZIP and validates its
+   root `idf_component.yml`: version, repository, component path, and
+   `repository_info.commit_sha` must match the intended source identity.
+   Success is reported as **registry artifact verified**.
+
+The upstream uploader uses `--allow-existing`. The preflight reduces accidental
+reuse, but another publisher can race between the check and upload. Verification
+therefore describes the registered artifact, never claims that this run created
+it, and fails if the embedded identity differs. Repository aliases predating the
+move to `openclaw` are not accepted as current release identity.
+
+Release runs are serialized and have a ten-minute job timeout. Public reads use
+15-second socket timeouts, reject redirects, and cap responses at 1 MiB for
+registry JSON and 16 MiB for ZIPs. Only one root manifest is read, up to 64 KiB,
+from an archive with at most 4096 entries; archive paths are never extracted.
+The checker uses the registry-provided HTTPS download URL on
+`components-file.espressif.com`, not a guessed version URL.
+
+## Diagnose without uploading
+
+From the repository root, run the checker in an isolated environment. PyYAML
+6.0.3 is a CI/checker-only dependency, not a firmware dependency. The workflow
+uses its own temporary Python virtual environment; these local commands use
+`uv` without modifying the system Python installation.
+
+```sh
+uv run --no-project --with PyYAML==6.0.3 python scripts/check_component_release.py \
+  preflight --expected-version 1.0.0
+
+uv run --no-project --with PyYAML==6.0.3 python scripts/check_component_release.py \
+  verify --expected-version '<approved-version>' --commit-sha '<full-dispatch-sha>'
+
+uv run --no-project --with PyYAML==6.0.3 python -m unittest discover \
+  -s scripts/tests -p 'test_check_component_release.py'
+```
+
+The `1.0.0` preflight is expected to refuse the existing registry version. Both
+checker modes perform only public reads. Neither dispatches an upload, requests
+OIDC credentials, changes manifests, or writes an extracted archive.
+
+If upload succeeds but verification fails, preserve the run and dispatch SHA,
+inspect the reported version, and repeat only the read-only `verify` command
+after any registry propagation delay. Do not rerun publication to repair a
+verification error or attempt to overwrite an existing version. A matching
+embedded identity is not a substitute for clean consumer builds, firmware
+qualification, or provenance verification beyond these manifest fields.

--- a/scripts/check_component_release.py
+++ b/scripts/check_component_release.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Read-only preflight and artifact identity checks for component releases."""
+
+import argparse
+import http.client
+import io
+import json
+from pathlib import Path
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+import yaml
+
+
+COMPONENT = "esp-openclaw-node"
+NAMESPACE = "espressif"
+COMPONENT_PATH = f"components/{COMPONENT}"
+REGISTRY_URL = f"https://components.espressif.com/api/components/{NAMESPACE}/{COMPONENT}"
+REPOSITORIES = {
+    "https://github.com/openclaw/esp-openclaw-node",
+    "https://github.com/openclaw/esp-openclaw-node.git",
+    "git://github.com/openclaw/esp-openclaw-node.git",
+}
+MAX_JSON_BYTES = 1024 * 1024
+MAX_ARCHIVE_BYTES = 16 * 1024 * 1024
+MAX_MANIFEST_BYTES = 64 * 1024
+MAX_ARCHIVE_ENTRIES = 4096
+REQUEST_TIMEOUT = 15
+
+
+class ReleaseError(Exception):
+    pass
+
+
+def unique_mapping(pairs):
+    result = {}
+    for key, value in pairs:
+        if not isinstance(key, str) or key in result:
+            raise ReleaseError("metadata contains a non-string or duplicate mapping key")
+        result[key] = value
+    return result
+
+
+class ManifestLoader(yaml.SafeLoader):
+    pass
+
+
+def construct_mapping(loader, node):
+    return unique_mapping(
+        (loader.construct_object(key), loader.construct_object(value))
+        for key, value in node.value
+    )
+
+
+ManifestLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
+)
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def download(url, limit):
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "esp-openclaw-node-release-check"}
+    )
+    try:
+        with urllib.request.build_opener(NoRedirect).open(
+            request, timeout=REQUEST_TIMEOUT
+        ) as response:
+            if response.status != 200:
+                raise ReleaseError("registry request did not return HTTP 200")
+            data = response.read(limit + 1)
+    except (urllib.error.URLError, OSError, http.client.HTTPException) as error:
+        raise ReleaseError("registry request failed; release is not verified") from error
+    if len(data) > limit:
+        raise ReleaseError("registry response exceeds the read limit")
+    return data
+
+
+def parse_manifest(data, expected_version, commit_sha=None):
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise ReleaseError("component manifest exceeds the read limit")
+    try:
+        manifest = yaml.load(data, Loader=ManifestLoader)
+    except (yaml.YAMLError, UnicodeError, RecursionError) as error:
+        raise ReleaseError("component manifest is malformed YAML") from error
+    if not isinstance(manifest, dict):
+        raise ReleaseError("component manifest must be a mapping")
+    if not isinstance(manifest.get("version"), str) or manifest["version"] != expected_version:
+        raise ReleaseError("component manifest version does not match expected version")
+    repository = manifest.get("repository")
+    if not isinstance(repository, str) or repository not in REPOSITORIES:
+        raise ReleaseError("component manifest repository does not match this repository")
+    info = manifest.get("repository_info")
+    if not isinstance(info, dict) or info.get("path") != COMPONENT_PATH:
+        raise ReleaseError("component manifest repository path does not match component")
+    if commit_sha is not None and info.get("commit_sha") != commit_sha:
+        raise ReleaseError("registry artifact commit SHA does not match dispatch SHA")
+
+
+def registry_versions():
+    try:
+        metadata = json.loads(
+            download(REGISTRY_URL, MAX_JSON_BYTES), object_pairs_hook=unique_mapping
+        )
+    except (ValueError, UnicodeError, RecursionError) as error:
+        raise ReleaseError("registry response is malformed JSON") from error
+    if not isinstance(metadata, dict) or (
+        metadata.get("name") != COMPONENT or metadata.get("namespace") != NAMESPACE
+    ):
+        raise ReleaseError("registry response does not identify the expected component")
+    versions = metadata.get("versions")
+    if not isinstance(versions, list):
+        raise ReleaseError("registry response has no versions list")
+    result = {}
+    for entry in versions:
+        if not isinstance(entry, dict):
+            raise ReleaseError("registry version entry is malformed")
+        version = entry.get("version")
+        if not isinstance(version, str) or not version or version in result:
+            raise ReleaseError("registry version is missing, invalid, or duplicated")
+        if not isinstance(entry.get("url"), str) or not entry["url"]:
+            raise ReleaseError("registry version has no artifact URL")
+        result[version] = entry
+    return result
+
+
+def archive_manifest(entry):
+    try:
+        url = urllib.parse.urlsplit(entry["url"])
+    except ValueError as error:
+        raise ReleaseError("registry artifact URL is malformed") from error
+    if (
+        url.scheme != "https"
+        or url.netloc != "components-file.espressif.com"
+        or not url.path.startswith(f"/components/{NAMESPACE}/{COMPONENT}/")
+        or not url.path.endswith(".zip")
+        or url.query
+        or url.fragment
+    ):
+        raise ReleaseError("registry artifact URL is outside the expected download location")
+    data = download(entry["url"], MAX_ARCHIVE_BYTES)
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            entries = archive.infolist()
+            manifests = [item for item in entries if item.filename == "idf_component.yml"]
+            if len(entries) > MAX_ARCHIVE_ENTRIES or len(manifests) != 1:
+                raise ReleaseError("registry archive must contain one root component manifest")
+            manifest = manifests[0]
+            if manifest.file_size > MAX_MANIFEST_BYTES:
+                raise ReleaseError("archived component manifest exceeds the read limit")
+            # Read only the bounded root manifest; never extract registry archive paths.
+            with archive.open(manifest) as stream:
+                return stream.read(MAX_MANIFEST_BYTES + 1)
+    except (zipfile.BadZipFile, RuntimeError, NotImplementedError, OSError) as error:
+        raise ReleaseError("registry archive could not be read") from error
+
+
+def check_release(mode, manifest_path, expected_version, commit_sha=None):
+    if not expected_version or len(expected_version) > 128:
+        raise ReleaseError("expected version must be a nonempty version string")
+    if mode == "verify" and (
+        commit_sha is None or re.fullmatch(r"[0-9a-f]{40}", commit_sha) is None
+    ):
+        raise ReleaseError("verification requires the full checked-out dispatch commit SHA")
+    with manifest_path.open("rb") as stream:
+        parse_manifest(stream.read(MAX_MANIFEST_BYTES + 1), expected_version)
+    versions = registry_versions()
+    if mode == "preflight":
+        if expected_version in versions:
+            raise ReleaseError(f"version {expected_version} already exists; refusing release")
+        return f"release preflight passed: {NAMESPACE}/{COMPONENT} {expected_version} is absent"
+    entry = versions.get(expected_version)
+    if entry is None:
+        raise ReleaseError("expected version is not visible in the registry; artifact not verified")
+    if entry.get("yanked_at") is not None:
+        raise ReleaseError("registry artifact is yanked")
+    parse_manifest(archive_manifest(entry), expected_version, commit_sha)
+    return f"registry artifact verified: {NAMESPACE}/{COMPONENT} {expected_version} at {commit_sha}"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("preflight", "verify"))
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--commit-sha")
+    parser.add_argument(
+        "--manifest", type=Path, default=Path(COMPONENT_PATH) / "idf_component.yml"
+    )
+    args = parser.parse_args(argv)
+    try:
+        print(check_release(args.mode, args.manifest, args.expected_version, args.commit_sha))
+    except (ReleaseError, OSError) as error:
+        print(f"component release check failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_component_release.py
+++ b/scripts/tests/test_check_component_release.py
@@ -1,0 +1,228 @@
+"""Exercise the release guard at its CLI and registry-read boundaries."""
+
+from contextlib import redirect_stderr, redirect_stdout
+import copy
+import importlib.util
+import io
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+import urllib.error
+import zipfile
+
+import yaml
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_component_release.py"
+SPEC = importlib.util.spec_from_file_location("check_component_release", SCRIPT)
+release = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release)
+
+VERSION = "1.0.1"
+SHA = "a" * 40
+ARTIFACT_URL = (
+    "https://components-file.espressif.com/components/espressif/esp-openclaw-node/"
+    "1.0.1/espressif__esp-openclaw-node-v1.0.1.zip"
+)
+MANIFEST = {
+    "version": VERSION,
+    "repository": "https://github.com/openclaw/esp-openclaw-node.git",
+    "repository_info": {"path": "components/esp-openclaw-node", "commit_sha": SHA},
+}
+
+
+def registry(*versions):
+    return json.dumps({
+        "name": "esp-openclaw-node", "namespace": "espressif", "versions": list(versions),
+    }).encode()
+
+
+def version_entry(**changes):
+    return {"version": VERSION, "url": ARTIFACT_URL, "yanked_at": None, **changes}
+
+
+def archive_bytes(manifest=MANIFEST, filename="idf_component.yml"):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        data = manifest if isinstance(manifest, bytes) else yaml.safe_dump(manifest).encode()
+        archive.writestr(filename, data)
+    return output.getvalue()
+
+
+class ReleaseCheckTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory(prefix="component-release-test-")
+        self.addCleanup(self.directory.cleanup)
+        self.manifest = Path(self.directory.name) / "idf_component.yml"
+        self.manifest.write_text(yaml.safe_dump(MANIFEST), encoding="utf-8")
+
+    def run_check(self, mode="preflight", expected_version=VERSION, commit_sha=SHA):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        args = [mode, "--manifest", str(self.manifest), "--expected-version", expected_version]
+        if mode == "verify":
+            args.extend(["--commit-sha", commit_sha])
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = release.main(args)
+        return status, stdout.getvalue(), stderr.getvalue()
+
+    def test_version_mismatch_refuses_before_network_access(self):
+        with patch.object(release, "download") as read:
+            status, output, error = self.run_check(expected_version="1.0.2")
+        self.assertEqual(status, 1)
+        self.assertEqual(output, "")
+        self.assertIn("version does not match", error)
+        read.assert_not_called()
+
+    def test_preflight_allows_absent_version_but_refuses_existing_or_yanked(self):
+        cases = [
+            (registry(), 0, "preflight passed"),
+            (registry(version_entry()), 1, "already exists"),
+            (registry(version_entry(yanked_at="2026-01-01T00:00:00Z")), 1, "already exists"),
+        ]
+        for response, expected_status, message in cases:
+            with self.subTest(message=message), patch.object(
+                release, "download", return_value=response
+            ) as read:
+                status, output, error = self.run_check()
+            self.assertEqual(status, expected_status)
+            self.assertIn(message, output + error)
+            self.assertEqual(read.call_count, 1)
+
+    def test_registry_network_failures_are_not_absence(self):
+        for failure in (
+            urllib.error.URLError("unavailable"),
+            TimeoutError("timed out"),
+            urllib.error.HTTPError(release.REGISTRY_URL, 404, "missing", {}, None),
+            urllib.error.HTTPError(release.REGISTRY_URL, 302, "redirect", {}, None),
+        ):
+            with self.subTest(failure=type(failure).__name__), patch(
+                "urllib.request.OpenerDirector.open", side_effect=failure
+            ):
+                status, output, error = self.run_check()
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("registry request failed", error)
+
+    def test_malformed_registry_metadata_fails_closed(self):
+        malformed = [
+            b"not json", b"\xff", b"[]", b"{}", b'{"name":1,"name":2}',
+            registry(None), registry({}), registry(version_entry(version=1)),
+            registry(version_entry(url=None)), registry(version_entry(), version_entry()),
+            b'{"name":"esp-openclaw-node","namespace":"espressif","versions":{}}',
+            b'{"name":"other","namespace":"espressif","versions":[]}',
+        ]
+        for response in malformed:
+            with self.subTest(response=response), patch.object(
+                release, "download", return_value=response
+            ):
+                status, output, error = self.run_check()
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("check failed", error)
+
+    def test_manifest_parser_rejects_ambiguous_or_invalid_yaml(self):
+        for data in (
+            b"[", b"[]", b"version: 1.0\n", b"!!python/object:invalid {}",
+            b"version: 1.0.1\nversion: 1.0.2\n",
+            yaml.safe_dump({**MANIFEST, "repository": []}).encode(),
+            yaml.safe_dump({**MANIFEST, "repository": {}}).encode(),
+        ):
+            with self.subTest(data=data):
+                self.manifest.write_bytes(data)
+                with patch.object(release, "download") as read:
+                    status, output, error = self.run_check()
+                self.assertEqual(status, 1)
+                self.assertEqual(output, "")
+                self.assertIn("check failed", error)
+                read.assert_not_called()
+
+    def test_verifies_embedded_identity_not_registry_listing_claims(self):
+        entry = version_entry(repository="ignored listing metadata", commit_sha="b" * 40)
+        with patch.object(release, "download", side_effect=[
+            registry(entry), archive_bytes(),
+        ]) as read:
+            status, output, error = self.run_check("verify")
+        self.assertEqual((status, error), (0, ""))
+        self.assertIn("registry artifact verified", output)
+        self.assertIn(SHA, output)
+        self.assertNotIn("uploaded", output)
+        self.assertEqual(read.call_args_list[1].args[0], ARTIFACT_URL)
+
+    def test_verify_rejects_each_artifact_identity_mismatch(self):
+        mutations = [
+            {"version": "1.0.2"},
+            {"repository": "https://github.com/example/other.git"},
+            {"repository_info": {"path": "components/other", "commit_sha": SHA}},
+            {"repository_info": {"path": "components/esp-openclaw-node", "commit_sha": "b" * 40}},
+            {"repository_info": {"path": "components/esp-openclaw-node"}},
+        ]
+        for mutation in mutations:
+            manifest = {**copy.deepcopy(MANIFEST), **mutation}
+            with self.subTest(mutation=mutation), patch.object(
+                release, "download",
+                side_effect=[registry(version_entry()), archive_bytes(manifest)],
+            ):
+                status, output, error = self.run_check("verify")
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("check failed", error)
+
+    def test_verify_refuses_missing_yanked_or_untrusted_download(self):
+        for response in (
+            registry(), registry(version_entry(yanked_at="2026-01-01T00:00:00Z")),
+            registry(version_entry(url="https://example.com/archive.zip")),
+            registry(version_entry(url=ARTIFACT_URL.replace("https:", "http:"))),
+            registry(version_entry(url=ARTIFACT_URL + "?redirect=other")),
+            registry(version_entry(url="https://[invalid/archive.zip")),
+        ):
+            with self.subTest(response=response), patch.object(
+                release, "download", return_value=response
+            ) as read:
+                status, output, error = self.run_check("verify")
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("check failed", error)
+            self.assertEqual(read.call_count, 1)
+
+    def test_verify_requires_full_dispatch_sha_before_network(self):
+        for sha in ("main", "", "a" * 7):
+            with self.subTest(sha=sha), patch.object(release, "download") as read:
+                status, output, error = self.run_check("verify", commit_sha=sha)
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("dispatch commit SHA", error)
+            read.assert_not_called()
+
+    def test_archive_is_bounded_and_requires_root_manifest(self):
+        archives = [
+            b"not a zip",
+            archive_bytes(filename="../idf_component.yml"),
+            archive_bytes(b"x" * (release.MAX_MANIFEST_BYTES + 1)),
+            archive_bytes(b"["),
+        ]
+        for data in archives:
+            with self.subTest(length=len(data)), patch.object(
+                release, "download", side_effect=[registry(version_entry()), data]
+            ):
+                status, output, error = self.run_check("verify")
+            self.assertEqual(status, 1)
+            self.assertEqual(output, "")
+            self.assertIn("check failed", error)
+
+    def test_network_reads_at_most_limit_plus_one(self):
+        response = io.BytesIO(b"x" * (release.MAX_JSON_BYTES + 2))
+        response.status = 200
+        with patch(
+            "urllib.request.OpenerDirector.open", return_value=response
+        ), patch.object(response, "read", wraps=response.read) as read:
+            status, output, error = self.run_check()
+        self.assertEqual(status, 1)
+        self.assertEqual(output, "")
+        self.assertIn("exceeds the read limit", error)
+        read.assert_called_once_with(release.MAX_JSON_BYTES + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The component uploader previously ran on pushes to `main`, while its upstream `--allow-existing` behavior could report success without establishing that the registry contained the intended source revision.

## Changes

- Require a manual dispatch on `main` with an explicit `expected_version` matching the checked-in component manifest.
- Refuse existing or yanked versions, registry errors, malformed metadata, and ambiguous manifest mappings before upload.
- Retain the upstream v2 uploader and OIDC, with an immutable dispatch checkout and explicit repository/commit identity.
- Read the registered ZIP without extraction and verify its embedded version, repository, component path, and commit SHA. Report `registry artifact verified`, not that this run created it.
- Run focused checker tests on relevant pull requests without publication authority. OIDC and release serialization are confined to the dispatch-only upload job.
- Document the CI-only pinned YAML parser, bounded public reads, and read-only recovery after a verification failure.

## Checks

- Eleven focused host tests passed, covering refusal/success behavior, network failures, malformed metadata, bounded reads, and embedded archive identity mismatches.
- `actionlint` and `git diff --check` passed.
- A live read-only preflight for registry version `1.0.0` exited 1 with `version 1.0.0 already exists; refusing release`, as intended.
- Independent review of the complete four-file scope found no actionable P0-P2 findings.
- Final diff and publication text checked for private data.
- Hosted CI for PR head `58376f696500d19401e76a6d86bae03ee71552cc`: all five builds passed in https://github.com/openclaw/esp-openclaw-node/actions/runs/34130709019.
- All three CodeQL analyses passed for the same head in https://github.com/openclaw/esp-openclaw-node/actions/runs/34130706281.
- The hosted release-checker `validate` job passed all 11 tests with read-only contents/metadata permissions; `upload_components` was skipped in the pull-request run: https://github.com/openclaw/esp-openclaw-node/actions/runs/34130709050.

No upload workflow was dispatched, no component or firmware version was changed, and no stored credential or firmware runtime dependency was added. Actual OIDC upload, registry propagation, clean registry-package consumer builds, and physical hardware qualification remain untested. Post-upload verification checks the embedded manifest fields, not byte-for-byte equivalence to a rebuilt package, and does not attribute a concurrent upload to this run.

References OCF-123

## Landing Disposition

The maintainer has accepted the manual-only release handoff. `vincentkoc` owns
that handoff; the first separately approved new-version release must qualify the
OIDC upload and subsequent registry verification together. This landing does not
authorize or dispatch a release, change a version, or claim that publication has
been exercised.

This independently validated CI change is landing before the firmware stack so
subsequent main pushes cannot invoke the legacy automatic uploader. Voice remains
unverified; the separate preclaim device-status attempt ended with a disconnected
node before any Talk or provider request. That result is not a timeout finding or
voice proof for this PR.
