### PR TITLE
diag(tab5): capture first NVS and session-load failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           python3 -m unittest discover -s scripts/tests -p 'test_package_firmware.py' -v
           python3 -m unittest discover -s scripts/tests -p 'test_idf_tab5_compat.py' -v
+          python3 -m unittest discover -s scripts/tests -p 'test_nvs_diagnostics.py' -v
 
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
@@ -78,8 +79,10 @@ jobs:
           target: ${{ matrix.target }}
           path: ${{ matrix.path }}
           command: |
+            nvs_diagnostics="" &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
-              python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH"
+              nvs_diagnostics="--nvs-diagnostics" &&
+              python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH" --nvs-diagnostics
             fi &&
             idf.py reconfigure &&
             ninja -C build -j2 &&
@@ -101,7 +104,8 @@ jobs:
                 --pr-head-sha "${{ github.event.pull_request.head.sha }}" \
                 --run-id "${{ github.run_id }}" \
                 --run-attempt "${{ github.run_attempt }}" \
-                --idf-image "espressif/idf:release-v5.5"
+                --idf-image "espressif/idf:release-v5.5" \
+                $nvs_diagnostics
             fi
 
       - name: Upload firmware

--- a/components/esp-openclaw-node/src/esp_openclaw_node.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node.c
@@ -10,7 +10,9 @@
 #include <string.h>
 
 #include "esp_app_desc.h"
+#include "esp_attr.h"
 #include "esp_check.h"
+#include "esp_rom_sys.h"
 
 static const char *DEFAULT_PLATFORM = "esp32";
 static const char *DEFAULT_DEVICE_FAMILY = "ESP32";
@@ -578,17 +580,27 @@ esp_err_t esp_openclaw_node_request_connect(
         esp_err_t load_err = esp_openclaw_node_persisted_session_load(
             node->config.role,
             &fresh);
+        bool fresh_present = esp_openclaw_node_persisted_session_is_present(&fresh);
+        bool cached_present;
         if (load_err == ESP_OK) {
             esp_openclaw_node_lock_state(node);
+            cached_present = esp_openclaw_node_saved_session_is_present_locked(node);
             esp_openclaw_node_persisted_session_free(&node->persisted_session);
             node->persisted_session = fresh;
             esp_openclaw_node_unlock_state(node);
         } else {
+            cached_present = esp_openclaw_node_has_saved_session(node);
             ESP_LOGW(
                 ESP_OPENCLAW_NODE_TAG,
                 "saved-session reload from NVS failed, using in-memory copy: %s",
                 esp_err_to_name(load_err));
         }
+        unsigned role = node->config.role != NULL && strcmp(node->config.role, "node") == 0
+            ? 1 : node->config.role != NULL && strcmp(node->config.role, "operator") == 0 ? 2 : 0;
+        esp_rom_printf(
+            DRAM_STR("nvs_connect_diag role=%u cached=%u fresh_known=%u fresh=%u err=%d\n"),
+            role, (unsigned)cached_present, (unsigned)(load_err == ESP_OK),
+            (unsigned)fresh_present, (int)load_err);
     }
 
     esp_openclaw_node_connect_request_source_t connect_source = {0};

--- a/components/esp-openclaw-node/src/esp_openclaw_node_persisted_session.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_persisted_session.c
@@ -11,8 +11,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "esp_attr.h"
 #include "esp_check.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"
 #include "nvs.h"
 
 static const char *TAG = "esp_openclaw_node_session";
@@ -29,7 +31,36 @@ typedef struct {
     const char *version;
     const char *uri;
     const char *device_token;
+    unsigned diagnostic_role;
 } persisted_session_keys_t;
+
+enum {
+    SESSION_DIAG_OPEN = 1,
+    SESSION_DIAG_VERSION,
+    SESSION_DIAG_URI_SIZE,
+    SESSION_DIAG_URI_VALUE,
+    SESSION_DIAG_TOKEN_SIZE,
+    SESSION_DIAG_TOKEN_VALUE,
+    SESSION_DIAG_VALIDATE,
+    SESSION_DIAG_CLEAR,
+};
+
+enum {
+    SESSION_DIAG_UNREAD = 0,
+    SESSION_DIAG_ABSENT,
+    SESSION_DIAG_EMPTY,
+    SESSION_DIAG_UNSUPPORTED,
+    SESSION_DIAG_INCOMPLETE,
+    SESSION_DIAG_INVALID_URI,
+};
+
+static void log_session_load(
+    unsigned role, unsigned stage, esp_err_t err, unsigned presence)
+{
+    esp_rom_printf(
+        DRAM_STR("nvs_session_diag role=%u stage=%u err=%d presence=%u\n"),
+        role, stage, (int)err, presence);
+}
 
 static esp_err_t resolve_session_keys(
     const char *role,
@@ -43,6 +74,7 @@ static esp_err_t resolve_session_keys(
             .version = NVS_KEY_VERSION,
             .uri = NVS_KEY_URI,
             .device_token = NVS_KEY_DEVICE_TOKEN,
+            .diagnostic_role = 1,
         };
         return ESP_OK;
     }
@@ -51,6 +83,7 @@ static esp_err_t resolve_session_keys(
             .version = NVS_KEY_OPERATOR_VERSION,
             .uri = NVS_KEY_OPERATOR_URI,
             .device_token = NVS_KEY_OPERATOR_DEVICE_TOKEN,
+            .diagnostic_role = 2,
         };
         return ESP_OK;
     }
@@ -113,10 +146,17 @@ static esp_err_t validate_persisted_session(const esp_openclaw_node_persisted_se
 static esp_err_t load_optional_string(
     nvs_handle_t nvs,
     const char *key,
-    char **out_value)
+    char **out_value,
+    unsigned role,
+    unsigned size_stage,
+    unsigned value_stage)
 {
     size_t required = 0;
     esp_err_t err = nvs_get_str(nvs, key, NULL, &required);
+    if (err != ESP_OK) {
+        log_session_load(role, size_stage, err,
+            err == ESP_ERR_NVS_NOT_FOUND ? SESSION_DIAG_ABSENT : SESSION_DIAG_UNREAD);
+    }
     if (err == ESP_ERR_NVS_NOT_FOUND) {
         *out_value = NULL;
         return ESP_OK;
@@ -125,14 +165,18 @@ static esp_err_t load_optional_string(
 
     char *value = malloc(required);
     if (value == NULL) {
+        log_session_load(role, value_stage, ESP_ERR_NO_MEM, SESSION_DIAG_UNREAD);
         return ESP_ERR_NO_MEM;
     }
     err = nvs_get_str(nvs, key, value, &required);
     if (err != ESP_OK) {
+        log_session_load(role, value_stage, err,
+            err == ESP_ERR_NVS_NOT_FOUND ? SESSION_DIAG_ABSENT : SESSION_DIAG_UNREAD);
         free(value);
         return err;
     }
     if (value[0] == '\0') {
+        log_session_load(role, value_stage, err, SESSION_DIAG_EMPTY);
         free(value);
         value = NULL;
     }
@@ -184,6 +228,8 @@ static esp_err_t clear_invalid_loaded_session(
     clear_persisted_session_struct(session);
 
     esp_err_t clear_err = clear_session_keys(nvs, keys);
+    log_session_load(
+        keys->diagnostic_role, SESSION_DIAG_CLEAR, clear_err, SESSION_DIAG_UNREAD);
     if (clear_err != ESP_OK) {
         ESP_LOGW(
             TAG,
@@ -263,11 +309,17 @@ esp_err_t esp_openclaw_node_persisted_session_load(
     nvs_handle_t nvs = 0;
     esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs);
     if (err != ESP_OK) {
+        log_session_load(
+            keys.diagnostic_role, SESSION_DIAG_OPEN, err, SESSION_DIAG_UNREAD);
         return err;
     }
 
     uint8_t version = 0;
     err = nvs_get_u8(nvs, keys.version, &version);
+    if (err != ESP_OK) {
+        log_session_load(keys.diagnostic_role, SESSION_DIAG_VERSION, err,
+            err == ESP_ERR_NVS_NOT_FOUND ? SESSION_DIAG_ABSENT : SESSION_DIAG_UNREAD);
+    }
     if (err == ESP_ERR_NVS_NOT_FOUND) {
         nvs_close(nvs);
         return ESP_OK;
@@ -277,11 +329,15 @@ esp_err_t esp_openclaw_node_persisted_session_load(
         return err;
     }
     if (version != PERSISTED_SESSION_VERSION) {
+        log_session_load(
+            keys.diagnostic_role, SESSION_DIAG_VERSION, err, SESSION_DIAG_UNSUPPORTED);
         ESP_LOGW(
             TAG,
             "ignoring unsupported persisted session version %u",
             (unsigned)version);
         esp_err_t clear_err = clear_session_keys(nvs, &keys);
+        log_session_load(
+            keys.diagnostic_role, SESSION_DIAG_CLEAR, clear_err, SESSION_DIAG_UNREAD);
         nvs_close(nvs);
         if (clear_err != ESP_OK) {
             ESP_LOGW(
@@ -293,13 +349,21 @@ esp_err_t esp_openclaw_node_persisted_session_load(
     }
 
     session->version = version;
-    err = load_optional_string(nvs, keys.uri, &session->gateway_uri);
+    err = load_optional_string(
+        nvs, keys.uri, &session->gateway_uri, keys.diagnostic_role,
+        SESSION_DIAG_URI_SIZE, SESSION_DIAG_URI_VALUE);
     if (err == ESP_OK) {
-        err = load_optional_string(nvs, keys.device_token, &session->device_token);
+        err = load_optional_string(
+            nvs, keys.device_token, &session->device_token, keys.diagnostic_role,
+            SESSION_DIAG_TOKEN_SIZE, SESSION_DIAG_TOKEN_VALUE);
     }
     if (err == ESP_OK) {
         err = validate_persisted_session(session);
         if (err == ESP_ERR_INVALID_ARG) {
+            bool has_uri = session->gateway_uri != NULL && session->gateway_uri[0] != '\0';
+            bool has_token = session->device_token != NULL && session->device_token[0] != '\0';
+            log_session_load(keys.diagnostic_role, SESSION_DIAG_VALIDATE, err,
+                has_uri != has_token ? SESSION_DIAG_INCOMPLETE : SESSION_DIAG_INVALID_URI);
             err = clear_invalid_loaded_session(
                 nvs,
                 &keys,

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
@@ -952,6 +952,35 @@ TEST_CASE("setup code rejects invalid or ambiguous auth shapes", "[esp_openclaw_
     TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_destroy(node));
 }
 
+TEST_CASE("saved reconnect retains cached session when NVS reload fails", "[esp_openclaw_node][session]")
+{
+    reset_openclaw_storage();
+    reset_transport_state();
+    esp_openclaw_node_persisted_session_t session = {0};
+    const esp_openclaw_node_persisted_session_t update = {
+        .version = 1,
+        .gateway_uri = "wss://saved.example/ws",
+        .device_token = "synthetic-saved-token",
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_persisted_session_store("node", &session, &update));
+    esp_openclaw_node_persisted_session_free(&session);
+
+    esp_openclaw_node_config_t config = {0};
+    esp_openclaw_node_config_init_default(&config);
+    esp_openclaw_node_handle_t node = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_create(&config, &node));
+    TEST_ASSERT_TRUE(esp_openclaw_node_has_saved_session(node));
+    TEST_ASSERT_EQUAL(ESP_OK, nvs_flash_deinit());
+    TEST_ASSERT_EQUAL(ESP_OK, request_connect_saved_session(node));
+    TEST_ASSERT_TRUE(wait_for_int_value(&s_transport_state.start_calls, 1, pdMS_TO_TICKS(1000)));
+    TEST_ASSERT_TRUE(esp_openclaw_node_has_saved_session(node));
+    char *uri = esp_openclaw_node_dup_gateway_uri(node);
+    TEST_ASSERT_EQUAL_STRING("wss://saved.example/ws", uri);
+    free(uri);
+    TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_destroy(node));
+    TEST_ASSERT_EQUAL(ESP_OK, nvs_flash_init());
+}
+
 TEST_CASE("explicit connect request validates psk and no-auth arguments", "[esp_openclaw_node][api]")
 {
     reset_openclaw_storage();

--- a/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
+++ b/components/esp-openclaw-node/test_apps/esp_openclaw_node_unity_tests/main/test_esp_openclaw_node.c
@@ -956,11 +956,13 @@ TEST_CASE("saved reconnect retains cached session when NVS reload fails", "[esp_
 {
     reset_openclaw_storage();
     reset_transport_state();
+    char saved_uri[] = "wss://saved.example/ws";
+    char saved_token[] = "synthetic-saved-token";
     esp_openclaw_node_persisted_session_t session = {0};
     const esp_openclaw_node_persisted_session_t update = {
         .version = 1,
-        .gateway_uri = "wss://saved.example/ws",
-        .device_token = "synthetic-saved-token",
+        .gateway_uri = saved_uri,
+        .device_token = saved_token,
     };
     TEST_ASSERT_EQUAL(ESP_OK, esp_openclaw_node_persisted_session_store("node", &session, &update));
     esp_openclaw_node_persisted_session_free(&session);

--- a/components/esp-openclaw-room-node/esp_openclaw_room_node.c
+++ b/components/esp-openclaw-room-node/esp_openclaw_room_node.c
@@ -7,9 +7,11 @@
 #include "esp_console.h"
 #include "esp_event.h"
 #include "esp_check.h"
+#include "esp_attr.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_netif.h"
+#include "esp_rom_sys.h"
 #include "esp_openclaw_node.h"
 #include "esp_openclaw_node_example_repl.h"
 #include "esp_openclaw_node_wifi.h"
@@ -1251,6 +1253,9 @@ esp_err_t esp_openclaw_room_node_start(const esp_openclaw_room_node_config_t *co
 {
     ESP_RETURN_ON_ERROR(room_board_bind(config), TAG, "invalid board contract");
     esp_err_t nvs_err = nvs_flash_init();
+    if (nvs_err != ESP_OK) {
+        esp_rom_printf(DRAM_STR("nvs_init_diag err=%d\n"), (int)nvs_err);
+    }
     if (nvs_err == ESP_ERR_NVS_NO_FREE_PAGES || nvs_err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
         ESP_ERROR_CHECK(nvs_flash_erase());
         nvs_err = nvs_flash_init();

--- a/components/esp-openclaw-room-node/tests/host/esp_rom_sys.h
+++ b/components/esp-openclaw-room-node/tests/host/esp_rom_sys.h
@@ -1,0 +1,3 @@
+#pragma once
+int esp_rom_printf(const char *format, ...)
+    __attribute__((format(printf, 1, 2)));

--- a/components/esp-openclaw-room-node/tests/host/room_host_fakes.c
+++ b/components/esp-openclaw-room-node/tests/host/room_host_fakes.c
@@ -12,6 +12,7 @@
 #include "esp_openclaw_node_wifi.h"
 #include "esp_openclaw_talk.h"
 #include "esp_peer_default.h"
+#include "esp_rom_sys.h"
 #include "room_board.h"
 #include "room_canvas.h"
 #include "room_canvas_node_cmd.h"
@@ -81,6 +82,15 @@ void host_log(const char *tag, const char *format, ...)
     vfprintf(stderr, format, args);
     fputc('\n', stderr);
     va_end(args);
+}
+
+int esp_rom_printf(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int written = vfprintf(stderr, format, args);
+    va_end(args);
+    return written;
 }
 
 const char *esp_err_to_name(esp_err_t code)

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -53,6 +53,58 @@ The separate ELF/map artifact copies that same firmware manifest unchanged.
 Retire the patch, helper and packaging exception together only after an
 upstream SDK fix is selected and qualified on affected hardware.
 
+### NVS diagnostic build
+
+This diagnostic branch additionally applies
+`patches/esp-idf/tab5-nvs-first-failure.patch` in Tab5 CI. It does not repair
+session loss or change storage, retry, initialization recovery, or allocation
+policy. The SDK base and SPM patch above remain unchanged. Manual diagnostic
+builds must explicitly add `--nvs-diagnostics` to both helper commands above;
+packaging requires the same option. Verification permits exactly the two
+approved dirty SDK paths, with separate `compatibility_patch` and
+`diagnostic_patch` manifest records. The symbol artifact retains that same
+manifest.
+
+The following unprefixed ROM-output records contain fixed numeric fields only.
+Capture them before filtering for normal I/W/E log prefixes:
+
+| Record | Fields |
+| --- | --- |
+| `nvs_io_diag` | `op`, `err`; first captured failure per boot |
+| `nvs_session_diag` | `role`, `stage`, `err`, `presence` |
+| `nvs_connect_diag` | `role`, `cached`, `fresh_known`, `fresh`, `err` |
+| `nvs_init_diag` | `err`; initial initialization failure before existing recovery |
+
+`op`: 1 read_raw, 2 read, 3 write_raw, 4 write, 5 erase_range.
+Read/write alignment errors retain their original return and perform no I/O,
+but also claim the first-failure record. The other records follow the underlying
+partition call's return. The internal-RAM atomic claim is lock-free; output
+does not allocate or hold that claim as a lock. No success records, offsets,
+lengths, keys, URLs, IDs, or credential values are emitted by this SDK probe.
+
+`role`: 0 unknown, 1 node, 2 operator.
+Session `stage`: 1 open, 2 version, 3 URI size, 4 URI allocation/value read,
+5 token size, 6 token allocation/value read, 7 validation, 8 clear result.
+Session `presence` is a classification: 0 unread/not classified, 1 missing,
+2 empty, 3 unsupported version, 4 incomplete fields, 5 invalid URI.
+The original error precedes normalization or clear; clear has its own result.
+An `err=0` clear result is not proof of a physical write.
+
+Connect booleans are 0/1. `cached` is sampled under the state lock before
+replacement, or from the retained cache after a load error; `fresh_known=0`
+means a failed load, not authoritative absence. These are observations, not
+authorization or new recovery behavior. ROM output can interleave with other
+console output, and lack of a record does not prove healthy NVS. The SDK probe
+covers these five NVSPartition methods, not every flash operation.
+
+Host tests execute the patched SDK methods and actual session loader against
+I/O stubs, including original return values, no-I/O alignment failures,
+concurrent first capture, clear failures and synthetic canary non-disclosure.
+The fixture SDK file is the exact Apache-2.0 source at the pinned commit;
+normal CI still builds the real SDK. Target Unity lifecycle tests are built,
+not run by CI. Remove this temporary diagnostic patch and its explicit
+packaging mode after the observed failure is identified and qualified.
+
 The official BSP manifest pins `esp_video ~2.0`, while P4-capable
 `esp_capture` requires `esp_video ^2.1`. The source-only BSP build bridge uses
 exact inspected commit `f0ef9497efce684997ce391edd19733483e250a5` without

--- a/patches/esp-idf/tab5-nvs-first-failure.patch
+++ b/patches/esp-idf/tab5-nvs-first-failure.patch
@@ -1,0 +1,74 @@
+--- a/components/nvs_flash/src/nvs_partition.cpp
++++ b/components/nvs_flash/src/nvs_partition.cpp
+@@ -5,10 +5,28 @@
+  */
+ 
+ #include <cstdlib>
++#include "esp_attr.h"
++#include "esp_rom_sys.h"
+ #include "nvs_partition.hpp"
+ 
+ namespace nvs {
+ 
++static DRAM_ATTR uint32_t s_first_io_failure;
++static_assert(__atomic_always_lock_free(sizeof(s_first_io_failure), nullptr),
++              "NVS diagnostics require a lock-free failure claim");
++
++static esp_err_t report_io_result(unsigned operation, esp_err_t result)
++{
++    uint32_t expected = 0;
++    // Claim once per boot, outside flash I/O and without holding a logging lock.
++    if (result != ESP_OK &&
++        __atomic_compare_exchange_n(&s_first_io_failure, &expected, 1, false,
++                                    __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
++        esp_rom_printf(DRAM_STR("nvs_io_diag op=%u err=%d\n"), operation, (int)result);
++    }
++    return result;
++}
++
+ NVSPartition::NVSPartition(const esp_partition_t* partition)
+     : mESPPartition(partition)
+ {
+@@ -25,35 +43,35 @@
+ 
+ esp_err_t NVSPartition::read_raw(size_t src_offset, void* dst, size_t size)
+ {
+-    return esp_partition_read_raw(mESPPartition, src_offset, dst, size);
++    return report_io_result(1, esp_partition_read_raw(mESPPartition, src_offset, dst, size));
+ }
+ 
+ esp_err_t NVSPartition::read(size_t src_offset, void* dst, size_t size)
+ {
+     if (size % ESP_ENCRYPT_BLOCK_SIZE != 0) {
+-        return ESP_ERR_INVALID_ARG;
++        return report_io_result(2, ESP_ERR_INVALID_ARG);
+     }
+ 
+-    return esp_partition_read(mESPPartition, src_offset, dst, size);
++    return report_io_result(2, esp_partition_read(mESPPartition, src_offset, dst, size));
+ }
+ 
+ esp_err_t NVSPartition::write_raw(size_t dst_offset, const void* src, size_t size)
+ {
+-    return esp_partition_write_raw(mESPPartition, dst_offset, src, size);
++    return report_io_result(3, esp_partition_write_raw(mESPPartition, dst_offset, src, size));
+ }
+ 
+ esp_err_t NVSPartition::write(size_t dst_offset, const void* src, size_t size)
+ {
+     if (size % ESP_ENCRYPT_BLOCK_SIZE != 0) {
+-        return ESP_ERR_INVALID_ARG;
++        return report_io_result(4, ESP_ERR_INVALID_ARG);
+     }
+ 
+-    return esp_partition_write(mESPPartition, dst_offset, src, size);
++    return report_io_result(4, esp_partition_write(mESPPartition, dst_offset, src, size));
+ }
+ 
+ esp_err_t NVSPartition::erase_range(size_t dst_offset, size_t size)
+ {
+-    return esp_partition_erase_range(mESPPartition, dst_offset, size);
++    return report_io_result(5, esp_partition_erase_range(mESPPartition, dst_offset, size));
+ }
+ 
+ uint32_t NVSPartition::get_address()

--- a/scripts/idf_tab5_compat.py
+++ b/scripts/idf_tab5_compat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply or verify the single approved Tab5 patch in an explicitly selected SDK."""
+"""Apply or verify the approved Tab5 patches in an explicitly selected SDK."""
 
 import argparse
 import hashlib
@@ -16,6 +16,13 @@ PATCH_RELATIVE = "patches/esp-idf/tab5-spm-stack-sanity.patch"
 PATCH_PATH = Path(__file__).resolve().parents[1] / PATCH_RELATIVE
 PATCH_SHA256 = "9f2b51789034460f6b74ca3b0a20934512837d8c126fb3fc8286aaaac5dfa8fe"
 PATCHED_STATUS = b" M " + SOURCE_PATH.encode() + b"\0"
+DIAGNOSTIC_SOURCE_PATH = "components/nvs_flash/src/nvs_partition.cpp"
+DIAGNOSTIC_ORIGINAL_SHA256 = "84ebf8ce5f76de96e839f3d43b1b5a75704617c9050598ee1c10f19ed45a42f3"
+DIAGNOSTIC_PATCHED_SHA256 = "e2dc534f82d1b0f47d8b7236f697b075ea034e85b55ef0d09b08297a00eca5ee"
+DIAGNOSTIC_PATCH_RELATIVE = "patches/esp-idf/tab5-nvs-first-failure.patch"
+DIAGNOSTIC_PATCH_PATH = Path(__file__).resolve().parents[1] / DIAGNOSTIC_PATCH_RELATIVE
+DIAGNOSTIC_PATCH_SHA256 = "a921a244bd79a5a6a29a0b184787e95d08a3fc4e6e71fb73f4dd5b92e9d94968"
+DIAGNOSTIC_STATUS = b" M " + DIAGNOSTIC_SOURCE_PATH.encode() + b"\0" + PATCHED_STATUS
 
 
 def digest(data):
@@ -29,61 +36,94 @@ def git(idf, *arguments):
     )
 
 
-def inspect_sdk(idf):
+def inspect_source(idf, source_path, original_hash, patch_path, patch_hash):
+    if patch_path.is_symlink() or digest(patch_path.read_bytes()) != patch_hash:
+        raise ValueError("Tracked SDK patch has unexpected contents")
+    if digest(git(idf, "show", f"HEAD:{source_path}")) != original_hash:
+        raise ValueError("SDK base source does not match the approved whole-file hash")
+    source = idf / source_path
+    if source.resolve(strict=True) != source or not source.is_file():
+        raise ValueError("SDK source must be a regular file at the approved path")
+    return digest(source.read_bytes())
+
+
+def inspect_sdk(idf, nvs_diagnostics=False):
     idf = Path(idf).resolve(strict=True)
     root = Path(git(idf, "rev-parse", "--show-toplevel").decode().strip()).resolve()
     if root != idf:
         raise ValueError("Select the SDK repository root explicitly")
     if git(idf, "rev-parse", "HEAD").decode().strip() != BASE_COMMIT:
         raise ValueError("SDK is not at the approved compatibility-patch base")
-    if PATCH_PATH.is_symlink() or digest(PATCH_PATH.read_bytes()) != PATCH_SHA256:
-        raise ValueError("Tracked compatibility patch has unexpected contents")
-    if digest(git(idf, "show", f"HEAD:{SOURCE_PATH}")) != ORIGINAL_SHA256:
-        raise ValueError("SDK base source does not match the approved whole-file hash")
-    source = idf / SOURCE_PATH
-    if source.resolve(strict=True) != source or not source.is_file():
-        raise ValueError("SDK source must be a regular file at the approved path")
+    source_hash = inspect_source(idf, SOURCE_PATH, ORIGINAL_SHA256, PATCH_PATH, PATCH_SHA256)
+    diagnostic_hash = None
+    if nvs_diagnostics:
+        diagnostic_hash = inspect_source(
+            idf, DIAGNOSTIC_SOURCE_PATH, DIAGNOSTIC_ORIGINAL_SHA256,
+            DIAGNOSTIC_PATCH_PATH, DIAGNOSTIC_PATCH_SHA256,
+        )
     status = git(
         idf, "status", "--porcelain=v1", "-z",
         "--untracked-files=all", "--ignore-submodules=none",
     )
-    return idf, status, digest(source.read_bytes())
+    return idf, status, source_hash, diagnostic_hash
 
 
-def verify_sdk_patch(idf):
-    _, status, source_hash = inspect_sdk(idf)
-    # Exact base, sole dirty path and whole-file bytes prove the actual SDK delta.
-    if status != PATCHED_STATUS or source_hash != PATCHED_SHA256:
-        raise ValueError("SDK is not modified by exactly the approved Tab5 patch")
-    return {
+def verify_sdk_patch(idf, nvs_diagnostics=False):
+    _, status, source_hash, diagnostic_hash = inspect_sdk(idf, nvs_diagnostics)
+    expected_status = DIAGNOSTIC_STATUS if nvs_diagnostics else PATCHED_STATUS
+    if (status != expected_status or source_hash != PATCHED_SHA256 or
+            (nvs_diagnostics and diagnostic_hash != DIAGNOSTIC_PATCHED_SHA256)):
+        raise ValueError("SDK is not modified by exactly the selected Tab5 patches")
+    result = {"compatibility_patch": {
         "base_commit": BASE_COMMIT,
         "patch": PATCH_RELATIVE,
         "patch_sha256": PATCH_SHA256,
         "source": SOURCE_PATH,
         "original_source_sha256": ORIGINAL_SHA256,
         "patched_source_sha256": source_hash,
-    }
+    }}
+    if nvs_diagnostics:
+        result["diagnostic_patch"] = {
+            "base_commit": BASE_COMMIT,
+            "patch": DIAGNOSTIC_PATCH_RELATIVE,
+            "patch_sha256": DIAGNOSTIC_PATCH_SHA256,
+            "source": DIAGNOSTIC_SOURCE_PATH,
+            "original_source_sha256": DIAGNOSTIC_ORIGINAL_SHA256,
+            "patched_source_sha256": diagnostic_hash,
+        }
+    return result
 
 
-def apply_sdk_patch(idf):
-    idf, status, source_hash = inspect_sdk(idf)
-    if status == PATCHED_STATUS and source_hash == PATCHED_SHA256:
-        return verify_sdk_patch(idf)
-    if status or source_hash != ORIGINAL_SHA256:
+def apply_sdk_patch(idf, nvs_diagnostics=False):
+    idf, status, source_hash, diagnostic_hash = inspect_sdk(idf, nvs_diagnostics)
+    expected_status = DIAGNOSTIC_STATUS if nvs_diagnostics else PATCHED_STATUS
+    if status == expected_status:
+        return verify_sdk_patch(idf, nvs_diagnostics)
+    patches = [str(PATCH_PATH)]
+    if nvs_diagnostics:
+        if diagnostic_hash != DIAGNOSTIC_ORIGINAL_SHA256:
+            raise ValueError("Diagnostic source must match the approved original")
+        patches.append(str(DIAGNOSTIC_PATCH_PATH))
+        if status == PATCHED_STATUS and source_hash == PATCHED_SHA256:
+            patches = [str(DIAGNOSTIC_PATCH_PATH)]
+        elif status or source_hash != ORIGINAL_SHA256:
+            raise ValueError("SDK must be clean or contain the exact compatibility patch")
+    elif status or source_hash != ORIGINAL_SHA256:
         raise ValueError("SDK must be clean or contain exactly the verified Tab5 patch")
-    git(idf, "apply", "--check", str(PATCH_PATH))
-    git(idf, "apply", str(PATCH_PATH))
-    return verify_sdk_patch(idf)
+    git(idf, "apply", "--check", *patches)
+    git(idf, "apply", *patches)
+    return verify_sdk_patch(idf, nvs_diagnostics)
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--idf-path", type=Path, required=True)
     parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--nvs-diagnostics", action="store_true")
     arguments = parser.parse_args()
     try:
         operation = verify_sdk_patch if arguments.verify_only else apply_sdk_patch
-        result = operation(arguments.idf_path)
+        result = operation(arguments.idf_path, arguments.nvs_diagnostics)
     except (OSError, ValueError, subprocess.CalledProcessError) as error:
         parser.exit(1, f"SDK compatibility patch refused: {error}\n")
     print(json.dumps(result, indent=2))

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -162,7 +162,7 @@ def tab5_provenance(project, build):
     }
 
 
-def package_firmware(project, build, output, target, provenance, dependencies):
+def package_firmware(project, build, output, target, provenance, dependencies, nvs_diagnostics=False):
     project, build, output = project.resolve(), build.resolve(), output.resolve()
     repo = Path(git(project, "rev-parse", "--show-toplevel")).resolve()
     if project.parent != repo / "examples" or EXAMPLES.get(project.name) != target:
@@ -193,10 +193,12 @@ def package_firmware(project, build, output, target, provenance, dependencies):
         raise ValueError("Repository contains modified source")
     idf_dirty = bool(git(idf, "status", "--porcelain", "--untracked-files=all"))
     idf_compatibility = None
+    if nvs_diagnostics and (project.name != "m5stack-tab5-room-node" or not idf_dirty):
+        raise ValueError("NVS diagnostics require the explicitly patched Tab5 SDK")
     if idf_dirty:
         if project.name != "m5stack-tab5-room-node":
             raise ValueError("IDF contains modified source")
-        idf_compatibility = verify_sdk_patch(idf)
+        idf_compatibility = verify_sdk_patch(idf, nvs_diagnostics)
     if not dependencies.get("dependencies"):
         raise ValueError("Resolved dependency lock is empty")
     normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
@@ -231,7 +233,7 @@ def package_firmware(project, build, output, target, provenance, dependencies):
         },
     }
     if idf_compatibility is not None:
-        manifest["idf"]["compatibility_patch"] = idf_compatibility
+        manifest["idf"].update(idf_compatibility)
     if project.name == "m5stack-tab5-room-node":
         manifest["tab5_bsp"] = tab5_provenance(project, build)
     extra = flash["extra_esptool_args"]
@@ -338,9 +340,11 @@ def main():
     for name in ("repository", "event", "event-sha", "run-id", "run-attempt", "idf-image"):
         parser.add_argument("--" + name, required=True)
     parser.add_argument("--pr-head-sha", default="")
+    parser.add_argument("--nvs-diagnostics", action="store_true")
     args = parser.parse_args()
     provenance = vars(args).copy()
     provenance.pop("target")
+    provenance.pop("nvs_diagnostics")
     project = Path.cwd()
     # ruamel.yaml is already part of ESP-IDF's component-manager environment.
     try:
@@ -351,7 +355,7 @@ def main():
         dependencies = read_dependency_lock(project / "dependencies.lock")
         output = package_firmware(
             project, project / "build", project / "build/firmware",
-            args.target, provenance, dependencies,
+            args.target, provenance, dependencies, args.nvs_diagnostics,
         )
     except ValueError as error:
         parser.exit(1, f"Firmware packaging failed: {error}\n")

--- a/scripts/tests/fixtures/nvs_partition.cpp
+++ b/scripts/tests/fixtures/nvs_partition.cpp
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2019-2023 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cstdlib>
+#include "nvs_partition.hpp"
+
+namespace nvs {
+
+NVSPartition::NVSPartition(const esp_partition_t* partition)
+    : mESPPartition(partition)
+{
+    // ensure the class is in a valid state
+    if (partition == nullptr) {
+        std::abort();
+    }
+}
+
+const char *NVSPartition::get_partition_name()
+{
+    return mESPPartition->label;
+}
+
+esp_err_t NVSPartition::read_raw(size_t src_offset, void* dst, size_t size)
+{
+    return esp_partition_read_raw(mESPPartition, src_offset, dst, size);
+}
+
+esp_err_t NVSPartition::read(size_t src_offset, void* dst, size_t size)
+{
+    if (size % ESP_ENCRYPT_BLOCK_SIZE != 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return esp_partition_read(mESPPartition, src_offset, dst, size);
+}
+
+esp_err_t NVSPartition::write_raw(size_t dst_offset, const void* src, size_t size)
+{
+    return esp_partition_write_raw(mESPPartition, dst_offset, src, size);
+}
+
+esp_err_t NVSPartition::write(size_t dst_offset, const void* src, size_t size)
+{
+    if (size % ESP_ENCRYPT_BLOCK_SIZE != 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return esp_partition_write(mESPPartition, dst_offset, src, size);
+}
+
+esp_err_t NVSPartition::erase_range(size_t dst_offset, size_t size)
+{
+    return esp_partition_erase_range(mESPPartition, dst_offset, size);
+}
+
+uint32_t NVSPartition::get_address()
+{
+    return mESPPartition->address;
+}
+
+uint32_t NVSPartition::get_size()
+{
+    return mESPPartition->size;
+}
+
+bool NVSPartition::get_readonly()
+{
+    return mESPPartition->readonly;
+}
+
+} // nvs

--- a/scripts/tests/fixtures/test_nvs_partition.cpp
+++ b/scripts/tests/fixtures/test_nvs_partition.cpp
@@ -1,0 +1,84 @@
+#include <atomic>
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include "nvs_partition.hpp"
+
+static std::atomic<int> calls{0}, records{0};
+static int result, recorded_error;
+static unsigned recorded_operation;
+static thread_local bool in_io;
+static const esp_partition_t partition = {"synthetic-id-canary", 4096, 8192, false};
+
+int esp_rom_printf(const char *format, ...)
+{
+    assert(!in_io);
+    va_list args;
+    va_start(args, format);
+    recorded_operation = va_arg(args, unsigned);
+    recorded_error = va_arg(args, int);
+    va_end(args);
+    char text[128];
+    std::snprintf(text, sizeof(text), format, recorded_operation, recorded_error);
+    assert(std::strstr(text, "canary") == nullptr);
+    records.fetch_add(1);
+    return 0;
+}
+
+static int io(const esp_partition_t *p, size_t offset, size_t size)
+{
+    in_io = true;
+    assert(p == &partition && offset == 32 && size == 16);
+    calls.fetch_add(1);
+    in_io = false;
+    return result;
+}
+esp_err_t esp_partition_read_raw(const esp_partition_t *p, size_t o, void *, size_t s) { return io(p, o, s); }
+esp_err_t esp_partition_read(const esp_partition_t *p, size_t o, void *, size_t s) { return io(p, o, s); }
+esp_err_t esp_partition_write_raw(const esp_partition_t *p, size_t o, const void *, size_t s) { return io(p, o, s); }
+esp_err_t esp_partition_write(const esp_partition_t *p, size_t o, const void *, size_t s) { return io(p, o, s); }
+esp_err_t esp_partition_erase_range(const esp_partition_t *p, size_t o, size_t s) { return io(p, o, s); }
+
+static int invoke(nvs::NVSPartition &nvs, unsigned op, size_t size = 16)
+{
+    char buffer[32] = "synthetic-token-canary";
+    switch (op) {
+    case 1: return nvs.read_raw(32, buffer, size);
+    case 2: return nvs.read(32, buffer, size);
+    case 3: return nvs.write_raw(32, buffer, size);
+    case 4: return nvs.write(32, buffer, size);
+    default: return nvs.erase_range(32, size);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    assert(argc == 2);
+    nvs::NVSPartition nvs(&partition);
+    assert(nvs.get_address() == 4096 && nvs.get_size() == 8192 && !nvs.get_readonly());
+    if (std::strncmp(argv[1], "alignment-", 10) == 0) {
+        unsigned op = std::strcmp(argv[1], "alignment-read") == 0 ? 2 : 4;
+        assert(invoke(nvs, op, 1) == ESP_ERR_INVALID_ARG);
+        assert(calls == 0 && records == 1);
+        assert(recorded_operation == op && recorded_error == ESP_ERR_INVALID_ARG);
+        assert(invoke(nvs, op, 1) == ESP_ERR_INVALID_ARG && records == 1 && calls == 0);
+    } else if (std::strcmp(argv[1], "concurrent") == 0) {
+        result = -23;
+        std::thread workers[16];
+        for (auto &worker : workers) worker = std::thread([&] { assert(invoke(nvs, 1) == -23); });
+        for (auto &worker : workers) worker.join();
+        assert(calls == 16 && records == 1 && recorded_error == -23);
+    } else {
+        unsigned op = static_cast<unsigned>(std::atoi(argv[1]));
+        assert(invoke(nvs, op) == ESP_OK && records == 0 && calls == 1);
+        result = -37;
+        assert(invoke(nvs, op) == -37 && records == 1 && calls == 2);
+        assert(recorded_operation == op && recorded_error == -37);
+        result = 4363;
+        assert(invoke(nvs, op) == 4363 && records == 1 && calls == 3);
+    }
+    return 0;
+}

--- a/scripts/tests/fixtures/test_nvs_session.c
+++ b/scripts/tests/fixtures/test_nvs_session.c
@@ -1,0 +1,146 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include "esp_openclaw_node_persisted_session.h"
+#include "nvs.h"
+
+typedef struct { unsigned role, stage, presence; int err; } record_t;
+static record_t records[16];
+static unsigned record_count, string_calls, erase_calls, commit_calls, close_calls;
+static int open_error, version_error, size_error[2], value_error[2], clear_error;
+static uint8_t version;
+static const char *values[2];
+
+int esp_rom_printf(const char *format, ...)
+{
+    assert(record_count < 16);
+    record_t *r = &records[record_count++];
+    va_list args;
+    va_start(args, format);
+    r->role = va_arg(args, unsigned);
+    r->stage = va_arg(args, unsigned);
+    r->err = va_arg(args, int);
+    r->presence = va_arg(args, unsigned);
+    va_end(args);
+    char text[160];
+    snprintf(text, sizeof(text), format, r->role, r->stage, r->err, r->presence);
+    assert(strstr(text, "canary") == NULL);
+    assert(strstr(text, "://") == NULL);
+    return 0;
+}
+
+esp_err_t nvs_open(const char *name, int mode, nvs_handle_t *handle)
+{
+    assert(strcmp(name, "openclaw") == 0 && mode == NVS_READWRITE);
+    *handle = 1;
+    return open_error;
+}
+void nvs_close(nvs_handle_t handle) { assert(handle == 1); close_calls++; }
+esp_err_t nvs_get_u8(nvs_handle_t h, const char *key, uint8_t *out)
+{
+    (void)h; (void)key; *out = version; return version_error;
+}
+esp_err_t nvs_get_str(nvs_handle_t h, const char *key, char *out, size_t *size)
+{
+    (void)h;
+    string_calls++;
+    unsigned field = strstr(key, "uri") != NULL ? 0 : 1;
+    int err = out == NULL ? size_error[field] : value_error[field];
+    if (err != ESP_OK) return err;
+    size_t required = strlen(values[field]) + 1;
+    if (out != NULL) { assert(*size >= required); memcpy(out, values[field], required); }
+    *size = required;
+    return ESP_OK;
+}
+esp_err_t nvs_erase_key(nvs_handle_t h, const char *key)
+{
+    (void)h; (void)key;
+    assert(record_count > 0); /* The original failure must be captured before clearing. */
+    erase_calls++;
+    return clear_error;
+}
+esp_err_t nvs_commit(nvs_handle_t h) { (void)h; commit_calls++; return ESP_OK; }
+esp_err_t nvs_set_u8(nvs_handle_t h, const char *k, uint8_t v)
+{ (void)h; (void)k; (void)v; assert(0); return ESP_FAIL; }
+esp_err_t nvs_set_str(nvs_handle_t h, const char *k, const char *v)
+{ (void)h; (void)k; (void)v; assert(0); return ESP_FAIL; }
+
+static void reset(void)
+{
+    record_count = string_calls = erase_calls = commit_calls = close_calls = 0;
+    open_error = version_error = clear_error = 0;
+    memset(size_error, 0, sizeof(size_error));
+    memset(value_error, 0, sizeof(value_error));
+    version = 1;
+    values[0] = "wss://synthetic-url-canary.example/synthetic-id-canary";
+    values[1] = "synthetic-token-canary";
+}
+
+static void expect(unsigned index, unsigned role, unsigned stage, int err, unsigned presence)
+{
+    assert(index < record_count);
+    record_t r = records[index];
+    assert(r.role == role && r.stage == stage && r.err == err && r.presence == presence);
+}
+
+int main(void)
+{
+    const char *roles[] = {"node", "operator"};
+    for (unsigned role = 1; role <= 2; role++) {
+        esp_openclaw_node_persisted_session_t session;
+        reset();
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        assert(esp_openclaw_node_persisted_session_is_present(&session));
+        assert(strcmp(session.gateway_uri, values[0]) == 0 && strcmp(session.device_token, values[1]) == 0);
+        assert(record_count == 0 && string_calls == 4 && erase_calls == 0 && close_calls == 1);
+        esp_openclaw_node_persisted_session_free(&session);
+
+        reset(); open_error = 4363;
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == 4363);
+        expect(0, role, 1, 4363, 0);
+        assert(close_calls == 0 && string_calls == 0 && erase_calls == 0);
+
+        reset(); version_error = ESP_ERR_NVS_NOT_FOUND;
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        expect(0, role, 2, ESP_ERR_NVS_NOT_FOUND, 1);
+        assert(!esp_openclaw_node_persisted_session_is_present(&session) && erase_calls == 0);
+
+        for (unsigned field = 0; field < 2; field++) {
+            for (unsigned value_read = 0; value_read < 2; value_read++) {
+                reset();
+                (value_read ? value_error : size_error)[field] = 4363;
+                assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == 4363);
+                expect(0, role, 3 + 2 * field + value_read, 4363, 0);
+                assert(session.gateway_uri == NULL && session.device_token == NULL && erase_calls == 0);
+            }
+        }
+
+        reset(); version = 2; clear_error = 4363;
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        expect(0, role, 2, ESP_OK, 3);
+        expect(1, role, 8, 4363, 0);
+        assert(erase_calls == 1 && commit_calls == 0 && !esp_openclaw_node_persisted_session_is_present(&session));
+
+        reset(); size_error[1] = ESP_ERR_NVS_NOT_FOUND;
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        expect(0, role, 5, ESP_ERR_NVS_NOT_FOUND, 1);
+        expect(1, role, 7, ESP_ERR_INVALID_ARG, 4);
+        expect(2, role, 8, ESP_OK, 0);
+        assert(erase_calls == 3 && commit_calls == 1 && session.gateway_uri == NULL);
+
+        reset(); values[0] = "synthetic-invalid-uri-canary"; clear_error = 4363;
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        expect(0, role, 7, ESP_ERR_INVALID_ARG, 5);
+        expect(1, role, 8, 4363, 0);
+        assert(session.gateway_uri == NULL && session.device_token == NULL);
+
+        reset(); values[0] = ""; values[1] = "";
+        assert(esp_openclaw_node_persisted_session_load(roles[role - 1], &session) == ESP_OK);
+        expect(0, role, 4, ESP_OK, 2);
+        expect(1, role, 6, ESP_OK, 2);
+        assert(record_count == 2 && erase_calls == 0 && !esp_openclaw_node_persisted_session_is_present(&session));
+    }
+    puts("session diagnostic boundary cases passed");
+    return 0;
+}

--- a/scripts/tests/test_idf_tab5_compat.py
+++ b/scripts/tests/test_idf_tab5_compat.py
@@ -36,6 +36,9 @@ def seed_sdk(idf):
     source = idf / compat.SOURCE_PATH
     source.parent.mkdir(parents=True, exist_ok=True)
     source.write_bytes(ORIGINAL)
+    diagnostic = idf / compat.DIAGNOSTIC_SOURCE_PATH
+    diagnostic.parent.mkdir(parents=True, exist_ok=True)
+    diagnostic.write_bytes((Path(__file__).parent / "fixtures/nvs_partition.cpp").read_bytes())
     (idf / "other.c").write_text("/* unchanged SDK fixture */\n")
     compat.git(idf, "add", ".")
     compat.git(
@@ -75,9 +78,9 @@ class SdkCompatibilityTests(unittest.TestCase):
         metadata = compat.apply_sdk_patch(self.idf)
         self.assertEqual(self.source.read_bytes(), PATCHED)
         self.assertEqual(compat.git(self.idf, "status", "--porcelain=v1", "-z"), compat.PATCHED_STATUS)
-        self.assertEqual(metadata["base_commit"], self.base)
-        self.assertEqual(metadata["patch_sha256"], compat.digest(compat.PATCH_PATH.read_bytes()))
-        self.assertEqual(metadata["patched_source_sha256"], compat.digest(self.source.read_bytes()))
+        self.assertEqual(metadata["compatibility_patch"]["base_commit"], self.base)
+        self.assertEqual(metadata["compatibility_patch"]["patch_sha256"], compat.digest(compat.PATCH_PATH.read_bytes()))
+        self.assertEqual(metadata["compatibility_patch"]["patched_source_sha256"], compat.digest(self.source.read_bytes()))
         self.assertEqual(compat.apply_sdk_patch(self.idf), metadata)
         self.assertEqual(compat.verify_sdk_patch(self.idf), metadata)
         self.assertEqual(self.source.read_bytes(), PATCHED)
@@ -139,6 +142,39 @@ class SdkCompatibilityTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             compat.apply_sdk_patch(self.source.parent)
         self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_diagnostics_apply_from_clean_or_compatibility_only_and_are_idempotent(self):
+        compat.apply_sdk_patch(self.idf)
+        metadata = compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        self.assertEqual(compat.git(self.idf, "status", "--porcelain=v1", "-z"), compat.DIAGNOSTIC_STATUS)
+        self.assertEqual(metadata["diagnostic_patch"]["patched_source_sha256"],
+                         compat.digest((self.idf / compat.DIAGNOSTIC_SOURCE_PATH).read_bytes()))
+        self.assertEqual(compat.apply_sdk_patch(self.idf, nvs_diagnostics=True), metadata)
+        self.assertEqual(compat.verify_sdk_patch(self.idf, nvs_diagnostics=True), metadata)
+        with self.assertRaises(ValueError):
+            compat.verify_sdk_patch(self.idf)
+
+    def test_diagnostics_reject_wrong_base_dirt_and_tampering_before_mutation(self):
+        source = self.idf / compat.DIAGNOSTIC_SOURCE_PATH
+        original = source.read_bytes()
+        with patch.object(compat, "BASE_COMMIT", "0" * 40), self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        with patch.object(compat, "DIAGNOSTIC_PATCH_SHA256", "0" * 64), self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        source.write_bytes(original + b"\n")
+        with self.assertRaises(ValueError):
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        source.write_bytes(original)
+        metadata = compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        self.assertEqual(metadata["diagnostic_patch"]["base_commit"], self.base)
+        source.write_bytes(source.read_bytes() + b"\n")
+        for operation in (compat.apply_sdk_patch, compat.verify_sdk_patch):
+            with self.subTest(operation=operation.__name__), self.assertRaises(ValueError):
+                operation(self.idf, nvs_diagnostics=True)
+        (self.idf / "other.c").write_text("unrelated\n")
+        with self.assertRaises(ValueError):
+            compat.verify_sdk_patch(self.idf, nvs_diagnostics=True)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_nvs_diagnostics.py
+++ b/scripts/tests/test_nvs_diagnostics.py
@@ -1,0 +1,123 @@
+"""Execute the actual SDK/session owners against bounded I/O and logging stubs."""
+
+from pathlib import Path
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import idf_tab5_compat as compat
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).parent / "fixtures"
+HEADERS = {
+    "esp_attr.h": '#pragma once\n#define DRAM_ATTR\n#define DRAM_STR(s) (s)\n',
+    "esp_rom_sys.h": '#pragma once\nint esp_rom_printf(const char *format, ...);\n',
+    "esp_err.h": """#pragma once
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_FAIL -1
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_NVS_NOT_FOUND 0x1102
+static inline const char *esp_err_to_name(esp_err_t error) { (void)error; return "synthetic-error"; }
+""",
+    "esp_log.h": """#pragma once
+static inline void host_legacy_log(const char *format, ...) { (void)format; }
+#define ESP_LOGW(tag, ...) do { (void)(tag); host_legacy_log(__VA_ARGS__); } while (0)
+""",
+    "esp_check.h": """#pragma once
+#define ESP_RETURN_ON_ERROR(call, tag, ...) do { \\
+    (void)(tag); esp_err_t e = (call); if (e != ESP_OK) return e; \\
+} while (0)
+""",
+    "nvs.h": """#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+typedef unsigned nvs_handle_t;
+#define NVS_READWRITE 1
+esp_err_t nvs_open(const char *, int, nvs_handle_t *);
+void nvs_close(nvs_handle_t);
+esp_err_t nvs_get_u8(nvs_handle_t, const char *, uint8_t *);
+esp_err_t nvs_get_str(nvs_handle_t, const char *, char *, size_t *);
+esp_err_t nvs_set_u8(nvs_handle_t, const char *, uint8_t);
+esp_err_t nvs_set_str(nvs_handle_t, const char *, const char *);
+esp_err_t nvs_erase_key(nvs_handle_t, const char *);
+esp_err_t nvs_commit(nvs_handle_t);
+""",
+    "nvs_partition.hpp": """#pragma once
+#include <cstddef>
+#include <cstdint>
+#include "esp_err.h"
+#define ESP_ENCRYPT_BLOCK_SIZE 16
+struct esp_partition_t { const char *label; uint32_t address, size; bool readonly; };
+esp_err_t esp_partition_read_raw(const esp_partition_t *, size_t, void *, size_t);
+esp_err_t esp_partition_read(const esp_partition_t *, size_t, void *, size_t);
+esp_err_t esp_partition_write_raw(const esp_partition_t *, size_t, const void *, size_t);
+esp_err_t esp_partition_write(const esp_partition_t *, size_t, const void *, size_t);
+esp_err_t esp_partition_erase_range(const esp_partition_t *, size_t, size_t);
+namespace nvs {
+class NVSPartition {
+    const esp_partition_t *mESPPartition;
+public:
+    explicit NVSPartition(const esp_partition_t *);
+    const char *get_partition_name();
+    esp_err_t read_raw(size_t, void *, size_t);
+    esp_err_t read(size_t, void *, size_t);
+    esp_err_t write_raw(size_t, const void *, size_t);
+    esp_err_t write(size_t, const void *, size_t);
+    esp_err_t erase_range(size_t, size_t);
+    uint32_t get_address();
+    uint32_t get_size();
+    bool get_readonly();
+};
+}
+""",
+}
+
+
+class NvsDiagnosticsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temporary = tempfile.TemporaryDirectory(prefix="nvs-diagnostics-test-")
+        cls.addClassCleanup(cls.temporary.cleanup)
+        cls.root = Path(cls.temporary.name)
+        for name, content in HEADERS.items():
+            (cls.root / name).write_text(content)
+        original = (FIXTURES / "nvs_partition.cpp").read_bytes()
+        if compat.digest(original) != compat.DIAGNOSTIC_ORIGINAL_SHA256:
+            raise AssertionError("SDK fixture must be the exact pinned original")
+        source = cls.root / compat.DIAGNOSTIC_SOURCE_PATH
+        source.parent.mkdir(parents=True)
+        source.write_bytes(original)
+        subprocess.run(["git", "apply", str(compat.DIAGNOSTIC_PATCH_PATH)],
+                       cwd=cls.root, check=True)
+        if compat.digest(source.read_bytes()) != compat.DIAGNOSTIC_PATCHED_SHA256:
+            raise AssertionError("SDK fixture patch must produce the approved source")
+        common = ["-Wall", "-Wextra", "-Werror", "-I", str(cls.root)]
+        subprocess.run([os.environ.get("CXX", "c++"), "-std=c++11", "-pthread", *common,
+                        str(source), str(FIXTURES / "test_nvs_partition.cpp"),
+                        "-o", str(cls.root / "partition")], check=True)
+        node = ROOT / "components/esp-openclaw-node"
+        subprocess.run([os.environ.get("CC", "cc"), "-std=c11", "-D_POSIX_C_SOURCE=200809L",
+                        *common, "-I", str(node / "private_include"),
+                        str(node / "src/esp_openclaw_node_persisted_session.c"),
+                        str(FIXTURES / "test_nvs_session.c"),
+                        "-o", str(cls.root / "session")], check=True)
+
+    def test_partition_returns_alignment_and_concurrent_first_capture(self):
+        # Each process models a fresh boot and resets the private SDK latch naturally.
+        for scenario in ("1", "2", "3", "4", "5", "alignment-read", "alignment-write", "concurrent"):
+            with self.subTest(scenario=scenario):
+                subprocess.run([str(self.root / "partition"), scenario], check=True)
+
+    def test_session_original_errors_presence_clear_and_canary_privacy(self):
+        subprocess.run([str(self.root / "session")], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -133,11 +133,11 @@ class FirmwareBundleTests(unittest.TestCase):
         (self.build / "project_description.json").write_text(json.dumps(self.description))
         (self.build / "flasher_args.json").write_text(json.dumps(self.flash))
 
-    def package(self):
+    def package(self, nvs_diagnostics=False):
         self.write_metadata()
         return firmware.package_firmware(
             self.project, self.build, self.output, self.description["target"],
-            self.provenance, self.dependencies,
+            self.provenance, self.dependencies, nvs_diagnostics,
         )
 
     def test_relocated_bundle_preserves_every_image_and_original_inputs(self):
@@ -349,7 +349,7 @@ class FirmwareBundleTests(unittest.TestCase):
         metadata = json.loads((self.output / "manifest.json").read_text())["idf"]
         self.assertTrue(metadata["dirty"])
         self.assertEqual(metadata["commit"], base)
-        self.assertEqual(metadata["compatibility_patch"], expected)
+        self.assertEqual(metadata["compatibility_patch"], expected["compatibility_patch"])
         self.assertEqual(
             metadata["compatibility_patch"]["patched_source_sha256"],
             firmware.sha256(self.idf / compat.SOURCE_PATH),
@@ -383,6 +383,34 @@ class FirmwareBundleTests(unittest.TestCase):
             compat.apply_sdk_patch(self.idf)
             with self.assertRaisesRegex(ValueError, "IDF contains modified source"):
                 self.package()
+        self.assertFalse(self.output.exists())
+
+    def test_diagnostic_bundle_requires_explicit_mode_and_records_both_actual_patches(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            expected = compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            with self.assertRaises(ValueError):
+                self.package()
+            self.assertFalse(self.output.exists())
+            self.package(nvs_diagnostics=True)
+        metadata = json.loads((self.output / "manifest.json").read_text())["idf"]
+        self.assertTrue(metadata["dirty"])
+        self.assertEqual(metadata["commit"], base)
+        for name in ("compatibility_patch", "diagnostic_patch"):
+            self.assertEqual(metadata[name], expected[name])
+
+    def test_diagnostic_mode_rejects_clean_sdk_and_non_tab5(self):
+        with self.assertRaises(ValueError):
+            self.package(nvs_diagnostics=True)
+        self.configure_tab5()
+        with self.assertRaises(ValueError):
+            self.package(nvs_diagnostics=True)
+        base = seed_sdk(self.idf)
+        with fixture_profile(base):
+            compat.apply_sdk_patch(self.idf)
+            with self.assertRaises(ValueError):
+                self.package(nvs_diagnostics=True)
         self.assertFalse(self.output.exists())
 
 


### PR DESCRIPTION
## Problem

Saved-session absence can follow several different NVS outcomes. Existing
normalization and clearing paths do not expose the first underlying failure.
The cause remains unknown; this is diagnostic instrumentation, not a repair.

Stacked on https://github.com/openclaw/esp-openclaw-node/pull/43, base
`fix/tab5-psram-allocation-policy` at
`d4aae3f2f07f7d2f8a59b9df1b73c63849df6edd`.

## Changes

- Add a temporary, explicitly selected Tab5 SDK diagnostic patch. The five
  NVSPartition methods capture one failing result per boot, including existing
  alignment rejection, using a lock-free internal-RAM claim and heap-free ROM
  output after the operation returns.
- Record fixed numeric session-load role/stage/error/classification before
  normalization or clearing; record the clear result separately. Observe cached
  and fresh session presence during saved reconnect, and initial NVS init errors
  before the existing recovery path.
- Preserve original returns, no-I/O alignment behavior, session/cache ownership,
  clearing/recovery policy, and connection behavior. No retries, tasks, commands,
  persistent fields, or recovery fixes are added.
- Keep SDK base `362a1776ec212788fda95f75b733bfdde3a0c394`, the existing SPM patch
  bytes, allocation cutoff 1024, reserve 32768, and other configuration unchanged.
  This is ESP-IDF plus two tracked patches, not pristine ESP-IDF.
- Require explicit diagnostic mode for the exact two SDK source deltas.
  Firmware provenance records both patches and whole-source hashes; the separate
  symbol artifact copies the same manifest.

New diagnostic records contain only fixed labels and numeric fields, without
keys, lengths, offsets, URLs, IDs, tokens, or payloads. They are unprefixed ROM
lines; consumers must capture them before normal I/W/E filtering. Output can
interleave, and missing records do not establish healthy NVS. SDK instrumentation
is Tab5-only; session/init observations are in the existing shared components.

## Validation

- 12 SDK helper tests passed: exact-base/delta verification, refusal, and idempotence.
- 14 packaging tests passed; the local YAML-reader case is skipped and remains
  exercised inside the existing IDF CI environment.
- Host diagnostic tests passed against the actual patched SDK methods and actual
  session loader: original returns, alignment without I/O, concurrent single
  capture, missing/empty/unsupported/malformed sessions, clear failure, and
  synthetic canary non-disclosure.
- Added one cached-session retention regression to the existing target Unity
  suite. Target tests are built by CI, not executed here.
- Actionlint and `git diff --check` passed. Fresh independent scoped review
  through P2 reported no actionable findings.

- [CI run 34247823770, attempt 1](https://github.com/openclaw/esp-openclaw-node/actions/runs/34247823770)
  passed all five build jobs at head
  `c6d56b5dfa8718f5b7822919d0459824bf857336`, including the component test app
  and Waveshare host lifecycle/UI checks.
- The follow-up commit changes only three test files: mutable session fixture
  arrays and a format-checked host ROM-output shim. These correct the two initial
  CI failures without changing production code, SDK patches, or configuration.
  Focused review found no actionable issues. Full lifecycle execution was
  unavailable locally because managed dependencies were absent; CI ran it.

The earlier head `71febcbea6d88fb51e63720489e8267beff1e326` produced test-merge
image `3d22ae8616a34b670a5c947e25e9838caf8292dd` in
[run 34233725476](https://github.com/openclaw/esp-openclaw-node/actions/runs/34233725476).
Its Tab5 archive (artifact `10059256231`, SHA256
`17a2e5818161a7e24d41b98487d5d7399b3d5f191c9993e3251882d0273d2775`)
was checked against the API digest, all 11 file checksums, source-parent
linkage, four image offsets, unchanged configuration, and both exact SDK
patch records. Its flash ranges exclude NVS. The four images were subsequently
flashed and readback-verified on M5Stack Tab5.

That is historical-image evidence, not a claim that the latest tests-only head
was flashed. A subsequent SDIO receive-buffer assertion remains unresolved;
this diagnostic PR does not claim to repair it or qualify a complete Talk flow.
No JTAG or release was performed during that verification.

## Maintainer Disposition

On September 12, 2026, accept this bounded diagnostic change using its existing
source review, host regression tests, exact-head native builds, and the
historical-image evidence above. Target Unity fixtures were compiled, not
executed. First-failure instrumentation does not establish healthy NVS when no
record is observed, and this PR does not repair session loss or qualify voice.
The exact SDK refusal policy remains intact. Land with a merge commit and
retain the signed source objects; no release or new hardware test is implied.
