### PR TITLE
fix: recognize P4 SPM stacks in flash guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Firmware packaging tests
         if: matrix.name == 'component-test-app-build'
-        run: python3 -m unittest discover -s scripts/tests -p 'test_package_firmware.py' -v
+        run: |
+          python3 -m unittest discover -s scripts/tests -p 'test_package_firmware.py' -v
+          python3 -m unittest discover -s scripts/tests -p 'test_idf_tab5_compat.py' -v
 
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
@@ -76,6 +78,9 @@ jobs:
           target: ${{ matrix.target }}
           path: ${{ matrix.path }}
           command: |
+            if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
+              python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH"
+            fi &&
             idf.py reconfigure &&
             ninja -C build -j2 &&
             if [ "${{ matrix.name }}" = "component-test-app-build" ]; then

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -13,6 +13,46 @@ idf.py reconfigure
 idf.py build
 ```
 
+### Isolated SDK compatibility patch
+
+Tab5 CI applies `patches/esp-idf/tab5-spm-stack-sanity.patch` to SDK commit
+`362a1776ec212788fda95f75b733bfdde3a0c394` before configuring the build. This is
+ESP-IDF plus a tracked compatibility patch, not pristine ESP-IDF 5.5.5.
+
+On ESP32-P4 v1.3, internal SPM can hold an ordinary task stack but is omitted
+from this SDK's flash-operation stack-sanity predicate. See
+[ESP-IDF issue 19020](https://github.com/espressif/esp-idf/issues/19020).
+The patch adds only the `SOC_MEM_SPM_SUPPORTED`-guarded `esp_ptr_in_spm(sp)`
+case. It retains the assertion and existing DRAM/RTC checks; it does not make
+PSRAM stacks safe for flash access or change allocation policy.
+
+The connected qualification board is ESP32-P4 v1.3. The existing profile sets
+`CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y`; inspected image headers have minimum
+revision 0 and maximum revision 199. This is not evidence that the same binary
+supports revision 3 or newer silicon. Other P4 revisions remain physically
+unqualified, and this patch does not change chip-revision selections.
+
+For manual reproduction, use a dedicated SDK checkout at the exact commit,
+never a shared SDK installation. From this example directory, explicitly
+apply the patch before `idf.py reconfigure` or `idf.py build`:
+
+```sh
+python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH"
+python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH" --verify-only
+```
+
+The helper rejects another SDK base, unrelated tracked/untracked changes,
+changed patch bytes, or an unexpected complete source file. An already-applied
+exact patch is verified without reapplying it. CMake never edits the SDK.
+CI uses only its isolated SDK container and does not change shared checkouts.
+
+Firmware packaging independently verifies the actual SDK source delta, not a
+marker file. Its manifest records the dirty SDK state, base commit, patch
+SHA256, and patched-source SHA256; other examples still reject dirty SDKs.
+The separate ELF/map artifact copies that same firmware manifest unchanged.
+Retire the patch, helper and packaging exception together only after an
+upstream SDK fix is selected and qualified on affected hardware.
+
 The official BSP manifest pins `esp_video ~2.0`, while P4-capable
 `esp_capture` requires `esp_video ^2.1`. The source-only BSP build bridge uses
 exact inspected commit `f0ef9497efce684997ce391edd19733483e250a5` without

--- a/patches/esp-idf/tab5-spm-stack-sanity.patch
+++ b/patches/esp-idf/tab5-spm-stack-sanity.patch
@@ -1,0 +1,13 @@
+diff --git a/components/spi_flash/cache_utils.c b/components/spi_flash/cache_utils.c
+--- a/components/spi_flash/cache_utils.c
++++ b/components/spi_flash/cache_utils.c
+@@ -60,6 +60,9 @@ static inline bool esp_task_stack_is_sane_cache_disabled(void)
+     return esp_ptr_in_dram(sp)
+ #if CONFIG_ESP_SYSTEM_ALLOW_RTC_FAST_MEM_AS_HEAP
+            || esp_ptr_in_rtc_dram_fast(sp)
+ #endif
++#if SOC_MEM_SPM_SUPPORTED
++           || esp_ptr_in_spm(sp)
++#endif
+            ;
+ }

--- a/scripts/idf_tab5_compat.py
+++ b/scripts/idf_tab5_compat.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Apply or verify the single approved Tab5 patch in an explicitly selected SDK."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+
+BASE_COMMIT = "362a1776ec212788fda95f75b733bfdde3a0c394"
+SOURCE_PATH = "components/spi_flash/cache_utils.c"
+ORIGINAL_SHA256 = "15bb5f74f4deb8dbe24ba18eadf90e417592f3d2e40988c8bf0c093144e500fe"
+PATCHED_SHA256 = "4e8074e6d6320a86451b9ae4af8bfb50584a2ad97dc0e1d29ff171d83ead33b8"
+PATCH_RELATIVE = "patches/esp-idf/tab5-spm-stack-sanity.patch"
+PATCH_PATH = Path(__file__).resolve().parents[1] / PATCH_RELATIVE
+PATCH_SHA256 = "9f2b51789034460f6b74ca3b0a20934512837d8c126fb3fc8286aaaac5dfa8fe"
+PATCHED_STATUS = b" M " + SOURCE_PATH.encode() + b"\0"
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def git(idf, *arguments):
+    return subprocess.check_output(
+        ["git", "--no-optional-locks", "-C", str(idf), *arguments],
+        stderr=subprocess.PIPE,
+    )
+
+
+def inspect_sdk(idf):
+    idf = Path(idf).resolve(strict=True)
+    root = Path(git(idf, "rev-parse", "--show-toplevel").decode().strip()).resolve()
+    if root != idf:
+        raise ValueError("Select the SDK repository root explicitly")
+    if git(idf, "rev-parse", "HEAD").decode().strip() != BASE_COMMIT:
+        raise ValueError("SDK is not at the approved compatibility-patch base")
+    if PATCH_PATH.is_symlink() or digest(PATCH_PATH.read_bytes()) != PATCH_SHA256:
+        raise ValueError("Tracked compatibility patch has unexpected contents")
+    if digest(git(idf, "show", f"HEAD:{SOURCE_PATH}")) != ORIGINAL_SHA256:
+        raise ValueError("SDK base source does not match the approved whole-file hash")
+    source = idf / SOURCE_PATH
+    if source.resolve(strict=True) != source or not source.is_file():
+        raise ValueError("SDK source must be a regular file at the approved path")
+    status = git(
+        idf, "status", "--porcelain=v1", "-z",
+        "--untracked-files=all", "--ignore-submodules=none",
+    )
+    return idf, status, digest(source.read_bytes())
+
+
+def verify_sdk_patch(idf):
+    _, status, source_hash = inspect_sdk(idf)
+    # Exact base, sole dirty path and whole-file bytes prove the actual SDK delta.
+    if status != PATCHED_STATUS or source_hash != PATCHED_SHA256:
+        raise ValueError("SDK is not modified by exactly the approved Tab5 patch")
+    return {
+        "base_commit": BASE_COMMIT,
+        "patch": PATCH_RELATIVE,
+        "patch_sha256": PATCH_SHA256,
+        "source": SOURCE_PATH,
+        "original_source_sha256": ORIGINAL_SHA256,
+        "patched_source_sha256": source_hash,
+    }
+
+
+def apply_sdk_patch(idf):
+    idf, status, source_hash = inspect_sdk(idf)
+    if status == PATCHED_STATUS and source_hash == PATCHED_SHA256:
+        return verify_sdk_patch(idf)
+    if status or source_hash != ORIGINAL_SHA256:
+        raise ValueError("SDK must be clean or contain exactly the verified Tab5 patch")
+    git(idf, "apply", "--check", str(PATCH_PATH))
+    git(idf, "apply", str(PATCH_PATH))
+    return verify_sdk_patch(idf)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--idf-path", type=Path, required=True)
+    parser.add_argument("--verify-only", action="store_true")
+    arguments = parser.parse_args()
+    try:
+        operation = verify_sdk_patch if arguments.verify_only else apply_sdk_patch
+        result = operation(arguments.idf_path)
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"SDK compatibility patch refused: {error}\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -15,6 +15,8 @@ import subprocess
 import tempfile
 from urllib.parse import urlsplit
 
+from idf_tab5_compat import verify_sdk_patch
+
 
 EXAMPLES = {
     "esp32-node": "esp32s3",
@@ -189,8 +191,12 @@ def package_firmware(project, build, output, target, provenance, dependencies):
         raise ValueError("Build metadata does not match the active IDF")
     if git(repo, "status", "--porcelain", "--untracked-files=normal"):
         raise ValueError("Repository contains modified source")
-    if git(idf, "status", "--porcelain", "--untracked-files=normal"):
-        raise ValueError("IDF contains modified source")
+    idf_dirty = bool(git(idf, "status", "--porcelain", "--untracked-files=all"))
+    idf_compatibility = None
+    if idf_dirty:
+        if project.name != "m5stack-tab5-room-node":
+            raise ValueError("IDF contains modified source")
+        idf_compatibility = verify_sdk_patch(idf)
     if not dependencies.get("dependencies"):
         raise ValueError("Resolved dependency lock is empty")
     normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
@@ -208,6 +214,7 @@ def package_firmware(project, build, output, target, provenance, dependencies):
             "commit": git(idf, "rev-parse", "HEAD"),
             "build_revision": description["git_revision"],
             "image_requested": provenance["idf_image"],
+            "dirty": idf_dirty,
         },
         "tools": {
             "esptool": importlib.metadata.version("esptool"),
@@ -223,6 +230,8 @@ def package_firmware(project, build, output, target, provenance, dependencies):
             "flasher_args.json": sha256(flash_file),
         },
     }
+    if idf_compatibility is not None:
+        manifest["idf"]["compatibility_patch"] = idf_compatibility
     if project.name == "m5stack-tab5-room-node":
         manifest["tab5_bsp"] = tab5_provenance(project, build)
     extra = flash["extra_esptool_args"]

--- a/scripts/tests/test_idf_tab5_compat.py
+++ b/scripts/tests/test_idf_tab5_compat.py
@@ -1,0 +1,145 @@
+"""Exercise SDK patch refusal and idempotence using task-owned Git fixtures."""
+
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import idf_tab5_compat as compat
+
+
+ORIGINAL = b"""/* Synthetic SDK fixture, not a copy of the complete SDK source. */
+static inline bool esp_task_stack_is_sane_cache_disabled(void)
+{
+    const void *sp = (const void *)esp_cpu_get_sp();
+
+    return esp_ptr_in_dram(sp)
+#if CONFIG_ESP_SYSTEM_ALLOW_RTC_FAST_MEM_AS_HEAP
+           || esp_ptr_in_rtc_dram_fast(sp)
+#endif
+           ;
+}
+"""
+PATCHED = ORIGINAL.replace(
+    b"           ;",
+    b"#if SOC_MEM_SPM_SUPPORTED\n           || esp_ptr_in_spm(sp)\n#endif\n           ;",
+)
+
+
+def seed_sdk(idf):
+    source = idf / compat.SOURCE_PATH
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(ORIGINAL)
+    (idf / "other.c").write_text("/* unchanged SDK fixture */\n")
+    compat.git(idf, "add", ".")
+    compat.git(
+        idf, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.com",
+        "-c", "commit.gpgsign=false", "commit", "-qm", "SDK fixture",
+    )
+    return compat.git(idf, "rev-parse", "HEAD").decode().strip()
+
+
+@contextmanager
+def fixture_profile(base):
+    # Use real Git state and the real tracked patch with a small synthetic base.
+    with patch.multiple(
+        compat, BASE_COMMIT=base,
+        ORIGINAL_SHA256=compat.digest(ORIGINAL),
+        PATCHED_SHA256=compat.digest(PATCHED),
+    ):
+        yield
+
+
+class SdkCompatibilityTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="sdk-compat-test-")
+        self.addCleanup(temporary.cleanup)
+        self.idf = Path(temporary.name).resolve()
+        contexts = ExitStack()
+        self.addCleanup(contexts.close)
+        contexts.enter_context(patch.dict(os.environ, {
+            "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1",
+        }))
+        compat.git(self.idf, "init", "-q")
+        self.base = seed_sdk(self.idf)
+        contexts.enter_context(fixture_profile(self.base))
+        self.source = self.idf / compat.SOURCE_PATH
+
+    def test_apply_and_repeat_preserve_exact_delta_and_report_actual_hashes(self):
+        metadata = compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+        self.assertEqual(compat.git(self.idf, "status", "--porcelain=v1", "-z"), compat.PATCHED_STATUS)
+        self.assertEqual(metadata["base_commit"], self.base)
+        self.assertEqual(metadata["patch_sha256"], compat.digest(compat.PATCH_PATH.read_bytes()))
+        self.assertEqual(metadata["patched_source_sha256"], compat.digest(self.source.read_bytes()))
+        self.assertEqual(compat.apply_sdk_patch(self.idf), metadata)
+        self.assertEqual(compat.verify_sdk_patch(self.idf), metadata)
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+
+    def test_verify_does_not_apply_to_clean_sdk(self):
+        with self.assertRaises(ValueError):
+            compat.verify_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_wrong_base_is_rejected_before_mutation(self):
+        with patch.object(compat, "BASE_COMMIT", "0" * 40), self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_unrelated_tracked_dirt_is_preserved_and_rejected(self):
+        other = self.idf / "other.c"
+        other.write_text("unrelated edit\n")
+        with self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.assertEqual(other.read_text(), "unrelated edit\n")
+
+    def test_untracked_file_is_preserved_and_rejected(self):
+        extra = self.idf / "extra.c"
+        extra.write_text("unrelated file\n")
+        with self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.assertTrue(extra.exists())
+
+    def test_patch_tampering_is_rejected_before_mutation(self):
+        with tempfile.TemporaryDirectory(prefix="patch-tamper-") as root:
+            altered = Path(root) / "altered.patch"
+            altered.write_bytes(compat.PATCH_PATH.read_bytes() + b"\n")
+            with patch.object(compat, "PATCH_PATH", altered), self.assertRaises(ValueError):
+                compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_unexpected_original_whole_file_is_rejected(self):
+        with patch.object(compat, "ORIGINAL_SHA256", "0" * 64), self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_patched_source_tampering_is_not_idempotent_success(self):
+        compat.apply_sdk_patch(self.idf)
+        self.source.write_bytes(PATCHED + b"/* unrelated change */\n")
+        for operation in (compat.apply_sdk_patch, compat.verify_sdk_patch):
+            with self.subTest(operation=operation.__name__), self.assertRaises(ValueError):
+                operation(self.idf)
+        self.assertEqual(self.source.read_bytes(), PATCHED + b"/* unrelated change */\n")
+
+    def test_staged_patch_is_not_the_expected_worktree_delta(self):
+        compat.apply_sdk_patch(self.idf)
+        compat.git(self.idf, "add", compat.SOURCE_PATH)
+        with self.assertRaises(ValueError):
+            compat.verify_sdk_patch(self.idf)
+
+    def test_nested_sdk_path_is_rejected(self):
+        with self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.source.parent)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -9,12 +9,17 @@ from pathlib import Path
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).resolve().parents[1] / "package_firmware.py"
+sys.path.insert(0, str(SCRIPT.parent))
+from test_idf_tab5_compat import fixture_profile, seed_sdk
+import idf_tab5_compat as compat
+
 SPEC = importlib.util.spec_from_file_location("package_firmware", SCRIPT)
 firmware = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(firmware)
@@ -167,6 +172,8 @@ class FirmwareBundleTests(unittest.TestCase):
         self.assertEqual(manifest["source"]["commit"], self.git(self.repo, "rev-parse", "HEAD"))
         self.assertEqual(manifest["idf"]["commit"], self.git(self.idf, "rev-parse", "HEAD"))
         self.assertEqual(manifest["idf"]["build_revision"], "v5.5.5")
+        self.assertFalse(manifest["idf"]["dirty"])
+        self.assertNotIn("compatibility_patch", manifest["idf"])
         self.assertEqual(manifest["ci"]["pr_head_sha"], "2" * 40)
         self.assertEqual(manifest["ci"]["event_sha"], "1" * 40)
         inputs = manifest["configuration_inputs"]
@@ -291,7 +298,7 @@ class FirmwareBundleTests(unittest.TestCase):
             {"path": "third_party/sdk", "commit": self.git(self.idf, "rev-parse", "HEAD")}
         ])
 
-    def test_tab5_records_upstream_and_local_bridge_identity(self):
+    def configure_tab5(self):
         destination = self.repo / "examples/m5stack-tab5-room-node"
         self.project.rename(destination)
         self.project = destination
@@ -317,6 +324,10 @@ class FirmwareBundleTests(unittest.TestCase):
             f" URL_HASH SHA256={'b' * 64})\n"
         )
         (self.build / "CMakeCache.txt").write_text("OPENCLAW_TAB5_BSP_LOCAL_PATH:PATH=\n")
+        return bridge
+
+    def test_tab5_records_upstream_and_local_bridge_identity(self):
+        bridge = self.configure_tab5()
         self.package()
         manifest = json.loads((self.output / "manifest.json").read_text())
         self.assertEqual(manifest["tab5_bsp"]["upstream_commit"], "a" * 40)
@@ -325,8 +336,54 @@ class FirmwareBundleTests(unittest.TestCase):
         self.assertIn("not an unmodified upstream", manifest["tab5_bsp"]["integration"])
         self.assertEqual(manifest["configuration_inputs"][-1], {
             "kind": "partition_table", "path": "<project>/partitions.csv",
-            "sha256": firmware.sha256(destination / "partitions.csv"),
+            "sha256": firmware.sha256(self.project / "partitions.csv"),
         })
+
+    def test_verified_tab5_sdk_patch_records_actual_dirty_source_identity(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            expected = compat.apply_sdk_patch(self.idf)
+            self.description["git_revision"] = "v5.5.5-fixture-dirty"
+            self.package()
+        metadata = json.loads((self.output / "manifest.json").read_text())["idf"]
+        self.assertTrue(metadata["dirty"])
+        self.assertEqual(metadata["commit"], base)
+        self.assertEqual(metadata["compatibility_patch"], expected)
+        self.assertEqual(
+            metadata["compatibility_patch"]["patched_source_sha256"],
+            firmware.sha256(self.idf / compat.SOURCE_PATH),
+        )
+        self.assertEqual(metadata["build_revision"], "v5.5.5-fixture-dirty")
+
+    def test_tab5_rejects_post_patch_source_tampering_without_output(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            compat.apply_sdk_patch(self.idf)
+            source = self.idf / compat.SOURCE_PATH
+            source.write_bytes(source.read_bytes() + b"/* unrelated modification */\n")
+            with self.assertRaises(ValueError):
+                self.package()
+        self.assertFalse(self.output.exists())
+
+    def test_tab5_rejects_unrelated_sdk_dirt_without_output(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            compat.apply_sdk_patch(self.idf)
+            (self.idf / "other.c").write_text("unrelated modification\n")
+            with self.assertRaises(ValueError):
+                self.package()
+        self.assertFalse(self.output.exists())
+
+    def test_other_examples_reject_even_the_verified_sdk_patch(self):
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            compat.apply_sdk_patch(self.idf)
+            with self.assertRaisesRegex(ValueError, "IDF contains modified source"):
+                self.package()
+        self.assertFalse(self.output.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

On the connected M5Stack Tab5 ESP32-P4 v1.3, flash access asserted at `cache_utils.c:127` with a task stack pointer inside internal SPM. The selected ESP-IDF base accepts SPM for internal allocations but omits it from its flash-operation stack-sanity predicate. This matches https://github.com/espressif/esp-idf/issues/19020.

Stacked on https://github.com/openclaw/esp-openclaw-node/pull/41 to retain the exact normal ELF/map alongside the firmware. This does not merge any dependency PR.

## Changes

- Add only the `SOC_MEM_SPM_SUPPORTED`-guarded `esp_ptr_in_spm(sp)` case to the stack-sanity predicate. Keep the assertion, DRAM/RTC checks, allocation policy, NVS behavior, and chip-revision selections unchanged.
- Apply the tracked patch only in Tab5's isolated CI SDK container before configuration. Manual application requires an explicitly selected, dedicated SDK checkout.
- Require SDK base `362a1776ec212788fda95f75b733bfdde3a0c394`, the exact tracked patch, the original whole-file hash, and the exact resulting source hash. Reject unrelated tracked/untracked changes, another base, staged changes, and tampering. Verify an already-applied exact patch without reapplying it.
- Preserve the packager's dirty-SDK refusal for other examples. The Tab5 exception independently validates the actual SDK source and records dirty state, base commit, patch hash, and patched-source hash. Firmware and symbol artifacts share the same manifest.
- Document the isolated manual procedure and removal condition. This is ESP-IDF plus a tracked compatibility patch, not pristine ESP-IDF 5.5.5 or a claim that PSRAM stacks are safe for flash access.

## Original Checks

- Ten SDK-helper tests passed using real Git repositories and patch application: acceptance, idempotence, verification-only refusal, wrong base, unrelated tracked/untracked changes, patch/source tampering, staged changes, and invalid SDK-root selection.
- Twelve firmware-packaging tests passed; one existing dependency-lock reader test was skipped locally because its YAML dependency is supplied by IDF CI.
- Hosted CI reran the ten helper and twelve packaging tests successfully, then passed the real dependency-lock reader test inside the IDF container.
- The tracked patch applied cleanly to the independently captured original SDK file and produced the pinned patched-source hash.
- actionlint and `git diff --check` passed.
- Independent scoped review found no actionable P0-P2 findings.
- All five jobs passed in [run 34190325714, attempt 1](https://github.com/openclaw/esp-openclaw-node/actions/runs/34190325714) at PR head `c8e63f6b5510156ba1b12dc4e916031823a39056`, including Tab5 firmware and symbol uploads.
- The completed Tab5 firmware and symbols ZIPs match GitHub artifact digests (`10042137041` and `10042137904`). All 11 firmware and 3 symbol checksum entries passed; the four images retain offsets `0x2000`, `0x8000`, `0x10000`, and `0x810000`.
- Both manifests are byte-identical and record compiled merge `2949820b310a0e14d3317fd1ffb37f9f6fadd4c0`, with the expected PR/base parents and the same tree as the PR head.
- The retained ELF's full SHA256 matches the app's embedded ELF SHA256: `3ca692fc85a1259414e8f9cc9ca571fdfe47feaed08b6f96e11559a54c5ad9a3`. Embedded app version `2949820` and SDK revision match the manifest.

## Qualification Limits

Matched firmware/symbol download verification passed. The manifest records SDK base `362a1776ec212788fda95f75b733bfdde3a0c394`, revision `v5.5.5-648-g362a1776ec2-dirty`, and the exact approved patch/source hashes. The SDK base matches the preceding build, but its source now includes the tracked compatibility patch. The image selector remains moving and the helper fails closed if its base changes.

The affected connected board is P4 v1.3. Current profile/image evidence (`CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y`, image minimum revision 0, maximum 199) does not establish same-binary revision 3 or newer compatibility. These checks do not qualify other P4 revisions or the new ancestry-prepared image physically. The existing defaults comment suggesting "newer silicon" needs a separately qualified correction; this change does not alter revision selections.

No device access, flashing, USB-JTAG, Gateway, or provider calls were performed for this implementation. A successful build would not by itself prove that the observed assertion is resolved on hardware.

## Landing Preparation

Signed head `ba3437946360327d5e6c7dc386ad9fe50a7f9ce2` retains the original
SPM compatibility commit and incorporates the reviewed predecessor
`1d1c83af134b16824cbbeec940f834419c1e51ba`. Its complete tree is exactly that
predecessor plus the original compatibility delta, preserving the landed
release guard and node-home repair. No new SDK patch or runtime policy was
introduced. All five builds passed in
[exact-head CI run 34507229544](https://github.com/openclaw/esp-openclaw-node/actions/runs/34507229544);
the artifact evidence above belongs to the original build.

Maintainer disposition on September 12, 2026: accept the narrow compatibility
fix and its intentional fail-closed refusal when the moving SDK selector stops
matching the approved base. SDK pinning is separate work; this PR does not
weaken the identity guard to keep builds running.

Separate campaign evidence on the matched `2949820` image recorded four flash
readbacks, successful node-session persistence and 60 seconds without the SPM
assertion or reset. Later operator/NVS failures remained separate unresolved
outcomes; this is not complete storage, other-silicon, or voice qualification.
No new hardware test was performed for this ancestry-prepared head. Landing
uses a merge commit and retains the original signed objects.
