### PR TITLE
fix(tab5): allocate streaming SDIO RX buffers in PSRAM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,14 @@ jobs:
             sdio_diagnostics="" &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               nvs_diagnostics="--nvs-diagnostics" &&
-              sdio_diagnostics="--sdio-diagnostics" &&
+              sdio_diagnostics="--sdio-diagnostics --sdio-psram-rx" &&
               python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH" --nvs-diagnostics
             fi &&
             idf.py reconfigure &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               python3 ../../scripts/tab5_sdio_diagnostics.py \
-                --project-path . --component-path managed_components/espressif__esp_hosted --build-path build &&
+                --project-path . --component-path managed_components/espressif__esp_hosted --build-path build --psram-rx &&
+              python3 -m unittest discover -s ../../scripts/tests -p test_tab5_sdio_rx_psram.py -v &&
               python3 -m unittest discover -s ../../scripts/tests -p test_tab5_sdio_diagnostics.py -v &&
               python3 -m unittest discover -s ../../scripts/tests -p test_package_firmware.py -v
             fi &&

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -105,34 +105,45 @@ normal CI still builds the real SDK. Target Unity lifecycle tests are built,
 not run by CI. Remove this temporary diagnostic patch and its explicit
 packaging mode after the observed failure is identified and qualified.
 
-### SDIO allocation diagnostic build
+### Streaming RX PSRAM and allocation diagnostics
 
 This branch also applies `patches/esp-hosted/tab5-sdio-first-allocation-failure.patch`
 to the registry `esp_hosted` 1.4.0 component at revision
 `6040085eefe908de68fcd3438bf10b8ecd6de0c6`. It observes the streaming RX buffer's
-first failed allocation; it is not a repair for the receive-buffer assertion.
-The allocator remains `esp_dma_capable_malloc` with 64-byte alignment and DMA
-capabilities. Existing assertions, block reads, counter advancement, task
-stacks, mempools, SDK patches and allocation configuration are unchanged.
+first failed allocation. A second patch,
+`patches/esp-hosted/tab5-sdio-streaming-rx-psram.patch`, places only the two
+growable streaming RX buffers in PSRAM when PSRAM and SDMMC PSRAM DMA support
+are enabled. It uses `esp_dma_capable_malloc` with explicit SPIRAM/8-bit
+capabilities and the existing 64-byte DMA alignment; the SDK also accounts
+for cache alignment. Other targets retain the original DMA allocation.
+
+This addresses a captured 6,144-byte streaming allocation failure with only
+a 3,072-byte largest DMA block. TX, register buffers, packet pools, assertions,
+512-byte padding, reads, counters, task stacks, SDK patches, and configuration
+are unchanged. It is not a claim that all SDIO allocation failures are resolved;
+this profile still needs physical qualification.
 
 In an isolated configured project, explicitly apply the component patch
 after `idf.py reconfigure` and before normal Ninja:
 
 ```sh
-python3 ../../scripts/tab5_sdio_diagnostics.py \
+python3 ../../scripts/tab5_sdio_diagnostics.py --psram-rx \
   --project-path . --component-path managed_components/espressif__esp_hosted --build-path build
 ninja -C build -j2
-python3 ../../scripts/tab5_sdio_diagnostics.py \
+python3 ../../scripts/tab5_sdio_diagnostics.py --psram-rx \
   --project-path . --component-path managed_components/espressif__esp_hosted --build-path build --verify-only
 ```
 
 The helper requires the pinned lock identity, manifest/revision, whole component
 and source hashes, patch hash, and configured compile input. Verification checks
-actual bytes and permits exactly the selected patch, not arbitrary local edits.
+actual bytes and permits exactly the selected patch sequence, not arbitrary local edits.
 Do not rewrite component-manager integrity metadata or bypass a reconfiguration
-failure. Packaging additionally requires `--sdio-diagnostics` alongside
-`--nvs-diagnostics`; the separate `component_diagnostic_patch` manifest record
-identifies the modified component. The symbol artifact retains that same manifest.
+failure. Packaging requires `--sdio-psram-rx --sdio-diagnostics` alongside
+`--nvs-diagnostics`. The `component_compatibility_patch` manifest record lists
+both ordered patches, their intermediate source hashes, and the final source
+and whole-component hashes. The symbol artifact retains that same manifest.
+Omit `--psram-rx` and `--sdio-psram-rx` only for the original diagnostic-only
+profile, whose manifest retains `component_diagnostic_patch`.
 
 One unprefixed ROM line has this exact field order, with decimal integers and
 no trailing period:
@@ -143,8 +154,10 @@ sdio_alloc_diag requested=%u padded=%u buffer_index=%d old_size=%u dma_free=%u d
 
 `requested` and `padded` describe the current allocation before/after existing
 block padding. `buffer_index` and `old_size` describe the previous write buffer.
-`dma_free` and `dma_largest` are DMA heap samples after allocation failure,
-not a proof that an aligned allocation would fit. `reg_raw`, `reg_masked`,
+`dma_free` and `dma_largest` remain `MALLOC_CAP_DMA` heap samples after allocation
+failure. They are not PSRAM-heap measurements, even when the failed streaming
+allocation targeted PSRAM, nor proof that an aligned allocation would fit.
+`reg_raw`, `reg_masked`,
 and `rx_count` are the current packet-length register, its masked value,
 and local RX byte counter.
 
@@ -163,7 +176,10 @@ successful frames. The RX owner retains its existing driver mutex, samples
 heap information after allocation returns, and prints after heap queries
 release their locks. Absence of a record is not evidence of healthy transport.
 Helper and packaging tests exercise real component hashing and rejection
-boundaries. CI builds the actual driver but does not execute an SDIO
+boundaries. A host C test compiles the actual streaming allocator section
+against allocation stubs, covering the observed growth, reuse, alignment,
+legacy profiles, and retained assertion. It does not execute SDMMC DMA.
+CI builds the actual driver but does not execute an SDIO
 allocation-failure fixture. Hardware failure capture remains a separate
 qualification step; remove this temporary patch and packaging mode after
 the cause is identified and a repair is qualified.

--- a/patches/esp-hosted/tab5-sdio-streaming-rx-psram.patch
+++ b/patches/esp-hosted/tab5-sdio-streaming-rx-psram.patch
@@ -1,0 +1,44 @@
+--- a/host/drivers/transport/sdio/sdio_drv.c
++++ b/host/drivers/transport/sdio/sdio_drv.c
+@@ -27,6 +27,8 @@
+ #include "esp_attr.h"
+ #include "esp_heap_caps.h"
+ #include "esp_rom_sys.h"
++#include "esp_dma_utils.h"
++#include "soc/soc_caps.h"
+ 
+ static const char TAG[] = "H_SDIO_DRV";
+ 
+@@ -661,6 +663,23 @@
+ } sdio_last_failed_read;
+ static DRAM_ATTR bool sdio_alloc_reported;
+ 
++static uint8_t *sdio_streaming_rx_alloc(size_t len)
++{
++#if CONFIG_SPIRAM && SOC_SDMMC_PSRAM_DMA_CAPABLE
++	/* Only the streaming buffers use PSRAM; packet pools and registers do not. */
++	const esp_dma_mem_info_t dma_mem_info = {
++		.extra_heap_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
++		.dma_alignment_bytes = 64,
++	};
++	void *buffer = NULL;
++	if (esp_dma_capable_malloc(len, &dma_mem_info, &buffer, NULL) != ESP_OK)
++		return NULL;
++	return buffer;
++#else
++	return MEM_ALLOC(len);
++#endif
++}
++
+ // SDIO streaming mode
+ // return a buffer big enough to contain the data
+ static uint8_t * sdio_rx_get_buffer(uint32_t len)
+@@ -680,7 +699,7 @@
+ 			// free already allocated memory
+ 			g_h.funcs->_h_free(*buf);
+ 		}
+-		*buf = (uint8_t *)MEM_ALLOC(len);
++		*buf = sdio_streaming_rx_alloc(len);
+ 		if (!*buf && !sdio_alloc_reported) {
+ 			sdio_alloc_reported = true;
+ 			multi_heap_info_t info;

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -164,7 +164,7 @@ def tab5_provenance(project, build):
 
 
 def package_firmware(project, build, output, target, provenance, dependencies,
-                     nvs_diagnostics=False, sdio_diagnostics=False):
+                     nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False):
     project, build, output = project.resolve(), build.resolve(), output.resolve()
     repo = Path(git(project, "rev-parse", "--show-toplevel")).resolve()
     if project.parent != repo / "examples" or EXAMPLES.get(project.name) != target:
@@ -204,6 +204,10 @@ def package_firmware(project, build, output, target, provenance, dependencies,
     if not dependencies.get("dependencies"):
         raise ValueError("Resolved dependency lock is empty")
     sdio_patch = None
+    if sdio_psram_rx and (not sdio_diagnostics
+                         or config.get("CONFIG_SPIRAM") != "y"
+                         or config.get("CONFIG_SOC_SDMMC_PSRAM_DMA_CAPABLE") != "y"):
+        raise ValueError("Streaming RX PSRAM requires diagnostics and supported PSRAM SDMMC")
     if sdio_diagnostics and (project.name != "m5stack-tab5-room-node" or not nvs_diagnostics):
         raise ValueError("SDIO diagnostics require the explicitly selected Tab5 diagnostic build")
     if sdio_diagnostics or (
@@ -211,7 +215,7 @@ def package_firmware(project, build, output, target, provenance, dependencies,
             and SDIO_COMPONENT in dependencies["dependencies"]):
         sdio_patch = verify_component_patch(
             project, project / "managed_components/espressif__esp_hosted",
-            build, dependencies, patched=sdio_diagnostics,
+            build, dependencies, patched=sdio_diagnostics, psram_rx=sdio_psram_rx,
         )
     normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
     lock_file = checked_file(project / "dependencies.lock", roots)
@@ -246,7 +250,9 @@ def package_firmware(project, build, output, target, provenance, dependencies,
     }
     if idf_compatibility is not None:
         manifest["idf"].update(idf_compatibility)
-    if sdio_diagnostics:
+    if sdio_psram_rx:
+        manifest["component_compatibility_patch"] = sdio_patch
+    elif sdio_diagnostics:
         manifest["component_diagnostic_patch"] = sdio_patch
     if project.name == "m5stack-tab5-room-node":
         manifest["tab5_bsp"] = tab5_provenance(project, build)
@@ -356,11 +362,13 @@ def main():
     parser.add_argument("--pr-head-sha", default="")
     parser.add_argument("--nvs-diagnostics", action="store_true")
     parser.add_argument("--sdio-diagnostics", action="store_true")
+    parser.add_argument("--sdio-psram-rx", action="store_true")
     args = parser.parse_args()
     provenance = vars(args).copy()
     provenance.pop("target")
     provenance.pop("nvs_diagnostics")
     provenance.pop("sdio_diagnostics")
+    provenance.pop("sdio_psram_rx")
     project = Path.cwd()
     # ruamel.yaml is already part of ESP-IDF's component-manager environment.
     try:
@@ -371,7 +379,8 @@ def main():
         dependencies = read_dependency_lock(project / "dependencies.lock")
         output = package_firmware(
             project, project / "build", project / "build/firmware",
-            args.target, provenance, dependencies, args.nvs_diagnostics, args.sdio_diagnostics,
+            args.target, provenance, dependencies, args.nvs_diagnostics,
+            args.sdio_diagnostics, args.sdio_psram_rx,
         )
     except ValueError as error:
         parser.exit(1, f"Firmware packaging failed: {error}\n")

--- a/scripts/tab5_sdio_diagnostics.py
+++ b/scripts/tab5_sdio_diagnostics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply or verify the pinned Tab5 SDIO probe after IDF configuration."""
+"""Apply or verify the pinned Tab5 SDIO patches after IDF configuration."""
 
 import argparse
 import hashlib
@@ -20,13 +20,18 @@ PATCHED_SHA256 = "5d3772ff65d6aeb837019adc4f03513ed766e045101d1b225cb80d17d66cc9
 PATCH_RELATIVE = "patches/esp-hosted/tab5-sdio-first-allocation-failure.patch"
 PATCH_PATH = Path(__file__).resolve().parents[1] / PATCH_RELATIVE
 PATCH_SHA256 = "430b99399fc6ab7d9d624855c1dd80ef3f8c3739776480ceae2dedeb1cc91f84"
+PSRAM_PATCH_RELATIVE = "patches/esp-hosted/tab5-sdio-streaming-rx-psram.patch"
+PSRAM_PATCH_PATH = Path(__file__).resolve().parents[1] / PSRAM_PATCH_RELATIVE
+PSRAM_PATCH_SHA256 = "ce511b5747d847a8913c4f4de37a98600422137e09210ee1ff4b24a033b2f768"
+PSRAM_SHA256 = "60d7a83b15ca883539744da370aa0267060ab605a822ec50a9c47b67d94dc78e"
+PSRAM_COMPONENT_HASH = "62132bdfd0d1710eb954bd0d2ce6e6ed54dd33aad0cbe5d86e3dc76e54ed74a9"
 
 
 def digest(data):
     return hashlib.sha256(data).hexdigest()
 
 
-def inspect_component(project, component, build, dependencies):
+def inspect_component(project, component, build, dependencies, psram_rx=False):
     project = Path(project).resolve(strict=True)
     component = Path(component).absolute()
     build = Path(build).resolve(strict=True)
@@ -56,6 +61,9 @@ def inspect_component(project, component, build, dependencies):
     if (PATCH_PATH.is_symlink()
             or digest(PATCH_PATH.read_bytes()) != PATCH_SHA256):
         raise ValueError("Tracked SDIO patch has unexpected contents")
+    if psram_rx and (PSRAM_PATCH_PATH.is_symlink()
+                     or digest(PSRAM_PATCH_PATH.read_bytes()) != PSRAM_PATCH_SHA256):
+        raise ValueError("Tracked streaming RX PSRAM patch has unexpected contents")
     commands = json.loads((build / "compile_commands.json").read_text())
     compiled_sources = []
     for command in commands:
@@ -82,39 +90,63 @@ def validate_component_hash(component, expected):
         raise ValueError("Managed component bytes do not match the selected profile") from error
 
 
-def verify_component_patch(project, component, build, dependencies, patched=True):
-    component, source_hash = inspect_component(project, component, build, dependencies)
+def verify_component_patch(project, component, build, dependencies, patched=True, psram_rx=False):
+    if psram_rx and not patched:
+        raise ValueError("Streaming RX PSRAM requires the diagnostic patch first")
+    component, source_hash = inspect_component(project, component, build, dependencies, psram_rx)
     expected_source = PATCHED_SHA256 if patched else ORIGINAL_SHA256
     expected_component = PATCHED_COMPONENT_HASH if patched else COMPONENT_HASH
+    if psram_rx:
+        expected_source, expected_component = PSRAM_SHA256, PSRAM_COMPONENT_HASH
     if source_hash != expected_source:
         raise ValueError("SDIO source does not match the explicitly selected profile")
     validate_component_hash(component, expected_component)
     if not patched:
         return {"component": COMPONENT, "version": VERSION, "modified": False}
-    return {
+    result = {
         "component": COMPONENT,
         "version": VERSION,
         "registry_revision": REVISION,
         "registry_path": ".",
         "original_component_hash": COMPONENT_HASH,
         "modified": patched,
-        "patch": PATCH_RELATIVE,
-        "patch_sha256": PATCH_SHA256,
         "source": SOURCE_PATH,
         "original_source_sha256": ORIGINAL_SHA256,
         "patched_source_sha256": source_hash,
         "patched_component_hash": expected_component,
     }
+    if psram_rx:
+        result["profile"] = "streaming-rx-psram-with-diagnostics"
+        result["patches"] = [
+            {
+                "patch": PATCH_RELATIVE, "patch_sha256": PATCH_SHA256,
+                "input_source_sha256": ORIGINAL_SHA256,
+                "output_source_sha256": PATCHED_SHA256,
+            },
+            {
+                "patch": PSRAM_PATCH_RELATIVE, "patch_sha256": PSRAM_PATCH_SHA256,
+                "input_source_sha256": PATCHED_SHA256,
+                "output_source_sha256": PSRAM_SHA256,
+            },
+        ]
+    else:
+        result.update(patch=PATCH_RELATIVE, patch_sha256=PATCH_SHA256)
+    return result
 
 
-def apply_component_patch(project, component, build, dependencies):
-    component, source_hash = inspect_component(project, component, build, dependencies)
-    if source_hash == PATCHED_SHA256:
-        return verify_component_patch(project, component, build, dependencies)
-    verify_component_patch(project, component, build, dependencies, patched=False)
-    subprocess.run(["git", "apply", "--check", str(PATCH_PATH)], cwd=component, check=True)
-    subprocess.run(["git", "apply", str(PATCH_PATH)], cwd=component, check=True)
-    return verify_component_patch(project, component, build, dependencies)
+def apply_component_patch(project, component, build, dependencies, psram_rx=False):
+    component, source_hash = inspect_component(project, component, build, dependencies, psram_rx)
+    if psram_rx and source_hash == PSRAM_SHA256:
+        return verify_component_patch(project, component, build, dependencies, psram_rx=True)
+    if source_hash != PATCHED_SHA256:
+        verify_component_patch(project, component, build, dependencies, patched=False)
+        subprocess.run(["git", "apply", "--check", str(PATCH_PATH)], cwd=component, check=True)
+        subprocess.run(["git", "apply", str(PATCH_PATH)], cwd=component, check=True)
+    verify_component_patch(project, component, build, dependencies)
+    if psram_rx:
+        subprocess.run(["git", "apply", "--check", str(PSRAM_PATCH_PATH)], cwd=component, check=True)
+        subprocess.run(["git", "apply", str(PSRAM_PATCH_PATH)], cwd=component, check=True)
+    return verify_component_patch(project, component, build, dependencies, psram_rx=psram_rx)
 
 
 def main():
@@ -123,6 +155,7 @@ def main():
     parser.add_argument("--component-path", type=Path, required=True)
     parser.add_argument("--build-path", type=Path, required=True)
     parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--psram-rx", action="store_true")
     args = parser.parse_args()
     try:
         from ruamel.yaml import YAML
@@ -134,7 +167,8 @@ def main():
             (args.project_path / "dependencies.lock").read_text()
         )
         operation = verify_component_patch if args.verify_only else apply_component_patch
-        result = operation(args.project_path, args.component_path, args.build_path, dependencies)
+        result = operation(args.project_path, args.component_path, args.build_path,
+                           dependencies, psram_rx=args.psram_rx)
     except (ValueError, TypeError, KeyError, OSError, ImportError,
             YAMLError, subprocess.CalledProcessError):
         parser.exit(1, "SDIO diagnostic patch refused: verify the pinned component and build inputs.\n")

--- a/scripts/tests/fixtures/test_sdio_rx_allocator.c
+++ b/scripts/tests/fixtures/test_sdio_rx_allocator.c
@@ -1,0 +1,121 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+
+#define ESP_OK 0
+#define ESP_ERR_NO_MEM 0x101
+#define MALLOC_CAP_DMA 1
+#define MALLOC_CAP_SPIRAM 2
+#define MALLOC_CAP_8BIT 4
+#define ESP_BLOCK_SIZE 512
+#define H_SDIO_RX_BLOCK_ONLY_XFER 1
+#define ESP_SLAVE_LEN_MASK 0x3ffff
+#define PACKET_LEN_INDEX 0
+#define DRAM_ATTR
+#define DRAM_STR(s) (s)
+#define ESP_LOGD(tag, ...) ((void)(tag))
+
+typedef int esp_err_t;
+typedef struct { unsigned extra_heap_caps; size_t dma_alignment_bytes; } esp_dma_mem_info_t;
+typedef struct { size_t total_free_bytes, largest_free_block; } multi_heap_info_t;
+static const char *TAG = "fixture";
+static uint8_t reg_buf[4];
+static uint32_t sdio_rx_byte_count = 226009;
+static struct {
+    struct { uint8_t *buf; uint32_t buf_size; } buffer[2];
+    int write_index;
+} double_buf;
+static unsigned calls, frees, last_caps;
+static size_t last_size, last_alignment;
+static bool fail_psram;
+
+static void release(void *buffer) { ++frees; free(buffer); }
+static struct { void (*_h_free)(void *); } functions = { release };
+static struct { __typeof__(functions) *funcs; } g_h = { &functions };
+
+static esp_err_t esp_dma_capable_malloc(size_t size, const esp_dma_mem_info_t *info,
+                                       void **out, size_t *actual)
+{
+    ++calls;
+    last_caps = info->extra_heap_caps ? info->extra_heap_caps : MALLOC_CAP_DMA;
+    last_size = size;
+    last_alignment = info->dma_alignment_bytes;
+    printf("alloc caps=%u size=%zu alignment=%zu\n", last_caps, size, last_alignment);
+    fflush(stdout);
+    if ((last_caps == MALLOC_CAP_DMA && size > 3072) ||
+            ((last_caps & MALLOC_CAP_SPIRAM) && fail_psram))
+        return ESP_ERR_NO_MEM;
+    assert(last_alignment == 64);
+    size_t rounded = (size + 63) & ~(size_t)63;
+    assert(posix_memalign(out, last_alignment, rounded) == 0);
+    if (actual) *actual = rounded;
+    return ESP_OK;
+}
+
+static void heap_caps_get_info(multi_heap_info_t *info, unsigned caps)
+{
+    assert(caps == MALLOC_CAP_DMA);
+    info->total_free_bytes = 10915;
+    info->largest_free_block = 3072;
+}
+
+static int esp_rom_printf(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int count = vprintf(format, args);
+    va_end(args);
+    fflush(stdout);
+    return count;
+}
+
+#include "sdio_rx_under_test.inc"
+
+int main(int argc, char **argv)
+{
+    assert(argc == 2);
+    struct rlimit core_limit = {0, 0};
+    assert(setrlimit(RLIMIT_CORE, &core_limit) == 0);
+    uint32_t reg = 875792993;
+    memcpy(reg_buf, &reg, sizeof(reg));
+    static uint8_t reader[16];
+    double_buf.buffer[0].buf = reader;
+    double_buf.buffer[0].buf_size = sizeof(reader);
+    double_buf.write_index = 1;
+
+    if (strcmp(argv[1], "legacy") == 0) {
+        assert(sdio_rx_get_buffer(1024));
+        assert(last_caps == MALLOC_CAP_DMA && last_size == 1024);
+        assert(sdio_rx_get_buffer(2049));
+        assert(last_caps == MALLOC_CAP_DMA && last_size == 2560);
+    } else if (strcmp(argv[1], "alignment") == 0) {
+        const uint32_t lengths[] = {1, 512, 513, 6024, 6145};
+        for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); ++i) {
+            uint8_t *buffer = sdio_rx_get_buffer(lengths[i]);
+            assert(buffer && (uintptr_t)buffer % 64 == 0);
+            assert(double_buf.buffer[1].buf_size >= ((lengths[i] + 511) / 512) * 512);
+        }
+        assert(last_caps == (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    } else {
+        assert(posix_memalign((void **)&double_buf.buffer[1].buf, 64, 3072) == 0);
+        double_buf.buffer[1].buf_size = 3072;
+        fail_psram = strcmp(argv[1], "failure") == 0;
+        uint8_t *buffer = sdio_rx_get_buffer(6024);
+        assert(buffer && calls == 1 && frees == 1);
+        assert(last_size == 6144 && last_alignment == 64);
+        assert(double_buf.buffer[1].buf_size == 6144);
+        assert(last_caps == (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+        assert(sdio_rx_get_buffer(6024) == buffer && calls == 1 && frees == 1);
+        assert(sdio_rx_get_buffer(6145) && calls == 2 && frees == 2);
+        assert(last_size == 6656 && double_buf.buffer[1].buf_size == 6656);
+    }
+    assert(double_buf.buffer[0].buf == reader);
+    assert(double_buf.buffer[0].buf_size == sizeof(reader));
+    free(double_buf.buffer[1].buf);
+    return 0;
+}

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -135,11 +135,11 @@ class FirmwareBundleTests(unittest.TestCase):
         (self.build / "project_description.json").write_text(json.dumps(self.description))
         (self.build / "flasher_args.json").write_text(json.dumps(self.flash))
 
-    def package(self, nvs_diagnostics=False, sdio_diagnostics=False):
+    def package(self, nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False):
         self.write_metadata()
         return firmware.package_firmware(
             self.project, self.build, self.output, self.description["target"],
-            self.provenance, self.dependencies, nvs_diagnostics, sdio_diagnostics,
+            self.provenance, self.dependencies, nvs_diagnostics, sdio_diagnostics, sdio_psram_rx,
         )
 
     def test_relocated_bundle_preserves_every_image_and_original_inputs(self):
@@ -456,6 +456,36 @@ class FirmwareBundleTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.package(sdio_diagnostics=True)
         self.assertFalse(self.output.exists())
+
+    @unittest.skipUnless(HAS_MANAGER, "actual component hashing runs in the IDF environment")
+    def test_psram_rx_bundle_requires_opt_in_capabilities_and_exact_patch_chain(self):
+        self.configure_tab5()
+        self.config += "CONFIG_SPIRAM=y\nCONFIG_SOC_SDMMC_PSRAM_DMA_CAPABLE=y\n"
+        base = seed_sdk(self.idf)
+        with fixture_profile(base), component_fixture(
+                self.project, self.build, self.dependencies) as component:
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            expected = sdio.apply_component_patch(
+                self.project, component, self.build, self.dependencies, psram_rx=True,
+            )
+            with self.assertRaises(ValueError):
+                self.package(nvs_diagnostics=True, sdio_diagnostics=True)
+            with self.assertRaises(ValueError):
+                self.package(nvs_diagnostics=True, sdio_psram_rx=True)
+            original_config = self.config
+            for key in ("CONFIG_SPIRAM", "CONFIG_SOC_SDMMC_PSRAM_DMA_CAPABLE"):
+                self.config = original_config.replace(key + "=y", key + "=n")
+                with self.subTest(key=key), self.assertRaises(ValueError):
+                    self.package(nvs_diagnostics=True, sdio_diagnostics=True, sdio_psram_rx=True)
+                self.assertFalse(self.output.exists())
+            self.config = original_config
+            self.package(nvs_diagnostics=True, sdio_diagnostics=True, sdio_psram_rx=True)
+            manifest = json.loads((self.output / "manifest.json").read_text())
+            self.assertEqual(manifest["component_compatibility_patch"], expected)
+            self.assertNotIn("component_diagnostic_patch", manifest)
+            self.assertEqual(len(expected["patches"]), 2)
+            self.assertEqual(expected["patched_source_sha256"],
+                             firmware.sha256(component / sdio.SOURCE_PATH))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_tab5_sdio_diagnostics.py
+++ b/scripts/tests/test_tab5_sdio_diagnostics.py
@@ -19,6 +19,7 @@ import tab5_sdio_diagnostics as sdio
 HAS_MANAGER = importlib.util.find_spec("idf_component_tools") is not None
 ORIGINAL = b"/* Synthetic component fixture, not a transport simulator. */\nint fixture;\n"
 PATCHED = ORIGINAL + b"/* Diagnostic fixture change. */\n"
+PSRAM_PATCHED = PATCHED + b"/* Streaming RX PSRAM fixture change. */\n"
 REGISTRY_SOURCE = {
     "type": "service",
     "registry_url": "https://components.espressif.com/",
@@ -55,11 +56,19 @@ def component_fixture(project, build, dependencies):
     (component / ".component_hash").write_text(original_hash)
     source.write_bytes(PATCHED)
     patched_hash = directory_hash(component)
+    source.write_bytes(PSRAM_PATCHED)
+    psram_hash = directory_hash(component)
     source.write_bytes(ORIGINAL)
     patch_file = build / "fixture.patch"
     patch_file.write_text("".join(difflib.unified_diff(
         ORIGINAL.decode().splitlines(keepends=True),
         PATCHED.decode().splitlines(keepends=True),
+        fromfile="a/" + sdio.SOURCE_PATH, tofile="b/" + sdio.SOURCE_PATH,
+    )))
+    psram_patch_file = build / "psram-fixture.patch"
+    psram_patch_file.write_text("".join(difflib.unified_diff(
+        PATCHED.decode().splitlines(keepends=True),
+        PSRAM_PATCHED.decode().splitlines(keepends=True),
         fromfile="a/" + sdio.SOURCE_PATH, tofile="b/" + sdio.SOURCE_PATH,
     )))
     (build / "compile_commands.json").write_text(json.dumps([{
@@ -75,6 +84,9 @@ def component_fixture(project, build, dependencies):
         MANIFEST_SHA256=sdio.digest(manifest.read_bytes()),
         ORIGINAL_SHA256=sdio.digest(ORIGINAL), PATCHED_SHA256=sdio.digest(PATCHED),
         PATCH_PATH=patch_file, PATCH_SHA256=sdio.digest(patch_file.read_bytes()),
+        PSRAM_PATCH_PATH=psram_patch_file,
+        PSRAM_PATCH_SHA256=sdio.digest(psram_patch_file.read_bytes()),
+        PSRAM_SHA256=sdio.digest(PSRAM_PATCHED), PSRAM_COMPONENT_HASH=psram_hash,
     ):
         yield component
 
@@ -96,9 +108,9 @@ class SdioPatchTests(unittest.TestCase):
         self.addCleanup(context.__exit__, None, None, None)
         self.source = self.component / sdio.SOURCE_PATH
 
-    def apply(self):
+    def apply(self, psram_rx=False):
         return sdio.apply_component_patch(
-            self.project, self.component, self.build, self.dependencies,
+            self.project, self.component, self.build, self.dependencies, psram_rx=psram_rx,
         )
 
     def verify(self, patched=True):
@@ -220,6 +232,38 @@ class SdioPatchTests(unittest.TestCase):
             with self.subTest(entries=len(entries)), self.assertRaises(ValueError):
                 self.apply()
             self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_psram_patch_chain_idempotence_and_final_provenance(self):
+        metadata = self.apply(psram_rx=True)
+        self.assertEqual(self.source.read_bytes(), PSRAM_PATCHED)
+        self.assertEqual(metadata["patched_source_sha256"], sdio.digest(PSRAM_PATCHED))
+        self.assertEqual(metadata["patched_component_hash"], directory_hash(self.component))
+        self.assertEqual([p["output_source_sha256"] for p in metadata["patches"]],
+                         [sdio.digest(PATCHED), sdio.digest(PSRAM_PATCHED)])
+        self.assertEqual(metadata["patches"][1]["input_source_sha256"], sdio.digest(PATCHED))
+        self.assertEqual(self.apply(psram_rx=True), metadata)
+        with self.assertRaises(ValueError):
+            self.verify()
+        with self.assertRaises(ValueError):
+            sdio.verify_component_patch(self.project, self.component, self.build,
+                                        self.dependencies, patched=False, psram_rx=True)
+
+    def test_psram_tampering_refuses_before_applying_diagnostic_patch(self):
+        with patch.object(sdio, "PSRAM_PATCH_SHA256", "0" * 64), self.assertRaises(ValueError):
+            self.apply(psram_rx=True)
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_psram_transition_requires_exact_diagnostic_component(self):
+        self.apply()
+        other = self.component / "other.c"
+        original = other.read_bytes()
+        other.write_bytes(b"/* unrelated edit */\n")
+        with self.assertRaises(ValueError):
+            self.apply(psram_rx=True)
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+        other.write_bytes(original)
+        self.apply(psram_rx=True)
+        self.assertEqual(self.source.read_bytes(), PSRAM_PATCHED)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_tab5_sdio_rx_psram.py
+++ b/scripts/tests/test_tab5_sdio_rx_psram.py
@@ -1,0 +1,77 @@
+"""Compile the actual configured streaming allocator, not a transport simulation."""
+
+import hashlib
+import os
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+import unittest
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SOURCE_HASHES = {
+    "5d3772ff65d6aeb837019adc4f03513ed766e045101d1b225cb80d17d66cc986",
+    "60d7a83b15ca883539744da370aa0267060ab605a822ec50a9c47b67d94dc78e",
+}
+
+
+class StreamingRxAllocatorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        component = Path(os.environ.get(
+            "ESP_HOSTED_COMPONENT_DIR", "managed_components/espressif__esp_hosted"))
+        source = component / "host/drivers/transport/sdio/sdio_drv.c"
+        if not source.is_file():
+            raise unittest.SkipTest("requires the configured esp_hosted source")
+        data = source.read_bytes()
+        if hashlib.sha256(data).hexdigest() not in SOURCE_HASHES:
+            raise AssertionError("allocator input must match the pinned diagnostic or repaired source")
+        section = data.decode().split("#else // H_SDIO_HOST_STREAMING_MODE\n", 1)[1]
+        section = section.split("// this frees the buffer", 1)[0]
+        wrapper = (component / "host/port/include/os_wrapper.h").read_text()
+        macro = "#define MEM_ALLOC" + wrapper.split("#define MEM_ALLOC", 1)[1].split("#define FREE", 1)[0]
+        temporary = tempfile.TemporaryDirectory(prefix="sdio-rx-allocator-")
+        cls.addClassCleanup(temporary.cleanup)
+        cls.root = Path(temporary.name)
+        (cls.root / "sdio_rx_under_test.inc").write_text(macro + section)
+        for name, psram, dma in (("supported", 1, 1), ("no-psram", 0, 1), ("no-dma", 1, 0)):
+            subprocess.run([
+                os.environ.get("CC", "cc"), "-std=gnu11", "-D_POSIX_C_SOURCE=200809L",
+                "-Wall", "-Wextra", "-Werror", "-I", str(cls.root),
+                f"-DCONFIG_SPIRAM={psram}", f"-DSOC_SDMMC_PSRAM_DMA_CAPABLE={dma}",
+                str(FIXTURES / "test_sdio_rx_allocator.c"), "-o", str(cls.root / name),
+            ], check=True)
+
+    def run_case(self, binary, scenario):
+        return subprocess.run([str(self.root / binary), scenario],
+                              text=True, capture_output=True)
+
+    def test_observed_growth_reuse_and_reader_ownership(self):
+        result = self.run_case("supported", "growth")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_block_and_dma_alignment(self):
+        result = self.run_case("supported", "alignment")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_psram_failure_keeps_assertion_and_dma_sample_meaning(self):
+        result = self.run_case("supported", "failure")
+        self.assertEqual(result.returncode, -signal.SIGABRT)
+        self.assertEqual(result.stdout.count("alloc "), 1)
+        self.assertIn("alloc caps=6 size=6144 alignment=64", result.stdout)
+        self.assertIn("dma_free=10915 dma_largest=3072", result.stdout)
+
+    def test_unsupported_profiles_retain_dma_allocation_and_assertion(self):
+        for binary in ("no-psram", "no-dma"):
+            with self.subTest(binary=binary):
+                result = self.run_case(binary, "legacy")
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                result = self.run_case(binary, "growth")
+                self.assertEqual(result.returncode, -signal.SIGABRT)
+                self.assertIn("alloc caps=1 size=6144 alignment=64", result.stdout)
+                self.assertNotIn("alloc caps=6", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Stacked on https://github.com/openclaw/esp-openclaw-node/pull/45; only the streaming RX allocation repair and its build/provenance checks are added here.

The Tab5's streaming RX buffer failed to grow from 3,072 to 6,144 bytes for a 6,024-byte pending read. The post-failure DMA heap sample showed 10,915 bytes free but a largest block of only 3,072 bytes. This supports a contiguous allocation failure, not a claim of a heap leak, malformed SDIO traffic, or provider failure.

## Changes

- Allocate only the two streaming RX buffers through `esp_dma_capable_malloc` with explicit `MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT` and 64-byte alignment when PSRAM and SDMMC PSRAM DMA support are enabled. The pinned SDK accounts for cache alignment. Noneligible profiles retain the original allocation.
- Preserve 512-byte padding, growth/free behavior, assertions, synchronous reads, counters, and buffer ownership. TX, register buffers, packet pools, task stacks, allocation configuration, SDK patches, and dependency versions are unchanged.
- Extend the strict component helper with a second pinned patch and ordered source hashes. Firmware and symbol manifests identify the final component bytes and both patches under `component_compatibility_patch`. No component-manager integrity bypass.
- Keep the existing diagnostic format unchanged. Its DMA heap fields remain DMA-pool samples, not measurements of the PSRAM allocation arena.

At ESP-IDF `362a1776ec212788fda95f75b733bfdde3a0c394`, the P4 [capability](https://github.com/espressif/esp-idf/blob/362a1776ec212788fda95f75b733bfdde3a0c394/components/soc/esp32p4/include/soc/soc_caps.h#L534), [aligned DMA allocation](https://github.com/espressif/esp-idf/blob/362a1776ec212788fda95f75b733bfdde3a0c394/components/esp_hw_support/dma/esp_dma_utils.c#L162), and [SDMMC cache synchronization](https://github.com/espressif/esp-idf/blob/362a1776ec212788fda95f75b733bfdde3a0c394/components/esp_driver_sdmmc/src/sdmmc_transaction.c#L134) support this bounded allocation path. This remains ESP-IDF plus the existing tracked compatibility/diagnostic patches, not a pristine SDK release.

## Validation

- Actual pinned allocator C section: old-source regression demonstrated; repaired-source 4 tests pass, including the observed growth, reuse, alignment, legacy profiles, and allocation-failure assertion. These tests use allocation stubs, not real DMA.
- Component helper: 13 tests pass with the actual component-manager hashing API.
- Firmware packaging: 19 tests pass, including profile/capability rejection and final two-patch provenance.
- Both patches applied and verified idempotently against the actual pinned registry component; only the intended driver source changed.
- Workflow lint and source whitespace checks pass. The tracked unified patch's context prefixes trigger raw `git diff --check` warnings; `git apply --check --whitespace=error-all` passes against its exact input. Independent runtime review and frozen-candidate P2 review completed before publication.

All five native builds passed in [CI run 34297512556, attempt 1](https://github.com/openclaw/esp-openclaw-node/actions/runs/34297512556) for PR head `2310d069b9b59e1bdabecb3524e4dc528d1a4665`. The Tab5 artifact compiled test merge `853f2638ca0d50ddaf1e0668982316888d60dc8e`; its parents and tree match the stacked base and PR head. The downloaded ZIP matched the official API SHA256, all 11 file checksums and four image mappings passed, and the SDK/configuration/partition table remained unchanged. Both component patches and their final source hashes were verified.

Bounded physical checks on that exact Tab5 image:

- Four image flash/readback checks passed (4/4).
- A 141.146-second keyless connectivity check, including one Gateway restart, passed.
- A 42.921-second Talk attempt showed no SDIO fault, but RTC never became active. This is not a successful Talk/media test.
- One actual `camera.snap` dispatch returned `UNAVAILABLE` from the early camera/V4L2 capture branch, with no SDIO fault and no JPEG. The failing capture stage remains unidentified; no format, timeout, or allocation fix is claimed.

These results do not establish that all memory failures are resolved or that RTC, Talk, camera, or end-to-end media are qualified.

## Maintainer Disposition

On September 12, 2026, accept this narrow streaming-RX placement repair with
the pinned DMA/cache/synchronous-read contract, actual-source boundary tests,
five native builds, and bounded physical evidence above. Representative
receive-pressure and PSRAM-exhaustion qualification remain follow-ups, not
claimed results. Eligible profiles intentionally have no silent internal-DMA
fallback; PSRAM exhaustion can still reach the retained allocation assertion.
No global allocation or transport-mode change is included.

Land with a merge commit and retain the signed source objects. The earlier
camera and Talk outcomes are qualification limits, not successes; this decision
does not authorize a release or claim a complete memory or media repair.

## Landing Synchronization

Signed ancestry merge `d8b220b22a437c73a7fd6264c84e78153c454c45` retains the
original signed head and qualified main. Its full tree
`c0a2478df592d60e5ac1be77f175000e869be78d` equals the frozen RX-placement delta
on the reviewed cumulative tree, including the CI image pin. No new runtime
choice was made. This refresh was necessary because GitHub retained a
test-merge parent from the former stacked base after retargeting; the exact
parent gate was not relaxed.

[New-head CI](https://github.com/openclaw/esp-openclaw-node/actions/runs/34703063375)
passed all five native jobs; CodeQL also passed. The physical evidence above remains tied to its earlier image, not
this synchronization build.
