### PR TITLE
ci: retain matching Tab5 build symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,33 @@ jobs:
           name: firmware-${{ matrix.name }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_attempt }}
           path: ${{ matrix.path }}/build/firmware/
           if-no-files-found: error
+
+      - name: Stage Tab5 build symbols
+        if: matrix.name == 'm5stack-tab5-room-node'
+        working-directory: ${{ matrix.path }}
+        run: |
+          for file in \
+            build/openclaw_m5stack_tab5_room_node.elf \
+            build/openclaw_m5stack_tab5_room_node.map \
+            build/firmware/manifest.json; do
+            test -s "$file" || { echo "::error::Missing or empty $file"; exit 1; }
+          done
+          mkdir build/symbols
+          cp \
+            build/openclaw_m5stack_tab5_room_node.elf \
+            build/openclaw_m5stack_tab5_room_node.map \
+            build/firmware/manifest.json \
+            build/symbols/
+          cd build/symbols
+          sha256sum \
+            openclaw_m5stack_tab5_room_node.elf \
+            openclaw_m5stack_tab5_room_node.map \
+            manifest.json > SHA256SUMS
+
+      - name: Upload Tab5 build symbols
+        if: matrix.name == 'm5stack-tab5-room-node'
+        uses: actions/upload-artifact@v7
+        with:
+          name: symbols-${{ matrix.name }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ matrix.path }}/build/symbols/
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,13 +117,15 @@ jobs:
             build/firmware/manifest.json; do
             test -s "$file" || { echo "::error::Missing or empty $file"; exit 1; }
           done
-          mkdir build/symbols
+          # The container-owned build directory is not writable by the host runner.
+          symbols="$RUNNER_TEMP/tab5-build-symbols"
+          mkdir "$symbols"
           cp \
             build/openclaw_m5stack_tab5_room_node.elf \
             build/openclaw_m5stack_tab5_room_node.map \
             build/firmware/manifest.json \
-            build/symbols/
-          cd build/symbols
+            "$symbols/"
+          cd "$symbols"
           sha256sum \
             openclaw_m5stack_tab5_room_node.elf \
             openclaw_m5stack_tab5_room_node.map \
@@ -134,5 +136,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: symbols-${{ matrix.name }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ matrix.path }}/build/symbols/
+          path: ${{ runner.temp }}/tab5-build-symbols/
           if-no-files-found: error


### PR DESCRIPTION
## Problem

The normal Tab5 build produces an application ELF and linker map, but the firmware artifact does not retain them. Without the exact matching ELF, a captured crash cannot be reliably attributed using symbols from a later rebuild.

Stacked on https://github.com/openclaw/esp-openclaw-node/pull/40. This adds diagnostic capability, not a crash fix.

## Changes

- Retain the normal Tab5 application ELF and map in a separate artifact named with the example, target, compiled source SHA, run ID, and attempt.
- Require nonempty ELF, map, and firmware manifest before staging.
- Include SHA256 checksums and a byte-for-byte copy of the existing sanitized firmware manifest.
- Stage copies in runner-owned temporary storage without changing the container-owned build directory's permissions.
- Leave the SDK selector, application, panic configuration, build commands, permissions, and existing flash bundles unchanged.

## Original Checks

- Eight local staging fixtures passed: complete inputs, missing/empty ELF, map, or manifest, and a read-only build directory. The fixtures execute the workflow shell and check output contents, checksums, and preservation of flash files.
- actionlint and `git diff --check` passed.
- The initial hosted run passed all five compilations but exposed a host/container directory-ownership error during symbol staging. The read-only-directory regression reproduced that failure and passes with staging moved to runner-owned storage.
- All five jobs passed in [run 34188657538, attempt 1](https://github.com/openclaw/esp-openclaw-node/actions/runs/34188657538) at PR head `7655de8dcafeccf6fade022ac781c34dd81f904c`, including Tab5 symbol staging and upload.
- Downloaded the Tab5 firmware and separate symbols once each. Both ZIP SHA256 values match GitHub's artifact digests; all 11 firmware and 3 symbol checksum entries passed. The four flash images retain offsets `0x2000`, `0x8000`, `0x10000`, and `0x810000`.
- The firmware/symbol manifests are byte-identical. Compiled test-merge source `f9035f6d25235c6ea5c00919199e4fbda142c156` has the expected PR/base parents and the same tree as the PR head.
- The retained ELF's full SHA256 matches the application's embedded ELF SHA256: `d1273c140762b51c4cba5cde1df7e927388402941d31bd9e510e9da76ba1cc2a`.

## Validation Limits

The manifest records SDK commit `362a1776ec212788fda95f75b733bfdde3a0c394`, build revision `v5.5.5-648-g362a1776ec2`, and esptool `4.12.0`. The SDK image remains a moving selector, not pristine ESP-IDF 5.5.5. These are symbols for this new build, not recovered symbols for an earlier image.

No firmware was flashed and no USB-JTAG capture was performed for this PR. This unpatched build is not the next hardware candidate; the separately scoped SPM compatibility change is tracked in https://github.com/openclaw/esp-openclaw-node/pull/42.

## Landing Preparation

Signed head `1d1c83af134b16824cbbeec940f834419c1e51ba` retains the original
symbol commits and incorporates the reviewed predecessor
`905aa25ebca4cbfeaf01541b2ef0452ac138205d`. Its complete tree is exactly that
predecessor plus the original symbol-retention delta. No new build or
packaging behavior was introduced. All five builds passed in
[exact-head CI run 34506028271](https://github.com/openclaw/esp-openclaw-node/actions/runs/34506028271);
the downloaded artifact evidence above identifies the earlier build, not
this prepared head.
Maintainer disposition on September 12, 2026: land this independently verified
symbol-retention change with a merge commit, retaining the original signed
objects. The existing artifact and exact-head CI evidence are accepted; this
does not qualify voice or add new hardware evidence.
