### PR TITLE
diag(tab5): capture SDIO allocation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,19 @@ jobs:
           path: ${{ matrix.path }}
           command: |
             nvs_diagnostics="" &&
+            sdio_diagnostics="" &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               nvs_diagnostics="--nvs-diagnostics" &&
+              sdio_diagnostics="--sdio-diagnostics" &&
               python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH" --nvs-diagnostics
             fi &&
             idf.py reconfigure &&
+            if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
+              python3 ../../scripts/tab5_sdio_diagnostics.py \
+                --project-path . --component-path managed_components/espressif__esp_hosted --build-path build &&
+              python3 -m unittest discover -s ../../scripts/tests -p test_tab5_sdio_diagnostics.py -v &&
+              python3 -m unittest discover -s ../../scripts/tests -p test_package_firmware.py -v
+            fi &&
             ninja -C build -j2 &&
             if [ "${{ matrix.name }}" = "component-test-app-build" ]; then
               python3 ../../../esp-openclaw-talk/tests/run_host_tests.py --sanitize &&
@@ -105,7 +113,7 @@ jobs:
                 --run-id "${{ github.run_id }}" \
                 --run-attempt "${{ github.run_attempt }}" \
                 --idf-image "espressif/idf:release-v5.5" \
-                $nvs_diagnostics
+                $nvs_diagnostics $sdio_diagnostics
             fi
 
       - name: Upload firmware

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -105,6 +105,69 @@ normal CI still builds the real SDK. Target Unity lifecycle tests are built,
 not run by CI. Remove this temporary diagnostic patch and its explicit
 packaging mode after the observed failure is identified and qualified.
 
+### SDIO allocation diagnostic build
+
+This branch also applies `patches/esp-hosted/tab5-sdio-first-allocation-failure.patch`
+to the registry `esp_hosted` 1.4.0 component at revision
+`6040085eefe908de68fcd3438bf10b8ecd6de0c6`. It observes the streaming RX buffer's
+first failed allocation; it is not a repair for the receive-buffer assertion.
+The allocator remains `esp_dma_capable_malloc` with 64-byte alignment and DMA
+capabilities. Existing assertions, block reads, counter advancement, task
+stacks, mempools, SDK patches and allocation configuration are unchanged.
+
+In an isolated configured project, explicitly apply the component patch
+after `idf.py reconfigure` and before normal Ninja:
+
+```sh
+python3 ../../scripts/tab5_sdio_diagnostics.py \
+  --project-path . --component-path managed_components/espressif__esp_hosted --build-path build
+ninja -C build -j2
+python3 ../../scripts/tab5_sdio_diagnostics.py \
+  --project-path . --component-path managed_components/espressif__esp_hosted --build-path build --verify-only
+```
+
+The helper requires the pinned lock identity, manifest/revision, whole component
+and source hashes, patch hash, and configured compile input. Verification checks
+actual bytes and permits exactly the selected patch, not arbitrary local edits.
+Do not rewrite component-manager integrity metadata or bypass a reconfiguration
+failure. Packaging additionally requires `--sdio-diagnostics` alongside
+`--nvs-diagnostics`; the separate `component_diagnostic_patch` manifest record
+identifies the modified component. The symbol artifact retains that same manifest.
+
+One unprefixed ROM line has this exact field order, with decimal integers and
+no trailing period:
+
+```text
+sdio_alloc_diag requested=%u padded=%u buffer_index=%d old_size=%u dma_free=%u dma_largest=%u reg_raw=%u reg_masked=%u rx_count=%u last_seen=%u last_err=%d last_logical_len=%u last_transfer_arg_len=%u last_counter=%u
+```
+
+`requested` and `padded` describe the current allocation before/after existing
+block padding. `buffer_index` and `old_size` describe the previous write buffer.
+`dma_free` and `dma_largest` are DMA heap samples after allocation failure,
+not a proof that an aligned allocation would fit. `reg_raw`, `reg_masked`,
+and `rx_count` are the current packet-length register, its masked value,
+and local RX byte counter.
+
+The remaining fields retain the last failed block read this boot. `last_seen`
+is 0/1; when zero, its other fields are unset zeros. `last_err` is the original
+return. `last_logical_len` is the original pending length used by the unchanged
+counter-advance policy. `last_transfer_arg_len` is the actual `uint16_t` argument
+after the existing padding and conversion, not the pre-conversion padded value.
+`last_counter` is the local counter before that read's advancement. Successful
+reads do not clear this record. None of these lengths measures bytes consumed.
+All unsigned fields are uint32 values except the uint16 transfer argument
+and boolean `last_seen`; buffer index and error are signed int32 values.
+
+The probe does not log payloads, addresses, IDs, URLs, credentials, or normal
+successful frames. The RX owner retains its existing driver mutex, samples
+heap information after allocation returns, and prints after heap queries
+release their locks. Absence of a record is not evidence of healthy transport.
+Helper and packaging tests exercise real component hashing and rejection
+boundaries. CI builds the actual driver but does not execute an SDIO
+allocation-failure fixture. Hardware failure capture remains a separate
+qualification step; remove this temporary patch and packaging mode after
+the cause is identified and a repair is qualified.
+
 The official BSP manifest pins `esp_video ~2.0`, while P4-capable
 `esp_capture` requires `esp_video ^2.1`. The source-only BSP build bridge uses
 exact inspected commit `f0ef9497efce684997ce391edd19733483e250a5` without

--- a/patches/esp-hosted/tab5-sdio-first-allocation-failure.patch
+++ b/patches/esp-hosted/tab5-sdio-first-allocation-failure.patch
@@ -1,0 +1,78 @@
+--- a/host/drivers/transport/sdio/sdio_drv.c
++++ b/host/drivers/transport/sdio/sdio_drv.c
+@@ -24,6 +24,9 @@
+ #include "hci_drv.h"
+ #include "endian.h"
+ #include "esp_hosted_transport_init.h"
++#include "esp_attr.h"
++#include "esp_heap_caps.h"
++#include "esp_rom_sys.h"
+ 
+ static const char TAG[] = "H_SDIO_DRV";
+ 
+@@ -648,10 +651,21 @@
+ 	return ESP_OK;
+ }
+ #else // H_SDIO_HOST_STREAMING_MODE
++/* Only the RX task accesses this diagnostic state, under the driver mutex. */
++static DRAM_ATTR struct {
++	bool seen;
++	int err;
++	uint32_t logical_len;
++	uint16_t transfer_arg_len;
++	uint32_t counter_before_advance;
++} sdio_last_failed_read;
++static DRAM_ATTR bool sdio_alloc_reported;
++
+ // SDIO streaming mode
+ // return a buffer big enough to contain the data
+ static uint8_t * sdio_rx_get_buffer(uint32_t len)
+ {
++	uint32_t requested_len = len;
+ #if H_SDIO_RX_BLOCK_ONLY_XFER
+ 	// we need to allocate enough memory to hold the padded data
+ 	len = ((len + ESP_BLOCK_SIZE - 1) / ESP_BLOCK_SIZE) * ESP_BLOCK_SIZE;
+@@ -667,6 +681,25 @@
+ 			g_h.funcs->_h_free(*buf);
+ 		}
+ 		*buf = (uint8_t *)MEM_ALLOC(len);
++		if (!*buf && !sdio_alloc_reported) {
++			sdio_alloc_reported = true;
++			multi_heap_info_t info;
++			uint32_t reg_raw;
++			memcpy(&reg_raw, &reg_buf[PACKET_LEN_INDEX], sizeof(reg_raw));
++			heap_caps_get_info(&info, MALLOC_CAP_DMA);
++			esp_rom_printf(DRAM_STR(
++				"sdio_alloc_diag requested=%u padded=%u buffer_index=%d old_size=%u "
++				"dma_free=%u dma_largest=%u reg_raw=%u reg_masked=%u rx_count=%u "
++				"last_seen=%u last_err=%d last_logical_len=%u last_transfer_arg_len=%u last_counter=%u\n"),
++				(unsigned)requested_len, (unsigned)len, index,
++				(unsigned)double_buf.buffer[index].buf_size,
++				(unsigned)info.total_free_bytes, (unsigned)info.largest_free_block,
++				(unsigned)reg_raw, (unsigned)(reg_raw & ESP_SLAVE_LEN_MASK),
++				(unsigned)sdio_rx_byte_count, (unsigned)sdio_last_failed_read.seen,
++				sdio_last_failed_read.err, (unsigned)sdio_last_failed_read.logical_len,
++				(unsigned)sdio_last_failed_read.transfer_arg_len,
++				(unsigned)sdio_last_failed_read.counter_before_advance);
++		}
+ 		assert(*buf);
+ 		double_buf.buffer[index].buf_size = len;
+ 		ESP_LOGD(TAG, "buf %d size: %ld", index, double_buf.buffer[index].buf_size);
+@@ -898,6 +931,17 @@
+ 					pos, len_to_read, ACQUIRE_LOCK);
+ #endif
+ 			if (ret) {
++#if H_SDIO_HOST_RX_MODE == H_SDIO_HOST_STREAMING_MODE
++				sdio_last_failed_read.seen = true;
++				sdio_last_failed_read.err = ret;
++				sdio_last_failed_read.logical_len = len_from_slave;
++#if H_SDIO_RX_BLOCK_ONLY_XFER
++				sdio_last_failed_read.transfer_arg_len = (uint16_t)block_read_len;
++#else
++				sdio_last_failed_read.transfer_arg_len = (uint16_t)len_to_read;
++#endif
++				sdio_last_failed_read.counter_before_advance = sdio_rx_byte_count;
++#endif
+ 				ESP_LOGE(TAG, "%s: Failed to read data - %d %ld %ld",
+ 					__func__, ret, len_to_read, data_left);
+ 				sdio_rx_free_buffer(rxbuff);

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -16,6 +16,7 @@ import tempfile
 from urllib.parse import urlsplit
 
 from idf_tab5_compat import verify_sdk_patch
+from tab5_sdio_diagnostics import COMPONENT as SDIO_COMPONENT, verify_component_patch
 
 
 EXAMPLES = {
@@ -162,7 +163,8 @@ def tab5_provenance(project, build):
     }
 
 
-def package_firmware(project, build, output, target, provenance, dependencies, nvs_diagnostics=False):
+def package_firmware(project, build, output, target, provenance, dependencies,
+                     nvs_diagnostics=False, sdio_diagnostics=False):
     project, build, output = project.resolve(), build.resolve(), output.resolve()
     repo = Path(git(project, "rev-parse", "--show-toplevel")).resolve()
     if project.parent != repo / "examples" or EXAMPLES.get(project.name) != target:
@@ -201,6 +203,16 @@ def package_firmware(project, build, output, target, provenance, dependencies, n
         idf_compatibility = verify_sdk_patch(idf, nvs_diagnostics)
     if not dependencies.get("dependencies"):
         raise ValueError("Resolved dependency lock is empty")
+    sdio_patch = None
+    if sdio_diagnostics and (project.name != "m5stack-tab5-room-node" or not nvs_diagnostics):
+        raise ValueError("SDIO diagnostics require the explicitly selected Tab5 diagnostic build")
+    if sdio_diagnostics or (
+            project.name == "m5stack-tab5-room-node"
+            and SDIO_COMPONENT in dependencies["dependencies"]):
+        sdio_patch = verify_component_patch(
+            project, project / "managed_components/espressif__esp_hosted",
+            build, dependencies, patched=sdio_diagnostics,
+        )
     normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
     lock_file = checked_file(project / "dependencies.lock", roots)
     manifest = {
@@ -234,6 +246,8 @@ def package_firmware(project, build, output, target, provenance, dependencies, n
     }
     if idf_compatibility is not None:
         manifest["idf"].update(idf_compatibility)
+    if sdio_diagnostics:
+        manifest["component_diagnostic_patch"] = sdio_patch
     if project.name == "m5stack-tab5-room-node":
         manifest["tab5_bsp"] = tab5_provenance(project, build)
     extra = flash["extra_esptool_args"]
@@ -341,10 +355,12 @@ def main():
         parser.add_argument("--" + name, required=True)
     parser.add_argument("--pr-head-sha", default="")
     parser.add_argument("--nvs-diagnostics", action="store_true")
+    parser.add_argument("--sdio-diagnostics", action="store_true")
     args = parser.parse_args()
     provenance = vars(args).copy()
     provenance.pop("target")
     provenance.pop("nvs_diagnostics")
+    provenance.pop("sdio_diagnostics")
     project = Path.cwd()
     # ruamel.yaml is already part of ESP-IDF's component-manager environment.
     try:
@@ -355,7 +371,7 @@ def main():
         dependencies = read_dependency_lock(project / "dependencies.lock")
         output = package_firmware(
             project, project / "build", project / "build/firmware",
-            args.target, provenance, dependencies, args.nvs_diagnostics,
+            args.target, provenance, dependencies, args.nvs_diagnostics, args.sdio_diagnostics,
         )
     except ValueError as error:
         parser.exit(1, f"Firmware packaging failed: {error}\n")

--- a/scripts/tab5_sdio_diagnostics.py
+++ b/scripts/tab5_sdio_diagnostics.py
@@ -49,7 +49,7 @@ def inspect_component(project, component, build, dependencies):
             or dependency.get("version") != VERSION
             or dependency.get("component_hash") != COMPONENT_HASH
             or source.get("type") != "service"
-            or source.get("service_url") != "https://components.espressif.com/"):
+            or source.get("registry_url") != "https://components.espressif.com/"):
         raise ValueError("Resolved esp_hosted identity is not the approved 1.4.0 component")
     if digest((component / "idf_component.yml").read_bytes()) != MANIFEST_SHA256:
         raise ValueError("Component manifest or registry revision differs")

--- a/scripts/tab5_sdio_diagnostics.py
+++ b/scripts/tab5_sdio_diagnostics.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Apply or verify the pinned Tab5 SDIO probe after IDF configuration."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+
+COMPONENT = "espressif/esp_hosted"
+VERSION = "1.4.0"
+REVISION = "6040085eefe908de68fcd3438bf10b8ecd6de0c6"
+COMPONENT_HASH = "ef6bc803451fab3c3f9a679bbc1c48fba0ceeeabc5af4178dd7d2300fafa423e"
+PATCHED_COMPONENT_HASH = "cd2679547dfbc73f0d71d526fb5f42b6814c92f270acdc76e485118663ff6241"
+MANIFEST_SHA256 = "eb3cad8e876545eb28684e2648e83f73645bce7a260123776f36dff2efbe8027"
+SOURCE_PATH = "host/drivers/transport/sdio/sdio_drv.c"
+ORIGINAL_SHA256 = "9868f97b7c68e5d8f1a3ac904dc6922b8ba0cc160c28c6a1402cd5c4147a652a"
+PATCHED_SHA256 = "5d3772ff65d6aeb837019adc4f03513ed766e045101d1b225cb80d17d66cc986"
+PATCH_RELATIVE = "patches/esp-hosted/tab5-sdio-first-allocation-failure.patch"
+PATCH_PATH = Path(__file__).resolve().parents[1] / PATCH_RELATIVE
+PATCH_SHA256 = "430b99399fc6ab7d9d624855c1dd80ef3f8c3739776480ceae2dedeb1cc91f84"
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def inspect_component(project, component, build, dependencies):
+    project = Path(project).resolve(strict=True)
+    component = Path(component).absolute()
+    build = Path(build).resolve(strict=True)
+    expected = project / "managed_components/espressif__esp_hosted"
+    if (project.name != "m5stack-tab5-room-node" or project.parent.name != "examples"
+            or component != expected or component.resolve(strict=True) != expected
+            or not build.is_relative_to(project)):
+        raise ValueError("Select the configured Tab5 project and its managed component")
+    for path in component.rglob("*"):
+        if path.is_symlink():
+            raise ValueError("Managed component must not contain symbolic links")
+    if (not isinstance(dependencies, dict)
+            or not isinstance(dependencies.get("dependencies"), dict)):
+        raise ValueError("Dependency lock must contain a dependency mapping")
+    dependency = dependencies["dependencies"].get(COMPONENT, {})
+    if not isinstance(dependency, dict) or not isinstance(dependency.get("source"), dict):
+        raise ValueError("Resolved component must contain a registry source")
+    source = dependency.get("source", {})
+    if (dependencies.get("target") != "esp32p4"
+            or dependency.get("version") != VERSION
+            or dependency.get("component_hash") != COMPONENT_HASH
+            or source.get("type") != "service"
+            or source.get("service_url") != "https://components.espressif.com/"):
+        raise ValueError("Resolved esp_hosted identity is not the approved 1.4.0 component")
+    if digest((component / "idf_component.yml").read_bytes()) != MANIFEST_SHA256:
+        raise ValueError("Component manifest or registry revision differs")
+    if (PATCH_PATH.is_symlink()
+            or digest(PATCH_PATH.read_bytes()) != PATCH_SHA256):
+        raise ValueError("Tracked SDIO patch has unexpected contents")
+    commands = json.loads((build / "compile_commands.json").read_text())
+    compiled_sources = []
+    for command in commands:
+        filename = Path(command["file"])
+        if filename.name == "sdio_drv.c":
+            compiled_sources.append((Path(command["directory"]) / filename).resolve(strict=True))
+    if compiled_sources != [component / SOURCE_PATH]:
+        raise ValueError("Build must compile exactly the verified SDIO source")
+    return component, digest((component / SOURCE_PATH).read_bytes())
+
+
+def validate_component_hash(component, expected):
+    # Use the same manifest-aware hashing as the resolved IDF component manager.
+    from idf_component_tools.errors import ProcessingError
+    from idf_component_tools.hash_tools.errors import ValidatingHashError
+    from idf_component_tools.hash_tools.validate import (
+        validate_hash_eq_hashdir,
+        validate_hash_eq_hashfile,
+    )
+    try:
+        validate_hash_eq_hashfile(component, COMPONENT_HASH)
+        validate_hash_eq_hashdir(component, expected)
+    except (ProcessingError, ValidatingHashError) as error:
+        raise ValueError("Managed component bytes do not match the selected profile") from error
+
+
+def verify_component_patch(project, component, build, dependencies, patched=True):
+    component, source_hash = inspect_component(project, component, build, dependencies)
+    expected_source = PATCHED_SHA256 if patched else ORIGINAL_SHA256
+    expected_component = PATCHED_COMPONENT_HASH if patched else COMPONENT_HASH
+    if source_hash != expected_source:
+        raise ValueError("SDIO source does not match the explicitly selected profile")
+    validate_component_hash(component, expected_component)
+    if not patched:
+        return {"component": COMPONENT, "version": VERSION, "modified": False}
+    return {
+        "component": COMPONENT,
+        "version": VERSION,
+        "registry_revision": REVISION,
+        "registry_path": ".",
+        "original_component_hash": COMPONENT_HASH,
+        "modified": patched,
+        "patch": PATCH_RELATIVE,
+        "patch_sha256": PATCH_SHA256,
+        "source": SOURCE_PATH,
+        "original_source_sha256": ORIGINAL_SHA256,
+        "patched_source_sha256": source_hash,
+        "patched_component_hash": expected_component,
+    }
+
+
+def apply_component_patch(project, component, build, dependencies):
+    component, source_hash = inspect_component(project, component, build, dependencies)
+    if source_hash == PATCHED_SHA256:
+        return verify_component_patch(project, component, build, dependencies)
+    verify_component_patch(project, component, build, dependencies, patched=False)
+    subprocess.run(["git", "apply", "--check", str(PATCH_PATH)], cwd=component, check=True)
+    subprocess.run(["git", "apply", str(PATCH_PATH)], cwd=component, check=True)
+    return verify_component_patch(project, component, build, dependencies)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-path", type=Path, required=True)
+    parser.add_argument("--component-path", type=Path, required=True)
+    parser.add_argument("--build-path", type=Path, required=True)
+    parser.add_argument("--verify-only", action="store_true")
+    args = parser.parse_args()
+    try:
+        from ruamel.yaml import YAML
+        from ruamel.yaml.error import YAMLError
+    except ImportError:
+        parser.exit(1, "Run this helper in the configured ESP-IDF Python environment.\n")
+    try:
+        dependencies = YAML(typ="safe").load(
+            (args.project_path / "dependencies.lock").read_text()
+        )
+        operation = verify_component_patch if args.verify_only else apply_component_patch
+        result = operation(args.project_path, args.component_path, args.build_path, dependencies)
+    except (ValueError, TypeError, KeyError, OSError, ImportError,
+            YAMLError, subprocess.CalledProcessError):
+        parser.exit(1, "SDIO diagnostic patch refused: verify the pinned component and build inputs.\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -19,6 +19,8 @@ SCRIPT = Path(__file__).resolve().parents[1] / "package_firmware.py"
 sys.path.insert(0, str(SCRIPT.parent))
 from test_idf_tab5_compat import fixture_profile, seed_sdk
 import idf_tab5_compat as compat
+from test_tab5_sdio_diagnostics import HAS_MANAGER, component_fixture
+import tab5_sdio_diagnostics as sdio
 
 SPEC = importlib.util.spec_from_file_location("package_firmware", SCRIPT)
 firmware = importlib.util.module_from_spec(SPEC)
@@ -133,11 +135,11 @@ class FirmwareBundleTests(unittest.TestCase):
         (self.build / "project_description.json").write_text(json.dumps(self.description))
         (self.build / "flasher_args.json").write_text(json.dumps(self.flash))
 
-    def package(self, nvs_diagnostics=False):
+    def package(self, nvs_diagnostics=False, sdio_diagnostics=False):
         self.write_metadata()
         return firmware.package_firmware(
             self.project, self.build, self.output, self.description["target"],
-            self.provenance, self.dependencies, nvs_diagnostics,
+            self.provenance, self.dependencies, nvs_diagnostics, sdio_diagnostics,
         )
 
     def test_relocated_bundle_preserves_every_image_and_original_inputs(self):
@@ -411,6 +413,48 @@ class FirmwareBundleTests(unittest.TestCase):
             compat.apply_sdk_patch(self.idf)
             with self.assertRaises(ValueError):
                 self.package(nvs_diagnostics=True)
+        self.assertFalse(self.output.exists())
+
+    @unittest.skipUnless(HAS_MANAGER, "actual component hashing runs in the IDF environment")
+    def test_sdio_profile_is_explicit_and_records_actual_component_and_sdk_patches(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base), component_fixture(
+                self.project, self.build, self.dependencies) as component:
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            expected = sdio.apply_component_patch(
+                self.project, component, self.build, self.dependencies,
+            )
+            with self.assertRaises(ValueError):
+                self.package(nvs_diagnostics=True)
+            self.assertFalse(self.output.exists())
+            self.package(nvs_diagnostics=True, sdio_diagnostics=True)
+            manifest = json.loads((self.output / "manifest.json").read_text())
+            self.assertEqual(manifest["component_diagnostic_patch"], expected)
+            self.assertEqual(manifest["idf"]["commit"], base)
+            self.assertTrue(manifest["idf"]["dirty"])
+            self.assertIn("compatibility_patch", manifest["idf"])
+            self.assertIn("diagnostic_patch", manifest["idf"])
+
+    @unittest.skipUnless(HAS_MANAGER, "actual component hashing runs in the IDF environment")
+    def test_sdio_profile_rejects_tampered_component_without_uploadable_output(self):
+        self.configure_tab5()
+        base = seed_sdk(self.idf)
+        with fixture_profile(base), component_fixture(
+                self.project, self.build, self.dependencies) as component:
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            sdio.apply_component_patch(self.project, component, self.build, self.dependencies)
+            (component / "other.c").write_text("/* Unexpected edit. */\n")
+            with self.assertRaises(ValueError):
+                self.package(nvs_diagnostics=True, sdio_diagnostics=True)
+            self.assertFalse(self.output.exists())
+
+    def test_sdio_mode_rejects_other_examples_and_missing_nvs_profile(self):
+        with self.assertRaises(ValueError):
+            self.package(sdio_diagnostics=True)
+        self.configure_tab5()
+        with self.assertRaises(ValueError):
+            self.package(sdio_diagnostics=True)
         self.assertFalse(self.output.exists())
 
 

--- a/scripts/tests/test_tab5_sdio_diagnostics.py
+++ b/scripts/tests/test_tab5_sdio_diagnostics.py
@@ -1,0 +1,208 @@
+"""Exercise the component patch boundary using the actual IDF hash API."""
+
+from contextlib import contextmanager
+import copy
+import difflib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import tab5_sdio_diagnostics as sdio
+
+HAS_MANAGER = importlib.util.find_spec("idf_component_tools") is not None
+ORIGINAL = b"/* Synthetic component fixture, not a transport simulator. */\nint fixture;\n"
+PATCHED = ORIGINAL + b"/* Diagnostic fixture change. */\n"
+
+
+def directory_hash(component):
+    from idf_component_tools.hash_tools.calculate import hash_dir
+    from idf_component_tools.manager import ManifestManager
+    manifest = ManifestManager(component, "test").load()
+    return hash_dir(
+        component, use_gitignore=manifest.use_gitignore,
+        include=manifest.include_set,
+        exclude=set(manifest.exclude_set) | {"**/.component_hash", "**/CHECKSUMS.json"},
+        exclude_default=False,
+    )
+
+
+@contextmanager
+def component_fixture(project, build, dependencies):
+    component = project / "managed_components/espressif__esp_hosted"
+    source = component / sdio.SOURCE_PATH
+    source.parent.mkdir(parents=True)
+    source.write_bytes(ORIGINAL)
+    (component / "other.c").write_text("/* Unrelated component source. */\n")
+    manifest = component / "idf_component.yml"
+    manifest.write_text(json.dumps({
+        "version": sdio.VERSION,
+        "repository": "git://github.com/espressif/esp-hosted-mcu.git",
+        "repository_info": {"commit_sha": sdio.REVISION, "path": "."},
+        "dependencies": {"idf": ">=5.3"},
+    }))
+    original_hash = directory_hash(component)
+    (component / ".component_hash").write_text(original_hash)
+    source.write_bytes(PATCHED)
+    patched_hash = directory_hash(component)
+    source.write_bytes(ORIGINAL)
+    patch_file = build / "fixture.patch"
+    patch_file.write_text("".join(difflib.unified_diff(
+        ORIGINAL.decode().splitlines(keepends=True),
+        PATCHED.decode().splitlines(keepends=True),
+        fromfile="a/" + sdio.SOURCE_PATH, tofile="b/" + sdio.SOURCE_PATH,
+    )))
+    (build / "compile_commands.json").write_text(json.dumps([{
+        "directory": str(build), "file": str(source), "command": "cc -c fixture.c",
+    }]))
+    dependencies["target"] = "esp32p4"
+    dependencies.setdefault("dependencies", {})[sdio.COMPONENT] = {
+        "version": sdio.VERSION, "component_hash": original_hash,
+        "source": {"type": "service", "service_url": "https://components.espressif.com/"},
+    }
+    with patch.multiple(
+        sdio, COMPONENT_HASH=original_hash, PATCHED_COMPONENT_HASH=patched_hash,
+        MANIFEST_SHA256=sdio.digest(manifest.read_bytes()),
+        ORIGINAL_SHA256=sdio.digest(ORIGINAL), PATCHED_SHA256=sdio.digest(PATCHED),
+        PATCH_PATH=patch_file, PATCH_SHA256=sdio.digest(patch_file.read_bytes()),
+    ):
+        yield component
+
+
+@unittest.skipUnless(HAS_MANAGER, "requires the real IDF component-manager environment")
+class SdioPatchTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="sdio-patch-test-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        self.project = self.root / "examples/m5stack-tab5-room-node"
+        self.build = self.project / "build"
+        self.build.mkdir(parents=True)
+        # Exercise git apply inside a real repository, as in CI's managed directory.
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+        self.dependencies = {}
+        context = component_fixture(self.project, self.build, self.dependencies)
+        self.component = context.__enter__()
+        self.addCleanup(context.__exit__, None, None, None)
+        self.source = self.component / sdio.SOURCE_PATH
+
+    def apply(self):
+        return sdio.apply_component_patch(
+            self.project, self.component, self.build, self.dependencies,
+        )
+
+    def verify(self, patched=True):
+        return sdio.verify_component_patch(
+            self.project, self.component, self.build, self.dependencies, patched=patched,
+        )
+
+    def test_apply_idempotence_and_metadata_preserve_unrelated_bytes(self):
+        before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}
+        metadata = self.apply()
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+        self.assertTrue(metadata["modified"])
+        self.assertEqual(metadata["patched_source_sha256"], sdio.digest(PATCHED))
+        self.assertEqual(metadata["patched_component_hash"], directory_hash(self.component))
+        self.assertEqual(metadata["patch_sha256"], sdio.digest(sdio.PATCH_PATH.read_bytes()))
+        self.assertEqual(self.apply(), metadata)
+        self.assertEqual(self.verify(), metadata)
+        for path, data in before.items():
+            if path != self.source:
+                self.assertEqual(path.read_bytes(), data)
+
+    def test_verify_never_applies_and_unpatched_mode_rejects_patch(self):
+        with self.assertRaises(ValueError):
+            self.verify()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.assertFalse(self.verify(patched=False)["modified"])
+        self.apply()
+        with self.assertRaises(ValueError):
+            self.verify(patched=False)
+
+    def test_wrong_or_malformed_lock_refuses_before_mutation(self):
+        original = copy.deepcopy(self.dependencies)
+        cases = (
+            [],
+            {"target": "esp32p4", "dependencies": []},
+            {**original, "target": "esp32s3"},
+        )
+        for value in cases:
+            with self.subTest(value=value):
+                self.dependencies = value
+                with self.assertRaises(ValueError):
+                    self.apply()
+        for key, value in (("version", "2.6.0"), ("component_hash", "0" * 64),
+                           ("source", {"type": "git"}), ("source", [])):
+            self.dependencies = copy.deepcopy(original)
+            self.dependencies["dependencies"][sdio.COMPONENT][key] = value
+            with self.subTest(key=key, value=value), self.assertRaises(ValueError):
+                self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_unrelated_changes_and_extra_source_are_rejected(self):
+        other = self.component / "other.c"
+        other.write_text("/* Unexpected edit. */\n")
+        with self.assertRaises(ValueError):
+            self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        other.write_text("/* Unrelated component source. */\n")
+        extra = self.component / "extra.c"
+        extra.write_text("/* Unexpected file. */\n")
+        with self.assertRaises(ValueError):
+            self.apply()
+        self.assertTrue(extra.exists())
+
+    def test_patch_manifest_and_source_tampering_are_rejected(self):
+        for name in ("PATCH_SHA256", "MANIFEST_SHA256", "ORIGINAL_SHA256"):
+            with self.subTest(name=name), patch.object(sdio, name, "0" * 64):
+                with self.assertRaises(ValueError):
+                    self.apply()
+                self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.apply()
+        self.source.write_bytes(PATCHED + b"/* unrelated */\n")
+        with self.assertRaises(ValueError):
+            self.apply()
+        with self.assertRaises(ValueError):
+            self.verify()
+
+    def test_hash_marker_alone_cannot_authorize_changed_bytes(self):
+        self.source.write_bytes(PATCHED)
+        (self.component / "other.c").write_text("/* hidden modification */\n")
+        with self.assertRaises(ValueError):
+            self.verify()
+        (self.component / ".component_hash").write_text(sdio.PATCHED_COMPONENT_HASH)
+        with self.assertRaises(ValueError):
+            self.verify()
+
+    def test_symbolic_links_and_wrong_component_root_are_rejected(self):
+        extra = self.component / "link.c"
+        extra.symlink_to(self.source)
+        with self.assertRaises(ValueError):
+            self.apply()
+        extra.unlink()
+        with self.assertRaises(ValueError):
+            sdio.apply_component_patch(
+                self.project, self.component.parent, self.build, self.dependencies,
+            )
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_compile_input_must_select_only_the_verified_source(self):
+        commands = self.build / "compile_commands.json"
+        original = json.loads(commands.read_text())
+        wrong = self.root / "sdio_drv.c"
+        wrong.write_bytes(ORIGINAL)
+        for entries in ([], original * 2, [{**original[0], "file": str(wrong)}]):
+            commands.write_text(json.dumps(entries))
+            with self.subTest(entries=len(entries)), self.assertRaises(ValueError):
+                self.apply()
+            self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_tab5_sdio_diagnostics.py
+++ b/scripts/tests/test_tab5_sdio_diagnostics.py
@@ -19,6 +19,10 @@ import tab5_sdio_diagnostics as sdio
 HAS_MANAGER = importlib.util.find_spec("idf_component_tools") is not None
 ORIGINAL = b"/* Synthetic component fixture, not a transport simulator. */\nint fixture;\n"
 PATCHED = ORIGINAL + b"/* Diagnostic fixture change. */\n"
+REGISTRY_SOURCE = {
+    "type": "service",
+    "registry_url": "https://components.espressif.com/",
+}
 
 
 def directory_hash(component):
@@ -64,7 +68,7 @@ def component_fixture(project, build, dependencies):
     dependencies["target"] = "esp32p4"
     dependencies.setdefault("dependencies", {})[sdio.COMPONENT] = {
         "version": sdio.VERSION, "component_hash": original_hash,
-        "source": {"type": "service", "service_url": "https://components.espressif.com/"},
+        "source": copy.deepcopy(REGISTRY_SOURCE),
     }
     with patch.multiple(
         sdio, COMPONENT_HASH=original_hash, PATCHED_COMPONENT_HASH=patched_hash,
@@ -101,6 +105,20 @@ class SdioPatchTests(unittest.TestCase):
         return sdio.verify_component_patch(
             self.project, self.component, self.build, self.dependencies, patched=patched,
         )
+
+    def test_registry_source_matches_pinned_manager_lock_contract(self):
+        from idf_component_tools.sources.web_service import WebServiceSource
+        source = WebServiceSource(registry_url="https://components.espressif.com/")
+        self.assertEqual(source.model_dump(), REGISTRY_SOURCE)
+        self.assertFalse(self.verify(patched=False)["modified"])
+
+    def test_service_url_only_source_is_rejected_before_mutation(self):
+        self.dependencies["dependencies"][sdio.COMPONENT]["source"] = {
+            "type": "service", "service_url": "https://components.espressif.com/",
+        }
+        with self.assertRaisesRegex(ValueError, "Resolved esp_hosted identity"):
+            self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
 
     def test_apply_idempotence_and_metadata_preserve_unrelated_bytes(self):
         before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}


### PR DESCRIPTION
## Problem

A Tab5 streaming RX assertion in `sdio_rx_get_buffer` does not preserve the
allocation request and preceding block-read state needed to distinguish the
failure's cause. This PR adds diagnostic instrumentation, not a root-cause fix.

Originally stacked on https://github.com/openclaw/esp-openclaw-node/pull/44,
now merged. The landing branch also preserves the qualified Tab5 image from
https://github.com/openclaw/esp-openclaw-node/pull/57.

## Changes

- Add one pinned `esp_hosted` 1.4.0 source patch. On the first failed streaming
  buffer allocation, emit a fixed numeric ROM record before the original
  assertion, including request/padding, buffer capacity, DMA heap samples,
  register/counter values, and the last failed block read.
- Keep the prior read's logical pending length separate from its actual
  `uint16_t` transfer argument after the existing padding/conversion. Neither
  is a bytes-consumed measurement; later successful reads retain the last error.
- Apply explicitly after IDF configuration in the isolated Tab5 CI container.
  Validate registry identity, whole-component/source/patch hashes and compile
  input before application and packaging. Reject unrelated changes and missing
  diagnostic opt-in; never rewrite component-manager integrity metadata.
- Record modified-component provenance separately from the existing two SDK
  patches. Firmware and retained ELF/map artifacts share the same manifest.

No payloads, addresses, IDs, credentials, or normal-frame output are added.
Allocation mode, task stacks, mempools, assertions, block-read calls, counter
advancement, SDK base/patches, and configuration remain unchanged. Normal Ninja
must succeed; component-manager failures are not bypassed.

## Validation

- 10 helper tests and 18 packaging tests passed with the actual component-manager
  2.5.2 hash API, including tampering, identity, opt-in, and idempotence cases.
- The helper now requires the canonical lock key `registry_url`, as emitted by
  manager 2.5.2 and present in a previously verified firmware artifact. Regression
  tests failed before the correction and passed after it; `service_url`-only
  input is rejected. Pin, URL value, hash, and path checks are unchanged.
- The real pinned archive was patched and verified twice; only `sdio_drv.c`
  changed. It also verifies using the previously verified artifact's unchanged
  dependency lock. These checks use a synthetic compile-input fixture, not a
  native build.
- Independent runtime-source preservation review passed. The matching parser
  passed 6 SDIO cases and 4 NVS sibling cases.
- Initial full-diff P2 review passed with no findings. Focused correction review
  completed; its optional-dependency finding was rejected because the existing
  class-wide skip guard remains effective, confirmed by all 10 tests skipping
  cleanly without the manager.
- Actionlint and code/docs `git diff --check` passed. The generated patch passes
  `git apply --check --whitespace=error-all`; raw staged diff checking flags its
  normal unified-diff context prefixes, not whitespace added to driver source.

The initial CI run completed four jobs successfully. Tab5 reconfiguration
succeeded, then the patch helper refused before Ninja and artifact upload.
The caught exception was not exposed by the log; the independently reproduced
lock-key bug is not claimed to be the only possible cause of that refusal.

The corrected exact-head [CI run](https://github.com/openclaw/esp-openclaw-node/actions/runs/34255245428)
passed all five jobs. Only the Tab5 firmware archive was downloaded: GitHub's
archive digest, all 11 checksum entries, four flash images, and the SDK and
managed-component patch provenance were verified. Configuration and partition
table match the previous verified image; the four image erase ranges exclude
NVS. Compiled test-merge `7e6747a93d95c8905aa072cb8f86cad7f5720e4e`
has the expected base/head parents and matches PR head
`405bb8b81c756983b4e412453ed20479590923d6`'s tree. The actual SDK remains
`v5.5.5-648-g362a1776ec2-dirty` with the two existing tracked SDK patches,
not pristine release 5.5.5. Symbols were retained by CI but not downloaded
or ELF-matched in this verification.

There is no executable SDIO allocation-failure fixture in this repository, and
CI compilation is not runtime fault-injection proof.

## Subsequent Bounded Hardware Evidence

The matched `7e6747a` image was subsequently flashed and the first failed
streaming-RX allocation record was retained before the assertion. It reported
a 6024-byte request, 6144-byte padded allocation, 10915 bytes free in the DMA
heap, and a 3072-byte largest DMA block. No prior failed block read was recorded
in that event. This demonstrates one complete failure record on the tested
Tab5, not every field combination, every failure path, or broader qualification.

## Maintainer Disposition

On September 12, 2026, accept the unchanged diagnostic source using its reviewed
ownership/format, host provenance checks, five successful native builds, and
that bounded physical capture. Preserve all SDK/component identity guards and
the original assertion. Land with a merge commit and retain signed source
objects. No allocator/counter repair, successful Talk flow, or complete transport
repair is claimed by this PR.

## Landing Synchronization

Signed ancestry merge `1ef33d50adb85c0f0ae55d94966bd3d21696631f` preserves the
original signed head and merged main. Its complete tree
`fb5121e2073a2958f4946d29f5ae02c9c9a6974e` equals the frozen original PR delta
plus the three approved image-pin edits. Only workflow conflict context was
resolved; the SDIO source patch, strict guards, and provenance flags are intact.
Actionlint and diff checks passed. The new-head
[CI run](https://github.com/openclaw/esp-openclaw-node/actions/runs/34701488206)
passed all five native jobs; CodeQL also passed. Earlier physical evidence above
belongs to its recorded image, not this synchronization build.
