### PR TITLE
fix(tab5): bound camera dequeue waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               for hook in esp_openclaw_node_transport_start_begin esp_openclaw_node_transport_start_end; do
                 riscv32-esp-elf-nm --defined-only build/openclaw_m5stack_tab5_room_node.elf |
-                  awk -v hook="$hook" '$3 == hook && $2 == "T" { found = 1 } END { exit !found }' || exit 1
+                  grep -E "^[[:xdigit:]]+ T ${hook}$" >/dev/null || exit 1
               done
             fi &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           python3 -m unittest discover -s scripts/tests -p 'test_idf_tab5_compat.py' -v
           python3 -m unittest discover -s scripts/tests -p 'test_nvs_diagnostics.py' -v
           python3 -m unittest discover -s scripts/tests -p 'test_tab5_camera_diagnostics.py' -v
+          python3 -m unittest discover -s scripts/tests -p 'test_tab5_allocation_diagnostics.py' -v
 
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
@@ -101,6 +102,12 @@ jobs:
               python3 -m unittest discover -s ../../scripts/tests -p test_package_firmware.py -v
             fi &&
             ninja -C build -j2 &&
+            if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
+              for hook in esp_openclaw_node_transport_start_begin esp_openclaw_node_transport_start_end; do
+                riscv32-esp-elf-nm --defined-only build/openclaw_m5stack_tab5_room_node.elf |
+                  awk -v hook="$hook" '$3 == hook && $2 == "T" { found = 1 } END { exit !found }' || exit 1
+              done
+            fi &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               python3 ../../scripts/tab5_camera_compat.py --idf-path "$IDF_PATH" \
                 --project-path . --component-path managed_components/espressif__esp_video --build-path build --verify-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,20 +82,29 @@ jobs:
           command: |
             nvs_diagnostics="" &&
             sdio_diagnostics="" &&
+            camera_compat="" &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               nvs_diagnostics="--nvs-diagnostics" &&
               sdio_diagnostics="--sdio-diagnostics --sdio-psram-rx" &&
+              camera_compat="--camera-compat" &&
               python3 ../../scripts/idf_tab5_compat.py --idf-path "$IDF_PATH" --nvs-diagnostics
             fi &&
             idf.py reconfigure &&
             if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
               python3 ../../scripts/tab5_sdio_diagnostics.py \
                 --project-path . --component-path managed_components/espressif__esp_hosted --build-path build --psram-rx &&
+              python3 ../../scripts/tab5_camera_compat.py --idf-path "$IDF_PATH" \
+                --project-path . --component-path managed_components/espressif__esp_video --build-path build &&
               python3 -m unittest discover -s ../../scripts/tests -p test_tab5_sdio_rx_psram.py -v &&
               python3 -m unittest discover -s ../../scripts/tests -p test_tab5_sdio_diagnostics.py -v &&
+              python3 -m unittest discover -s ../../scripts/tests -p test_tab5_camera_compat.py -v &&
               python3 -m unittest discover -s ../../scripts/tests -p test_package_firmware.py -v
             fi &&
             ninja -C build -j2 &&
+            if [ "${{ matrix.name }}" = "m5stack-tab5-room-node" ]; then
+              python3 ../../scripts/tab5_camera_compat.py --idf-path "$IDF_PATH" \
+                --project-path . --component-path managed_components/espressif__esp_video --build-path build --verify-only
+            fi &&
             if [ "${{ matrix.name }}" = "component-test-app-build" ]; then
               python3 ../../../esp-openclaw-talk/tests/run_host_tests.py --sanitize &&
               python3 ../../../esp-openclaw-talk/tests/run_threaded_tests.py &&
@@ -115,7 +124,7 @@ jobs:
                 --run-id "${{ github.run_id }}" \
                 --run-attempt "${{ github.run_attempt }}" \
                 --idf-image "espressif/idf:release-v5.5" \
-                $nvs_diagnostics $sdio_diagnostics
+                $nvs_diagnostics $sdio_diagnostics $camera_compat
             fi
 
       - name: Upload firmware

--- a/components/esp-openclaw-node/private_include/esp_openclaw_node_transport_diag.h
+++ b/components/esp-openclaw-node/private_include/esp_openclaw_node_transport_diag.h
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "esp_err.h"
+
+/* Private, synchronous observation points; implementations must not change transport state. */
+void esp_openclaw_node_transport_start_begin(const char *role);
+void esp_openclaw_node_transport_start_end(const char *role, esp_err_t result);

--- a/components/esp-openclaw-node/src/esp_openclaw_node.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node.c
@@ -6,13 +6,12 @@
 
 #include "esp_openclaw_node_internal.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "esp_app_desc.h"
-#include "esp_attr.h"
 #include "esp_check.h"
-#include "esp_rom_sys.h"
 
 static const char *DEFAULT_PLATFORM = "esp32";
 static const char *DEFAULT_DEVICE_FAMILY = "ESP32";
@@ -597,8 +596,8 @@ esp_err_t esp_openclaw_node_request_connect(
         }
         unsigned role = node->config.role != NULL && strcmp(node->config.role, "node") == 0
             ? 1 : node->config.role != NULL && strcmp(node->config.role, "operator") == 0 ? 2 : 0;
-        esp_rom_printf(
-            DRAM_STR("nvs_connect_diag role=%u cached=%u fresh_known=%u fresh=%u err=%d\n"),
+        printf(
+            "nvs_connect_diag role=%u cached=%u fresh_known=%u fresh=%u err=%d\n",
             role, (unsigned)cached_present, (unsigned)(load_err == ESP_OK),
             (unsigned)fresh_present, (int)load_err);
     }

--- a/components/esp-openclaw-node/src/esp_openclaw_node_persisted_session.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_persisted_session.c
@@ -8,13 +8,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "esp_attr.h"
 #include "esp_check.h"
 #include "esp_log.h"
-#include "esp_rom_sys.h"
 #include "nvs.h"
 
 static const char *TAG = "esp_openclaw_node_session";
@@ -57,8 +56,8 @@ enum {
 static void log_session_load(
     unsigned role, unsigned stage, esp_err_t err, unsigned presence)
 {
-    esp_rom_printf(
-        DRAM_STR("nvs_session_diag role=%u stage=%u err=%d presence=%u\n"),
+    printf(
+        "nvs_session_diag role=%u stage=%u err=%d presence=%u\n",
         role, stage, (int)err, presence);
 }
 

--- a/components/esp-openclaw-node/src/esp_openclaw_node_transport.c
+++ b/components/esp-openclaw-node/src/esp_openclaw_node_transport.c
@@ -5,6 +5,7 @@
  */
 
 #include "esp_openclaw_node_internal.h"
+#include "esp_openclaw_node_transport_diag.h"
 
 #include <inttypes.h>
 #include <stdlib.h>
@@ -15,6 +16,17 @@
 #endif
 #include "esp_check.h"
 #include "esp_log.h"
+
+__attribute__((weak)) void esp_openclaw_node_transport_start_begin(const char *role)
+{
+    (void)role;
+}
+
+__attribute__((weak)) void esp_openclaw_node_transport_start_end(const char *role, esp_err_t result)
+{
+    (void)role;
+    (void)result;
+}
 
 static void websocket_event_handler(
     void *handler_args,
@@ -222,7 +234,9 @@ esp_err_t esp_openclaw_node_start_transport_for_active_source(
         return err;
     }
 
+    esp_openclaw_node_transport_start_begin(node->config.role);
     err = node->websocket_client_ops->client_start(ws);
+    esp_openclaw_node_transport_start_end(node->config.role, err);
     if (err != ESP_OK) {
         esp_openclaw_node_cleanup_transport_instance(node, false);
         return err;

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -112,7 +112,7 @@ approved dirty SDK paths, with separate `compatibility_patch` and
 `diagnostic_patch` manifest records. The symbol artifact retains that same
 manifest.
 
-The following unprefixed ROM-output records contain fixed numeric fields only.
+The following unprefixed records contain fixed numeric fields only.
 Capture them before filtering for normal I/W/E log prefixes:
 
 | Record | Fields |
@@ -121,6 +121,11 @@ Capture them before filtering for normal I/W/E log prefixes:
 | `nvs_session_diag` | `role`, `stage`, `err`, `presence` |
 | `nvs_connect_diag` | `role`, `cached`, `fresh_known`, `fresh`, `err` |
 | `nvs_init_diag` | `err`; initial initialization failure before existing recovery |
+
+Runtime session/connect records use one `printf` call after the NVS operation,
+outside the node state lock, sharing stdio serialization with normal logs.
+Their bare grammar is unchanged. Initial NVS and low-level I/O records retain
+ROM output; concurrent ROM writers can still interleave with console output.
 
 `op`: 1 read_raw, 2 read, 3 write_raw, 4 write, 5 erase_range.
 Read/write alignment errors retain their original return and perform no I/O,

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -152,6 +152,49 @@ normal CI still builds the real SDK. Target Unity lifecycle tests are built,
 not run by CI. Remove this temporary diagnostic patch and its explicit
 packaging mode after the observed failure is identified and qualified.
 
+### Transport-start allocation diagnostics
+
+Tab5 installs one global failed-allocation callback before board initialization.
+Two private, default-no-op transport hooks arm only the calling node/operator
+task around `client_start`. ISR and unrelated-task failures are ignored. The
+callback captures the first request size, capability mask, and SDK function
+pointer in internal RAM without dereferencing that pointer, logging, heap queries,
+allocation, or waiting. After disarm, the task maps the pinned SDK's static
+function name to a bounded allocator enum; no pointer or name is logged.
+No other failed-allocation callback may be registered in this diagnostic profile;
+the SDK registration API replaces the callback and has no getter.
+
+After the SDK returns, the task disarms capture before querying the matching
+capability heaps and logging, before existing transport-owner cleanup:
+
+```text
+alloc_diag phase=after_sdk_return_before_owner_cleanup role=<u32> sdk_err=<i32> captured=<0|1> requested=<u32> caps=<u32> allocator=<u32> origin=0 heap_sampled=<0|1> free=<u32> largest=<u32>
+```
+
+`role` is 1 node or 2 operator. `allocator` is 0 unknown, 1 `heap_caps_malloc`,
+2 `heap_caps_malloc_default`, 3 `heap_caps_calloc`, 4 `heap_caps_realloc`,
+5 `heap_caps_realloc_default`, 6 `heap_caps_malloc_prefer`,
+7 `heap_caps_calloc_prefer`, or 8 `heap_caps_realloc_prefer`. It identifies the
+reporting allocator API, **not** its caller; `origin=0` explicitly means unknown.
+`requested` is the SDK callback's byte-count argument, preserved without
+reinterpretation. In this SDK, `heap_caps_calloc_prefer` reports its element-size
+argument, so it must not be treated as independently verified total bytes.
+
+The heap samples are **after SDK return**, not fault-time heap availability.
+The SDK may already have freed resources. They do not prove alignment fit or a
+task-stack allocation cause. A failed SDK start without a matching callback
+still emits a record: `captured=0 heap_sampled=0`, and zero request/heap fields
+mean unavailable, not an empty heap. A captured allocation followed by SDK
+success is also reported; allocation capture alone does not mean start failed.
+Uncaptured success is silent. Registration failure emits only
+`alloc_diag_install err=<i32>` and does not change startup error handling.
+
+Host fixtures exercise the actual callback/start boundary; Tab5 CI also verifies
+that both final ELF hook definitions are strong. Other boards retain no-op hooks.
+These diagnostics change no stack sizes, allocator policy, SDK/dependency
+patches, retries, or cleanup. Physical allocation/reconnect proof remains a
+separate qualification gate.
+
 ### Streaming RX PSRAM and allocation diagnostics
 
 This branch also applies `patches/esp-hosted/tab5-sdio-first-allocation-failure.patch`

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -53,6 +53,53 @@ The separate ELF/map artifact copies that same firmware manifest unchanged.
 Retire the patch, helper and packaging exception together only after an
 upstream SDK fix is selected and qualified on affected hardware.
 
+### Camera CSI compatibility
+
+Tab5 CI additionally applies `patches/esp-video/tab5-csi-post-isp-format.patch`
+to the published `esp_video` 2.4.1 component at revision
+`67a555a517b7aa4753836432453659abfaca393a`. That component's IDF<6 mapping asks
+CSI to convert the sensor's RAW8 format to RGB565. The exact SDK above has
+backported the post-ISP CSI contract: on P4 revisions below 3, CSI input and
+output must match. The captured revision-1.3 failure was at `VIDIOC_STREAMON`,
+errno 3, which this video component maps from `ESP_ERR_NOT_SUPPORTED`.
+See [esp-video-components issue 98](https://github.com/espressif/esp-video-components/issues/98)
+for a related report; its different board/sensor is not Tab5 qualification.
+
+The patch keeps ISP conversion RAW8 to RGB565, then passes RGB565 to RGB565
+through CSI. This preserves 16-bit output and DMA sizing; it does not pass
+RAW8 through while claiming RGB565 buffers. Raw bypass, unsupported-format
+checks, SDK guards, allocation, sensor settings, and chip-revision selections
+are unchanged.
+
+Use only the isolated SDK and diagnostic profile described on this page.
+After SDK patching and `idf.py reconfigure`, apply the camera patch alongside
+the SDIO patches below, then build with normal Ninja:
+
+```sh
+python3 ../../scripts/tab5_camera_compat.py --idf-path "$IDF_PATH" \
+  --project-path . --component-path managed_components/espressif__esp_video --build-path build
+ninja -C build -j2
+python3 ../../scripts/tab5_camera_compat.py --idf-path "$IDF_PATH" \
+  --project-path . --component-path managed_components/espressif__esp_video --build-path build --verify-only
+```
+
+Application is gated by the exact SDK commit and CSI source hash, unchanged
+early-P4 profile, registry lock/manifest, original whole-component/source hashes,
+and tracked patch hash. Another SDK is refused without modifying it; no version
+macro is spoofed. After Ninja, verification checks the configured mapper path,
+current RISC-V object, and final patched component/source hashes. Component-manager
+integrity markers are never rewritten; stop if reconfiguration rejects a modified
+component rather than bypassing its checks.
+
+Packaging requires `--camera-compat` in addition to this branch's SDK/SDIO flags.
+Its additive `camera_compatibility_patch` record retains SDK and SDIO provenance
+unchanged, and the separate symbols artifact receives the same manifest. Host
+tests execute the complete upstream mapper, including original-failure/patched-pass,
+raw bypass, sibling outputs and rejection cases; they do not execute CSI DMA or
+capture a frame. A successful native build is not physical camera qualification.
+Retire this patch and its explicit packaging mode together after selecting and
+qualifying an upstream component that matches the actual SDK contract.
+
 ### NVS diagnostic build
 
 This diagnostic branch additionally applies

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -312,6 +312,14 @@ mislabeling the front image.
 openclaw nodes camera snap --node <tab5-node> --facing front
 ```
 
+`maxWidth` is an upper bound, not an exact JPEG width. Rotation and downscaling
+use one uniform PPA scale rounded down to a multiple of 1/16, without upscaling.
+For the 90/270-degree orientation, `maxWidth: 640` produces 630x1120 pixels;
+the JPEG and response report those actual dimensions. Packed RGB length and
+PPA output pitch use the same dimensions, while the allocation retains its
+cache-line alignment. This geometry correction does not qualify color,
+exposure, warm-up or the complete camera pipeline.
+
 ### Media stage diagnostics
 
 The capture owner emits one `camera_capture_diag` failure with a fixed `stage`,

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -382,10 +382,34 @@ The capture owner emits one `camera_capture_diag` failure with a fixed `stage`,
 `domain` and numeric `error`. `esp` is the BSP result; `errno` is captured
 immediately after the failed syscall; `validation` uses zero rather than stale
 errno. Existing numeric format, stride and length rejection details remain.
-The single `dqbuf_begin` marker precedes the first blocking dequeue; its
-presence without a terminal record does not prove capture success or failure.
-There is no per-frame trace, new timeout, capture retry or format fallback.
-The camera RPC's existing error code and cleanup behavior are unchanged.
+The single `dqbuf_begin` marker precedes the first dequeue; its presence without
+a later record does not locate a stall or prove capture success or failure.
+Each open configures a two-second ready-buffer wait through ESP Video's
+`VIDIOC_S_DQBUF_TIMEOUT`. Configuration failure reports `dqbuf_timeout_setup`
+and aborts capture. A missing frame fails without retry, including during
+`delayMs` warm-up. Warm-up still requeues early frames and selects the first
+valid frame at or after its 0..10000 ms deadline; it does not extend the
+per-dequeue allowance.
+
+This is a finite ready-buffer wait, not a whole-command deadline. Setup,
+preprocessing, PPA, JPEG and cleanup can take additional time. Two seconds
+is a policy allowance, not a measured maximum first-frame latency.
+
+`camera_pipeline_diag stage=<token> elapsed_ms=<unsigned decimal>` uses INFO
+level and tag `tab5_room_board`. Its fixed stages are `dqbuf_first_return`,
+`capture_complete`, `transform_begin`, `transform_end`, `encode_begin`,
+`encode_end`, `cleanup_begin`, `cleanup_end`, `release_begin`, and `release_end`.
+Each appears at most once, for at most ten new records per request, regardless
+of warm-up frames or JPEG quality attempts. Elapsed milliseconds use
+`uint64_t`/`PRIu64`; begin records contain zero. First-return measures only the
+first dequeue call, including failure; capture-complete follows selected-frame
+validation and includes warm-up. Other end records time their own synchronous
+region and mean it returned, not that ignored cleanup calls succeeded, sensor
+power was removed, or an RPC completed. Records carry no request identity;
+consumers must not infer association between requests from adjacency.
+
+There is no per-frame trace, capture retry or format fallback. The existing
+RPC error codes, privacy indicator and cleanup/ownership order are preserved.
 
 Talk uses the [component's fixed-field stage diagnostics](../../components/esp-openclaw-talk/README.md#stage-diagnostics),
 with room-generation startup/peer/teardown records and existing audio-counter

--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -313,12 +313,20 @@ clamped. The static home does not imply full touch, camera, network or Talk
 hardware qualification.
 
 The maintained MIPI-DSI/LVGL stack rotates to 1280x720 landscape and probes
-ILI9881C+GT911, ST7123 (touch firmware 3), and ST7121 (firmware 1). ST7123 is
-physically verified on the connected unit. ST7121 is compile-tested, not
-hardware-proven here, and uses only the isolated Apache-2.0 panel extension
+ILI9881C+GT911, ST7123 (touch firmware 3), and ST7121 (firmware 1). The upstream
+August 7, 2026 report records physical verification of ST7123. The September
+2026 test campaign instead recorded touch firmware revision 1, selecting
+ST7121, with panel initialization and LVGL startup observed. This is not full
+display or touch qualification. ST7121 uses the isolated Apache-2.0 panel extension
 adapted from M5Stack's official `M5Tab5-UserDemo` commit
 `68b19d37fbf9cefd5f256992f5dca34794c62ab4`; touch remains on the maintained
 ST7123-compatible API. No S3 bounce-buffer workaround is present.
+
+ST7121 explicitly places its two 720x40 RGB565 draw buffers and PPA rotation
+buffer in PSRAM, matching the other panel path. Their configured payload totals
+172,800 bytes, excluding allocation overhead; this is not a measured gain in
+internal heap or proof of working voice. Buffer dimensions, double buffering,
+rotation, cache handling, task stacks, and global allocation policy are unchanged.
 
 The board adapter keeps the official four-slot TDM order: MIC-L, speaker
 reference, MIC-R, headset mic. Shared AEC/WakeNet consume MIC-L plus the

--- a/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
+++ b/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
@@ -250,7 +250,8 @@ static lv_display_t *start_st7121_display(void)
         .vres = BSP_LCD_V_RES,
         .monochrome = false,
         .rotation = {.swap_xy = false, .mirror_x = false, .mirror_y = false},
-        .flags = {.buff_dma = true, .buff_spiram = false, .sw_rotate = true},
+        /* Match the other panels' PSRAM placement for draw and PPA buffers. */
+        .flags = {.buff_dma = false, .buff_spiram = true, .sw_rotate = true},
     };
     const lvgl_port_display_dsi_cfg_t dsi_cfg = {.flags.avoid_tearing = false};
     lv_display_t *display = lvgl_port_add_disp_dsi(&display_cfg, &dsi_cfg);

--- a/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
+++ b/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
@@ -5,8 +5,10 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/time.h>
 #include <time.h>
 
 #include "bsp/esp-bsp.h"
@@ -31,6 +33,7 @@
 #include "esp_timer.h"
 #include "esp_video_init.h"
 #include "esp_video_device.h"
+#include "esp_video_ioctl.h"
 #include "esp_vfs_fat.h"
 #include "linux/videodev2.h"
 #include "mbedtls/base64.h"
@@ -699,9 +702,19 @@ typedef struct {
     struct v4l2_buffer frame;
 } camera_frame_t;
 
+static void camera_pipeline_elapsed(const char *stage, int64_t started_us)
+{
+    uint64_t elapsed_ms = (uint64_t)(esp_timer_get_time() - started_us) / 1000U;
+    ESP_LOGI(TAG, "camera_pipeline_diag stage=%s elapsed_ms=%" PRIu64, stage, elapsed_ms);
+}
+
 static void close_camera_frame(camera_frame_t *camera)
 {
-    if (camera->fd >= 0) {
+    bool opened = camera->fd >= 0;
+    int64_t started_us = 0;
+    if (opened) {
+        ESP_LOGI(TAG, "camera_pipeline_diag stage=cleanup_begin elapsed_ms=0");
+        started_us = esp_timer_get_time();
         int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         (void)ioctl(camera->fd, VIDIOC_STREAMOFF, &type);
         for (size_t i = 0; i < 2; ++i) {
@@ -713,6 +726,7 @@ static void close_camera_frame(camera_frame_t *camera)
     }
     memset(camera, 0, sizeof(*camera));
     camera->fd = -1;
+    if (opened) camera_pipeline_elapsed("cleanup_end", started_us);
 }
 
 static esp_err_t capture_rgb565_frame(int delay_ms, camera_frame_t *camera)
@@ -741,6 +755,14 @@ static esp_err_t capture_rgb565_frame(int delay_ms, camera_frame_t *camera)
         goto fail;
     }
     needs_cleanup = true;
+
+    /* Bound each ready-buffer wait, not setup, warm-up, processing, or teardown. */
+    const struct timeval dequeue_timeout = {.tv_sec = 2, .tv_usec = 0};
+    if (ioctl(camera->fd, VIDIOC_S_DQBUF_TIMEOUT, &dequeue_timeout) != 0) {
+        failure_error = errno;
+        stage = "dqbuf_timeout_setup";
+        goto fail;
+    }
 
     struct v4l2_format format = {.type = V4L2_BUF_TYPE_VIDEO_CAPTURE};
     if (ioctl(camera->fd, VIDIOC_G_FMT, &format) != 0) {
@@ -862,14 +884,22 @@ static esp_err_t capture_rgb565_frame(int delay_ms, camera_frame_t *camera)
         goto fail;
     }
     ESP_LOGI(TAG, "camera_capture_diag stage=dqbuf_begin domain=none error=0");
-    int64_t deadline_us = esp_timer_get_time() + (int64_t)delay_ms * 1000;
+    int64_t capture_started_us = esp_timer_get_time();
+    int64_t deadline_us = capture_started_us + (int64_t)delay_ms * 1000;
+    bool first_dequeue = true;
     for (;;) {
         camera->frame = (struct v4l2_buffer){
             .type = V4L2_BUF_TYPE_VIDEO_CAPTURE,
             .memory = V4L2_MEMORY_MMAP,
         };
-        if (ioctl(camera->fd, VIDIOC_DQBUF, &camera->frame) != 0) {
-            failure_error = errno;
+        int64_t dequeue_started_us = first_dequeue ? esp_timer_get_time() : 0;
+        int dequeue_result = ioctl(camera->fd, VIDIOC_DQBUF, &camera->frame);
+        if (dequeue_result != 0) failure_error = errno;
+        if (first_dequeue) {
+            camera_pipeline_elapsed("dqbuf_first_return", dequeue_started_us);
+            first_dequeue = false;
+        }
+        if (dequeue_result != 0) {
             stage = "dqbuf";
             goto fail;
         }
@@ -898,6 +928,7 @@ static esp_err_t capture_rgb565_frame(int delay_ms, camera_frame_t *camera)
         domain = "validation";
         goto fail;
     }
+    camera_pipeline_elapsed("capture_complete", capture_started_us);
     return ESP_OK;
 fail:
     ESP_LOGE(TAG, "camera_capture_diag stage=%s domain=%s error=%d", stage, domain, failure_error);
@@ -1067,7 +1098,10 @@ static esp_err_t camera_snap(
 
     esp_err_t indicator_err = esp_openclaw_room_node_camera_indicator_begin();
     if (indicator_err != ESP_OK) {
+        ESP_LOGI(TAG, "camera_pipeline_diag stage=release_begin elapsed_ms=0");
+        int64_t release_started_us = esp_timer_get_time();
         esp_openclaw_room_node_release_camera();
+        camera_pipeline_elapsed("release_end", release_started_us);
         cJSON_Delete(params);
         error->code = "PRIVACY_INDICATOR_UNAVAILABLE";
         error->message = "capture refused because the visible camera indicator could not be armed";
@@ -1076,19 +1110,28 @@ static esp_err_t camera_snap(
     camera_frame_t camera = {.fd = -1};
     esp_err_t result = capture_rgb565_frame(delay_ms, &camera);
     if (result != ESP_OK) {
+        ESP_LOGI(TAG, "camera_pipeline_diag stage=release_begin elapsed_ms=0");
+        int64_t release_started_us = esp_timer_get_time();
         esp_openclaw_room_node_camera_indicator_end();
         esp_openclaw_room_node_release_camera();
+        camera_pipeline_elapsed("release_end", release_started_us);
         cJSON_Delete(params);
         error->code = "UNAVAILABLE";
         error->message = "Tab5 camera or V4L2 pipeline is unavailable";
         return result;
     }
     camera_transformed_frame_t transformed;
+    ESP_LOGI(TAG, "camera_pipeline_diag stage=transform_begin elapsed_ms=0");
+    int64_t stage_started_us = esp_timer_get_time();
     result = transform_camera_frame(&camera, max_width, &transformed);
+    camera_pipeline_elapsed("transform_end", stage_started_us);
     if (result != ESP_OK) {
         close_camera_frame(&camera);
+        ESP_LOGI(TAG, "camera_pipeline_diag stage=release_begin elapsed_ms=0");
+        stage_started_us = esp_timer_get_time();
         esp_openclaw_room_node_camera_indicator_end();
         esp_openclaw_room_node_release_camera();
+        camera_pipeline_elapsed("release_end", stage_started_us);
         cJSON_Delete(params);
         error->code = "UNAVAILABLE";
         error->message = "Tab5 camera PPA rotation/downscale is unavailable";
@@ -1099,6 +1142,8 @@ static esp_err_t camera_snap(
     int jpeg_size = 0;
     esp_err_t jpeg_result = ESP_OK;
     const char *jpeg_failure_message = NULL;
+    ESP_LOGI(TAG, "camera_pipeline_diag stage=encode_begin elapsed_ms=0");
+    stage_started_us = esp_timer_get_time();
     while (quality_percent >= 1) {
         jpeg_enc_config_t cfg = DEFAULT_JPEG_ENC_CONFIG();
         cfg.width = (int)transformed.width;
@@ -1145,12 +1190,16 @@ static esp_err_t camera_snap(
         jpeg_size = 0;
         quality_percent = quality_percent > 15 ? quality_percent - 15 : 0;
     }
+    camera_pipeline_elapsed("encode_end", stage_started_us);
     uint32_t captured_width = transformed.width;
     uint32_t captured_height = transformed.height;
     heap_caps_free(transformed.data);
     close_camera_frame(&camera);
+    ESP_LOGI(TAG, "camera_pipeline_diag stage=release_begin elapsed_ms=0");
+    stage_started_us = esp_timer_get_time();
     esp_openclaw_room_node_camera_indicator_end();
     esp_openclaw_room_node_release_camera();
+    camera_pipeline_elapsed("release_end", stage_started_us);
     cJSON_Delete(params);
     if (jpeg_result != ESP_OK) {
         error->code = "INTERNAL";

--- a/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
+++ b/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
@@ -46,7 +46,7 @@
 #define CAMERA_SENSOR_WIDTH 1280U
 #define CAMERA_SENSOR_HEIGHT 720U
 #define CAMERA_MAX_PIXELS (1024U * 1024U)
-#define CAMERA_DIMENSION_ALIGNMENT 8U
+#define CAMERA_SCALE_DENOMINATOR 16U
 #define CAMERA_ALIGN_UP(value, alignment) (((value) + (alignment) - 1) & ~((alignment) - 1))
 
 _Static_assert(
@@ -941,17 +941,18 @@ static esp_err_t transform_camera_frame(
     uint32_t natural_width = swaps_dimensions ? camera->height : camera->width;
     uint32_t natural_height = swaps_dimensions ? camera->width : camera->height;
     ESP_RETURN_ON_FALSE(
+        natural_width != 0 && natural_height != 0 &&
         (uint64_t)natural_width * natural_height <= CAMERA_MAX_PIXELS,
         ESP_ERR_NOT_SUPPORTED,
         TAG,
         "rotated camera frame exceeds one megapixel");
 
-    uint32_t output_width = natural_width;
-    if ((uint32_t)max_width < output_width) output_width = (uint32_t)max_width;
-    output_width &= ~(CAMERA_DIMENSION_ALIGNMENT - 1U);
-    uint32_t output_height = (uint32_t)(
-        ((uint64_t)natural_height * output_width / natural_width) &
-        ~(uint64_t)(CAMERA_DIMENSION_ALIGNMENT - 1U));
+    uint32_t width_limit = natural_width;
+    if ((uint32_t)max_width < width_limit) width_limit = (uint32_t)max_width;
+    /* PPA truncates scales to 1/16; geometry and DMA pitch must use that same scale. */
+    uint32_t scale_steps = (uint64_t)width_limit * CAMERA_SCALE_DENOMINATOR / natural_width;
+    uint32_t output_width = (uint64_t)natural_width * scale_steps / CAMERA_SCALE_DENOMINATOR;
+    uint32_t output_height = (uint64_t)natural_height * scale_steps / CAMERA_SCALE_DENOMINATOR;
     ESP_RETURN_ON_FALSE(
         output_width != 0 && output_height != 0 &&
         (uint64_t)output_width * output_height <= CAMERA_MAX_PIXELS,
@@ -968,12 +969,7 @@ static esp_err_t transform_camera_frame(
         MALLOC_CAP_SPIRAM);
     ESP_RETURN_ON_FALSE(output != NULL, ESP_ERR_NO_MEM, TAG, "camera transform buffer allocation failed");
 
-    float scale_x = (float)output_width / camera->width;
-    float scale_y = (float)output_height / camera->height;
-    if (swaps_dimensions) {
-        scale_x = (float)output_height / camera->width;
-        scale_y = (float)output_width / camera->height;
-    }
+    float scale = (float)scale_steps / CAMERA_SCALE_DENOMINATOR;
     const ppa_srm_oper_config_t config = {
         .in = {
             .buffer = camera->buffers[camera->frame.index],
@@ -991,8 +987,8 @@ static esp_err_t transform_camera_frame(
             .srm_cm = PPA_SRM_COLOR_MODE_RGB888,
         },
         .rotation_angle = rotation,
-        .scale_x = scale_x,
-        .scale_y = scale_y,
+        .scale_x = scale,
+        .scale_y = scale,
         .mode = PPA_TRANS_MODE_BLOCKING,
     };
     esp_err_t result = ppa_do_scale_rotate_mirror(camera_ppa_srm, &config);

--- a/examples/m5stack-tab5-room-node/main/CMakeLists.txt
+++ b/examples/m5stack-tab5-room-node/main/CMakeLists.txt
@@ -1,4 +1,8 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES esp-openclaw-room-node tab5_room_board)
+    REQUIRES esp-openclaw-room-node tab5_room_board
+    PRIV_REQUIRES esp-openclaw-node heap freertos)
+
+idf_component_get_property(node_component_dir esp-openclaw-node COMPONENT_DIR)
+target_include_directories(${COMPONENT_LIB} PRIVATE "${node_component_dir}/private_include")

--- a/examples/m5stack-tab5-room-node/main/main.c
+++ b/examples/m5stack-tab5-room-node/main/main.c
@@ -1,8 +1,147 @@
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <string.h>
+
+#include "esp_attr.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
 #include "esp_openclaw_room_node.h"
+#include "esp_openclaw_node_transport_diag.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "tab5_room_board.h"
+
+enum {
+    ALLOCATION_DISARMED,
+    ALLOCATION_ARMED,
+    ALLOCATION_WRITING,
+    ALLOCATION_CAPTURED,
+};
+
+typedef struct {
+    _Atomic(TaskHandle_t) task;
+    atomic_uint state;
+    size_t requested;
+    uint32_t caps;
+    const char *function;
+} allocation_slot_t;
+
+_Static_assert(ATOMIC_POINTER_LOCK_FREE == 2 && ATOMIC_INT_LOCK_FREE == 2,
+               "Allocation capture requires lock-free atomics");
+
+static DRAM_ATTR allocation_slot_t s_allocation_slots[2];
+static const char s_allocator_names[][32] = {
+    "heap_caps_malloc",
+    "heap_caps_malloc_default",
+    "heap_caps_calloc",
+    "heap_caps_realloc",
+    "heap_caps_realloc_default",
+    "heap_caps_malloc_prefer",
+    "heap_caps_calloc_prefer",
+    "heap_caps_realloc_prefer",
+};
+
+static int allocation_role(const char *role)
+{
+    if (role != NULL && strcmp(role, "node") == 0) {
+        return 0;
+    }
+    if (role != NULL && strcmp(role, "operator") == 0) {
+        return 1;
+    }
+    return -1;
+}
+
+static void IRAM_ATTR allocation_failed(size_t requested, uint32_t caps, const char *function)
+{
+    if (xPortInIsrContext()) {
+        return;
+    }
+    TaskHandle_t task = xTaskGetCurrentTaskHandle();
+    for (unsigned i = 0; i < 2; ++i) {
+        allocation_slot_t *slot = &s_allocation_slots[i];
+        if (atomic_load_explicit(&slot->task, memory_order_acquire) != task) {
+            continue;
+        }
+        unsigned expected = ALLOCATION_ARMED;
+        if (!atomic_compare_exchange_strong_explicit(
+                &slot->state, &expected, ALLOCATION_WRITING,
+                memory_order_acquire, memory_order_relaxed)) {
+            continue;
+        }
+        slot->requested = requested;
+        slot->caps = caps;
+        slot->function = function;
+        /* The matching task consumes only a completely published first failure. */
+        atomic_store_explicit(&slot->state, ALLOCATION_CAPTURED, memory_order_release);
+    }
+}
+
+void esp_openclaw_node_transport_start_begin(const char *role)
+{
+    int index = allocation_role(role);
+    if (index < 0) {
+        return;
+    }
+    allocation_slot_t *slot = &s_allocation_slots[index];
+    TaskHandle_t expected = NULL;
+    if (!atomic_compare_exchange_strong_explicit(
+            &slot->task, &expected, xTaskGetCurrentTaskHandle(),
+            memory_order_acq_rel, memory_order_relaxed)) {
+        return;
+    }
+    atomic_store_explicit(&slot->state, ALLOCATION_ARMED, memory_order_release);
+}
+
+void esp_openclaw_node_transport_start_end(const char *role, esp_err_t result)
+{
+    int index = allocation_role(role);
+    if (index < 0) {
+        return;
+    }
+    allocation_slot_t *slot = &s_allocation_slots[index];
+    if (atomic_load_explicit(&slot->task, memory_order_acquire) != xTaskGetCurrentTaskHandle()) {
+        return;
+    }
+    unsigned state = atomic_exchange_explicit(&slot->state, ALLOCATION_DISARMED, memory_order_acq_rel);
+    bool captured = state == ALLOCATION_CAPTURED;
+    size_t requested = captured ? slot->requested : 0;
+    uint32_t caps = captured ? slot->caps : 0;
+    const char *function = captured ? slot->function : NULL;
+    atomic_store_explicit(&slot->task, NULL, memory_order_release);
+
+    if (!captured && result == ESP_OK) {
+        return;
+    }
+    unsigned allocator = 0;
+    /* Pinned SDK callers pass static __func__ strings; never dereference in the callback. */
+    if (function != NULL) {
+        for (unsigned i = 0; i < sizeof(s_allocator_names) / sizeof(s_allocator_names[0]); ++i) {
+            if (strncmp(function, s_allocator_names[i], sizeof(s_allocator_names[0])) == 0) {
+                allocator = i + 1;
+                break;
+            }
+        }
+    }
+    /* After SDK return: it may already have freed resources since the failure. */
+    size_t free_bytes = captured ? heap_caps_get_free_size(caps) : 0;
+    size_t largest = captured ? heap_caps_get_largest_free_block(caps) : 0;
+    ESP_LOGI(
+        "tab5_alloc",
+        "alloc_diag phase=after_sdk_return_before_owner_cleanup role=%u sdk_err=%d "
+        "captured=%u requested=%zu caps=%" PRIu32 " allocator=%u origin=0 "
+        "heap_sampled=%u free=%zu largest=%zu",
+        (unsigned)index + 1, result, (unsigned)captured, requested, caps, allocator,
+        (unsigned)captured, free_bytes, largest);
+}
 
 void app_main(void)
 {
+    esp_err_t diagnostic_err = heap_caps_register_failed_alloc_callback(allocation_failed);
+    if (diagnostic_err != ESP_OK) {
+        ESP_LOGE("tab5_alloc", "alloc_diag_install err=%d", diagnostic_err);
+    }
     esp_openclaw_room_node_config_t config = {0};
     ESP_ERROR_CHECK(tab5_room_board_config(&config));
     ESP_ERROR_CHECK(esp_openclaw_room_node_start(&config));

--- a/patches/esp-video/tab5-csi-post-isp-format.patch
+++ b/patches/esp-video/tab5-csi-post-isp-format.patch
@@ -1,0 +1,18 @@
+diff --git a/src/device/esp_video_csi_format.c b/src/device/esp_video_csi_format.c
+--- a/src/device/esp_video_csi_format.c
++++ b/src/device/esp_video_csi_format.c
+@@ -506,13 +506,8 @@ esp_err_t esp_video_csi_check_format(esp_cam_sensor_output_format_t sensor_fmt, uint
+         /* ISP output to requested format */
+         in_out_format->isp_output_fmt = v4l2_to_isp_color(requested_fmt);
+
+-        /* ISP output to CSI output */
+-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+-        /* Old IDF version: use sensor format as CSI input */
+-        in_out_format->csi_input_fmt = v4l2_to_csi_color(sensor_v4l2_fmt);
+-#else
++        /* The pinned Tab5 SDK backports the post-ISP CSI input contract. */
+         in_out_format->csi_input_fmt = v4l2_to_csi_color(requested_fmt);
+-#endif
+         in_out_format->csi_output_fmt = v4l2_to_csi_color(requested_fmt);
+
+         ESP_LOGD(TAG, "Format supported: sensor->ISP(process)->CSI(passthrough)");

--- a/scripts/package_firmware.py
+++ b/scripts/package_firmware.py
@@ -17,6 +17,7 @@ from urllib.parse import urlsplit
 
 from idf_tab5_compat import verify_sdk_patch
 from tab5_sdio_diagnostics import COMPONENT as SDIO_COMPONENT, verify_component_patch
+from tab5_camera_compat import COMPONENT as CAMERA_COMPONENT, verify_component_patch as verify_camera_patch
 
 
 EXAMPLES = {
@@ -164,7 +165,8 @@ def tab5_provenance(project, build):
 
 
 def package_firmware(project, build, output, target, provenance, dependencies,
-                     nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False):
+                     nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False,
+                     camera_compat=False):
     project, build, output = project.resolve(), build.resolve(), output.resolve()
     repo = Path(git(project, "rev-parse", "--show-toplevel")).resolve()
     if project.parent != repo / "examples" or EXAMPLES.get(project.name) != target:
@@ -217,6 +219,16 @@ def package_firmware(project, build, output, target, provenance, dependencies,
             project, project / "managed_components/espressif__esp_hosted",
             build, dependencies, patched=sdio_diagnostics, psram_rx=sdio_psram_rx,
         )
+    camera_patch = None
+    if camera_compat and (project.name != "m5stack-tab5-room-node" or not nvs_diagnostics):
+        raise ValueError("Camera compatibility requires the explicitly patched Tab5 SDK")
+    if camera_compat or (
+            project.name == "m5stack-tab5-room-node"
+            and CAMERA_COMPONENT in dependencies["dependencies"]):
+        camera_patch = verify_camera_patch(
+            project, project / "managed_components/espressif__esp_video",
+            build, idf, dependencies, patched=camera_compat, compiled=camera_compat,
+        )
     normalize = [(build, "<build>"), (project, "<project>"), (repo, "<repository>"), (idf, "<idf>")]
     lock_file = checked_file(project / "dependencies.lock", roots)
     manifest = {
@@ -254,6 +266,8 @@ def package_firmware(project, build, output, target, provenance, dependencies,
         manifest["component_compatibility_patch"] = sdio_patch
     elif sdio_diagnostics:
         manifest["component_diagnostic_patch"] = sdio_patch
+    if camera_compat:
+        manifest["camera_compatibility_patch"] = camera_patch
     if project.name == "m5stack-tab5-room-node":
         manifest["tab5_bsp"] = tab5_provenance(project, build)
     extra = flash["extra_esptool_args"]
@@ -363,12 +377,14 @@ def main():
     parser.add_argument("--nvs-diagnostics", action="store_true")
     parser.add_argument("--sdio-diagnostics", action="store_true")
     parser.add_argument("--sdio-psram-rx", action="store_true")
+    parser.add_argument("--camera-compat", action="store_true")
     args = parser.parse_args()
     provenance = vars(args).copy()
     provenance.pop("target")
     provenance.pop("nvs_diagnostics")
     provenance.pop("sdio_diagnostics")
     provenance.pop("sdio_psram_rx")
+    provenance.pop("camera_compat")
     project = Path.cwd()
     # ruamel.yaml is already part of ESP-IDF's component-manager environment.
     try:
@@ -380,7 +396,7 @@ def main():
         output = package_firmware(
             project, project / "build", project / "build/firmware",
             args.target, provenance, dependencies, args.nvs_diagnostics,
-            args.sdio_diagnostics, args.sdio_psram_rx,
+            args.sdio_diagnostics, args.sdio_psram_rx, args.camera_compat,
         )
     except ValueError as error:
         parser.exit(1, f"Firmware packaging failed: {error}\n")

--- a/scripts/tab5_camera_compat.py
+++ b/scripts/tab5_camera_compat.py
@@ -32,6 +32,35 @@ PROFILE = {
     "CONFIG_ESP32P4_REV_MAX_FULL": "199",
 }
 
+# Only these exact static refusals may cross the CLI boundary.
+REFUSAL_CODES = {
+    "Select the configured Tab5 project and its managed esp_video": "project_path",
+    "Managed component must not contain symbolic links": "component_symlink",
+    "Dependency lock must contain a dependency mapping": "dependency_mapping",
+    "Resolved camera component must have a registry source": "registry_source",
+    "Resolved esp_video identity differs from the approved 2.4.1 component": "component_identity",
+    "Camera component manifest or registry revision differs": "component_manifest",
+    "Tracked camera patch has unexpected contents": "tracked_patch",
+    "Camera build does not select the explicit SDK and project": "build_identity",
+    "Camera configuration is outside the selected project": "config_path",
+    "Camera compatibility requires the unchanged early-P4 Tab5 profile": "early_p4_profile",
+    "SDK CSI source does not match the approved backported contract": "sdk_csi_contract",
+    "Build must compile exactly one camera format mapper": "mapper_count",
+    "Build selects a different camera format mapper": "mapper_path",
+    "Camera compiler invocation selects a different source": "compiler_source",
+    "Camera compile command must identify its output object": "compiler_output",
+    "Camera object must be inside the selected build": "object_path",
+    "Camera component bytes do not match the selected profile": "component_integrity",
+    "Camera source does not match the explicitly selected profile": "source_profile",
+    "Camera mapper needs a current ELF32 RISC-V relocatable object": "compiled_object",
+    "Select the SDK repository root explicitly": "sdk_root",
+    "SDK is not at the approved compatibility-patch base": "sdk_base",
+    "Tracked SDK patch has unexpected contents": "sdk_patch_bytes",
+    "SDK base source does not match the approved whole-file hash": "sdk_base_source",
+    "SDK source must be a regular file at the approved path": "sdk_source_path",
+    "SDK is not modified by exactly the selected Tab5 patches": "sdk_patch_state",
+}
+
 
 def digest(data):
     return hashlib.sha256(data).hexdigest()
@@ -185,7 +214,8 @@ def main():
                            args.idf_path, dependencies)
     except (ValueError, TypeError, KeyError, OSError, ImportError,
             YAMLError, subprocess.CalledProcessError) as error:
-        parser.exit(1, f"Camera compatibility patch refused: {type(error).__name__}. Check the pinned profile and build inputs.\n")
+        code = REFUSAL_CODES.get(str(error), "unclassified") if type(error) is ValueError else "unclassified"
+        parser.exit(1, f"Camera compatibility patch refused: guard={code}. Check the pinned profile and build inputs.\n")
     print(json.dumps(result, indent=2))
 
 

--- a/scripts/tab5_camera_compat.py
+++ b/scripts/tab5_camera_compat.py
@@ -4,6 +4,7 @@
 import argparse
 import hashlib
 import json
+import os
 from pathlib import Path
 import shlex
 import subprocess
@@ -59,6 +60,8 @@ REFUSAL_CODES = {
     "SDK base source does not match the approved whole-file hash": "sdk_base_source",
     "SDK source must be a regular file at the approved path": "sdk_source_path",
     "SDK is not modified by exactly the selected Tab5 patches": "sdk_patch_state",
+    "Cannot determine the camera component Git worktree": "component_worktree",
+    "Camera component is outside its Git worktree": "component_worktree_path",
 }
 
 
@@ -191,8 +194,26 @@ def apply_component_patch(project, component, build, idf, dependencies):
     if digest((component / SOURCE_PATH).read_bytes()) != PATCHED_SHA256:
         verify_component_patch(project, component, build, idf, dependencies,
                                patched=False, compiled=False)
-        subprocess.run(["git", "apply", "--check", str(PATCH_PATH)], cwd=component, check=True)
-        subprocess.run(["git", "apply", str(PATCH_PATH)], cwd=component, check=True)
+        discovery = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], cwd=component,
+            capture_output=True, text=True, env={**os.environ, "LC_ALL": "C"},
+        )
+        root, directory = component, []
+        if discovery.returncode == 0:
+            root = Path(discovery.stdout.strip()).resolve(strict=True)
+            if not component.is_relative_to(root):
+                raise ValueError("Camera component is outside its Git worktree")
+            directory = ["--directory=" + component.relative_to(root).as_posix()]
+        elif (discovery.returncode != 128
+              or discovery.stderr.strip()
+              != "fatal: not a git repository (or any of the parent directories): .git"
+              or any((parent / ".git").exists() or (parent / ".git").is_symlink()
+                     for parent in (component, *component.parents))):
+            raise ValueError("Cannot determine the camera component Git worktree")
+        # Git-style patch headers are filtered by the current repository prefix.
+        subprocess.run(["git", "apply", "--check", *directory, str(PATCH_PATH)],
+                       cwd=root, check=True)
+        subprocess.run(["git", "apply", *directory, str(PATCH_PATH)], cwd=root, check=True)
     return verify_component_patch(project, component, build, idf, dependencies, compiled=False)
 
 

--- a/scripts/tab5_camera_compat.py
+++ b/scripts/tab5_camera_compat.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Apply or verify the pinned Tab5 post-ISP CSI format compatibility patch."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import subprocess
+
+from idf_tab5_compat import BASE_COMMIT, git, verify_sdk_patch
+
+
+COMPONENT = "espressif/esp_video"
+VERSION = "2.4.1"
+REVISION = "67a555a517b7aa4753836432453659abfaca393a"
+COMPONENT_HASH = "ef614cc04e69e117fd08272a8b347ae5972eff2d0c8659af6444f8484931c7c1"
+PATCHED_COMPONENT_HASH = "106b93e92355f7577ee03f2ea3208d43b8fad15780c438b51633e20c81d10ccf"
+MANIFEST_SHA256 = "7ebdab70659a0b198ab04bf1baaacf0b97a6b3e90200f26190c48f51e0e90f62"
+SOURCE_PATH = "src/device/esp_video_csi_format.c"
+ORIGINAL_SHA256 = "1564837860a5af41f0e3191508e41b5c1dcbec87518b1c4b4d1a549a66a3aa3b"
+PATCHED_SHA256 = "99e47cbdbb6fc8d218ea17ac8ac4fd02c7b03aad89e06c48bbc1e5df4d4c3dfb"
+PATCH_RELATIVE = "patches/esp-video/tab5-csi-post-isp-format.patch"
+PATCH_PATH = Path(__file__).resolve().parents[1] / PATCH_RELATIVE
+PATCH_SHA256 = "725f6309fe77fd532a69330c7f3c9632b45675fe05a2489f76895d154098cd36"
+SDK_SOURCE = "components/esp_driver_cam/csi/src/esp_cam_ctlr_csi.c"
+SDK_SOURCE_SHA256 = "2ec4c6e9fa2f6b83760e04d8dce269b02f5eafaae3feed7d761de5699fac152b"
+PROFILE = {
+    "CONFIG_IDF_TARGET": '"esp32p4"',
+    "CONFIG_ESP32P4_SELECTS_REV_LESS_V3": "y",
+    "CONFIG_ESP32P4_REV_MIN_FULL": "0",
+    "CONFIG_ESP32P4_REV_MAX_FULL": "199",
+}
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def inspect_component(project, component, build, idf, dependencies, patched):
+    project = Path(project).resolve(strict=True)
+    component = Path(component).absolute()
+    build = Path(build).resolve(strict=True)
+    idf = Path(idf).resolve(strict=True)
+    expected = project / "managed_components/espressif__esp_video"
+    if (project.name != "m5stack-tab5-room-node" or project.parent.name != "examples"
+            or component != expected or component.resolve(strict=True) != expected
+            or not build.is_relative_to(project)):
+        raise ValueError("Select the configured Tab5 project and its managed esp_video")
+    if any(path.is_symlink() for path in component.rglob("*")):
+        raise ValueError("Managed component must not contain symbolic links")
+    if (not isinstance(dependencies, dict)
+            or not isinstance(dependencies.get("dependencies"), dict)):
+        raise ValueError("Dependency lock must contain a dependency mapping")
+    dependency = dependencies["dependencies"].get(COMPONENT, {})
+    if not isinstance(dependency, dict) or not isinstance(dependency.get("source"), dict):
+        raise ValueError("Resolved camera component must have a registry source")
+    source = dependency["source"]
+    if (dependencies.get("target") != "esp32p4"
+            or dependency.get("version") != VERSION
+            or dependency.get("component_hash") != COMPONENT_HASH
+            or source.get("type") != "service"
+            or source.get("registry_url") != "https://components.espressif.com/"):
+        raise ValueError("Resolved esp_video identity differs from the approved 2.4.1 component")
+    if digest((component / "idf_component.yml").read_bytes()) != MANIFEST_SHA256:
+        raise ValueError("Camera component manifest or registry revision differs")
+    if PATCH_PATH.is_symlink() or digest(PATCH_PATH.read_bytes()) != PATCH_SHA256:
+        raise ValueError("Tracked camera patch has unexpected contents")
+    description = json.loads((build / "project_description.json").read_text())
+    if (Path(description["idf_path"]).resolve() != idf
+            or Path(description["project_path"]).resolve() != project
+            or Path(description["build_dir"]).resolve() != build
+            or description["target"] != "esp32p4"):
+        raise ValueError("Camera build does not select the explicit SDK and project")
+    config_file = Path(description["config_file"]).resolve(strict=True)
+    if not config_file.is_relative_to(project):
+        raise ValueError("Camera configuration is outside the selected project")
+    config = dict(line.split("=", 1) for line in config_file.read_text().splitlines()
+                  if line.startswith("CONFIG_") and "=" in line)
+    if patched and any(config.get(key) != value for key, value in PROFILE.items()):
+        raise ValueError("Camera compatibility requires the unchanged early-P4 Tab5 profile")
+    if patched:
+        # The version number alone does not identify this backported CSI contract.
+        verify_sdk_patch(idf, nvs_diagnostics=True)
+        sdk_source = idf / SDK_SOURCE
+        if (sdk_source.resolve(strict=True) != sdk_source
+                or digest(sdk_source.read_bytes()) != SDK_SOURCE_SHA256
+                or digest(git(idf, "show", f"HEAD:{SDK_SOURCE}")) != SDK_SOURCE_SHA256):
+            raise ValueError("SDK CSI source does not match the approved backported contract")
+    commands = json.loads((build / "compile_commands.json").read_text())
+    selected = [entry for entry in commands if Path(entry["file"]).name == Path(SOURCE_PATH).name]
+    if len(selected) != 1:
+        raise ValueError("Build must compile exactly one camera format mapper")
+    command = selected[0]
+    directory = Path(command["directory"])
+    if (directory / command["file"]).resolve(strict=True) != component / SOURCE_PATH:
+        raise ValueError("Build selects a different camera format mapper")
+    arguments = command.get("arguments")
+    if arguments is None:
+        arguments = shlex.split(command["command"])
+    if (arguments.count("-c") != 1 or arguments.index("-c") + 1 == len(arguments)
+            or (directory / arguments[arguments.index("-c") + 1]).resolve(strict=True)
+            != component / SOURCE_PATH):
+        raise ValueError("Camera compiler invocation selects a different source")
+    if arguments.count("-o") != 1 or arguments.index("-o") + 1 == len(arguments):
+        raise ValueError("Camera compile command must identify its output object")
+    output = (directory / arguments[arguments.index("-o") + 1]).resolve()
+    if not output.is_relative_to(build):
+        raise ValueError("Camera object must be inside the selected build")
+    return component, output
+
+
+def validate_component_hash(component, expected):
+    from idf_component_tools.errors import ProcessingError
+    from idf_component_tools.hash_tools.errors import ValidatingHashError
+    from idf_component_tools.hash_tools.validate import (
+        validate_hash_eq_hashdir,
+        validate_hash_eq_hashfile,
+    )
+    try:
+        validate_hash_eq_hashfile(component, COMPONENT_HASH)
+        validate_hash_eq_hashdir(component, expected)
+    except (ProcessingError, ValidatingHashError) as error:
+        raise ValueError("Camera component bytes do not match the selected profile") from error
+
+
+def verify_component_patch(project, component, build, idf, dependencies,
+                           patched=True, compiled=True):
+    component, output = inspect_component(project, component, build, idf, dependencies, patched)
+    source = component / SOURCE_PATH
+    source_hash = digest(source.read_bytes())
+    if source_hash != (PATCHED_SHA256 if patched else ORIGINAL_SHA256):
+        raise ValueError("Camera source does not match the explicitly selected profile")
+    validate_component_hash(component, PATCHED_COMPONENT_HASH if patched else COMPONENT_HASH)
+    result = {"component": COMPONENT, "version": VERSION, "modified": patched}
+    if patched:
+        result.update(
+            profile="tab5-early-p4-post-isp-csi", sdk_base_commit=BASE_COMMIT,
+            sdk_contract_source=SDK_SOURCE, sdk_contract_sha256=SDK_SOURCE_SHA256,
+            registry_revision=REVISION, registry_path="esp_video",
+            original_component_hash=COMPONENT_HASH,
+            patched_component_hash=PATCHED_COMPONENT_HASH,
+            source=SOURCE_PATH, original_source_sha256=ORIGINAL_SHA256,
+            patched_source_sha256=source_hash,
+            patch=PATCH_RELATIVE, patch_sha256=PATCH_SHA256,
+        )
+    if compiled:
+        with output.open("rb") as stream:
+            header = stream.read(20)
+        if (header[:6] != b"\x7fELF\x01\x01" or header[16:20] != b"\x01\x00\xf3\x00"
+                or output.stat().st_mtime_ns < source.stat().st_mtime_ns):
+            raise ValueError("Camera mapper needs a current ELF32 RISC-V relocatable object")
+        result["compiled_object"] = {
+            "path": output.relative_to(Path(build).resolve()).as_posix(),
+            "sha256": digest(output.read_bytes()),
+        }
+    return result
+
+
+def apply_component_patch(project, component, build, idf, dependencies):
+    component, _ = inspect_component(project, component, build, idf, dependencies, patched=True)
+    if digest((component / SOURCE_PATH).read_bytes()) != PATCHED_SHA256:
+        verify_component_patch(project, component, build, idf, dependencies,
+                               patched=False, compiled=False)
+        subprocess.run(["git", "apply", "--check", str(PATCH_PATH)], cwd=component, check=True)
+        subprocess.run(["git", "apply", str(PATCH_PATH)], cwd=component, check=True)
+    return verify_component_patch(project, component, build, idf, dependencies, compiled=False)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ("project-path", "component-path", "build-path", "idf-path"):
+        parser.add_argument("--" + name, type=Path, required=True)
+    parser.add_argument("--verify-only", action="store_true")
+    args = parser.parse_args()
+    try:
+        from ruamel.yaml import YAML
+        from ruamel.yaml.error import YAMLError
+    except ImportError:
+        parser.exit(1, "Run this helper in the configured ESP-IDF Python environment.\n")
+    try:
+        dependencies = YAML(typ="safe").load((args.project_path / "dependencies.lock").read_text())
+        operation = verify_component_patch if args.verify_only else apply_component_patch
+        result = operation(args.project_path, args.component_path, args.build_path,
+                           args.idf_path, dependencies)
+    except (ValueError, TypeError, KeyError, OSError, ImportError,
+            YAMLError, subprocess.CalledProcessError) as error:
+        parser.exit(1, f"Camera compatibility patch refused: {type(error).__name__}. Check the pinned profile and build inputs.\n")
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/fixtures/test_nvs_session.c
+++ b/scripts/tests/fixtures/test_nvs_session.c
@@ -1,7 +1,10 @@
 #include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "esp_openclaw_node_persisted_session.h"
 #include "nvs.h"
 
@@ -11,23 +14,60 @@ static unsigned record_count, string_calls, erase_calls, commit_calls, close_cal
 static int open_error, version_error, size_error[2], value_error[2], clear_error;
 static uint8_t version;
 static const char *values[2];
+static bool contention, emitter_entered;
+static pthread_mutex_t emitter_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t emitter_ready = PTHREAD_COND_INITIALIZER;
 
-int esp_rom_printf(const char *format, ...)
+static int capture_record(const char *format, va_list args)
 {
     assert(record_count < 16);
     record_t *r = &records[record_count++];
-    va_list args;
-    va_start(args, format);
     r->role = va_arg(args, unsigned);
     r->stage = va_arg(args, unsigned);
     r->err = va_arg(args, int);
     r->presence = va_arg(args, unsigned);
-    va_end(args);
     char text[160];
     snprintf(text, sizeof(text), format, r->role, r->stage, r->err, r->presence);
     assert(strstr(text, "canary") == NULL);
     assert(strstr(text, "://") == NULL);
     return 0;
+}
+
+static void signal_emitter(void)
+{
+    assert(pthread_mutex_lock(&emitter_lock) == 0);
+    emitter_entered = true;
+    assert(pthread_cond_signal(&emitter_ready) == 0);
+    assert(pthread_mutex_unlock(&emitter_lock) == 0);
+}
+
+int host_diagnostic_printf(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    if (contention) signal_emitter();
+    int result = contention ? vprintf(format, args) : capture_record(format, args);
+    va_end(args);
+    return result;
+}
+
+int esp_rom_printf(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    int result;
+    if (contention) {
+        /* Model ROM's separate output path, which does not take stdout's lock. */
+        char text[160];
+        result = vsnprintf(text, sizeof(text), format, args);
+        assert(result > 0 && (size_t)result < sizeof(text));
+        assert(write(STDOUT_FILENO, text, (size_t)result) == result);
+        signal_emitter();
+    } else {
+        result = capture_record(format, args);
+    }
+    va_end(args);
+    return result;
 }
 
 esp_err_t nvs_open(const char *name, int mode, nvs_handle_t *handle)
@@ -84,8 +124,63 @@ static void expect(unsigned index, unsigned role, unsigned stage, int err, unsig
     assert(r.role == role && r.stage == stage && r.err == err && r.presence == presence);
 }
 
-int main(void)
+static void *load_session_during_log(void *arg)
 {
+    (void)arg;
+    esp_openclaw_node_persisted_session_t session;
+    assert(esp_openclaw_node_persisted_session_load("operator", &session) == 4363);
+    return NULL;
+}
+
+static void test_stdio_contention(void)
+{
+    reset();
+    open_error = 4363;
+    contention = true;
+    FILE *capture = tmpfile();
+    assert(capture != NULL);
+    assert(fflush(stdout) == 0);
+    int saved_stdout = dup(STDOUT_FILENO);
+    assert(saved_stdout >= 0);
+    assert(dup2(fileno(capture), STDOUT_FILENO) == STDOUT_FILENO);
+
+    flockfile(stdout);
+    assert(fputs("I ", stdout) >= 0);
+    assert(fflush(stdout) == 0);
+    pthread_t worker;
+    assert(pthread_create(&worker, NULL, load_session_during_log, NULL) == 0);
+    assert(pthread_mutex_lock(&emitter_lock) == 0);
+    while (!emitter_entered) {
+        assert(pthread_cond_wait(&emitter_ready, &emitter_lock) == 0);
+    }
+    assert(pthread_mutex_unlock(&emitter_lock) == 0);
+    assert(fputs("(1) synthetic: complete\n", stdout) >= 0);
+    assert(fflush(stdout) == 0);
+    funlockfile(stdout);
+    assert(pthread_join(worker, NULL) == 0);
+    assert(fflush(stdout) == 0);
+    assert(dup2(saved_stdout, STDOUT_FILENO) == STDOUT_FILENO);
+    assert(close(saved_stdout) == 0);
+
+    rewind(capture);
+    char output[256] = {0};
+    size_t length = fread(output, 1, sizeof(output) - 1, capture);
+    assert(!ferror(capture) && feof(capture));
+    const char *expected =
+        "I (1) synthetic: complete\n"
+        "nvs_session_diag role=2 stage=1 err=4363 presence=0\n";
+    assert(length == strlen(expected) && strcmp(output, expected) == 0);
+    assert(fclose(capture) == 0);
+    puts("runtime diagnostic preserved stdout log framing");
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "--stdio-contention") == 0) {
+        test_stdio_contention();
+        return 0;
+    }
+    assert(argc == 1);
     const char *roles[] = {"node", "operator"};
     for (unsigned role = 1; role <= 2; role++) {
         esp_openclaw_node_persisted_session_t session;

--- a/scripts/tests/fixtures/test_tab5_allocation_diagnostics.c
+++ b/scripts/tests/fixtures/test_tab5_allocation_diagnostics.c
@@ -1,0 +1,327 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdarg.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_openclaw_node_transport_diag.h"
+#include "esp_openclaw_room_node.h"
+#include "freertos/task.h"
+
+static esp_alloc_failed_hook_t callback;
+static esp_err_t install_result;
+static unsigned board_calls, room_calls;
+static _Thread_local TaskHandle_t current_task = (void *)1;
+static _Thread_local bool isr, in_callback, state_locked, sdk_returned, cleanup_done;
+static _Thread_local unsigned queries, records, starts, cleanups;
+static _Thread_local char record[768];
+static _Thread_local const char *scenario;
+static atomic_uint concurrent_ready;
+static bool concurrent;
+
+int xPortInIsrContext(void) { return isr; }
+TaskHandle_t xTaskGetCurrentTaskHandle(void) { assert(!isr); return current_task; }
+void *test_forbidden_malloc(size_t n) { (void)n; abort(); }
+void *test_forbidden_calloc(size_t n, size_t size) { (void)n; (void)size; abort(); }
+void *test_forbidden_realloc(void *p, size_t n) { (void)p; (void)n; abort(); }
+int test_allocator_strncmp(const char *a, const char *b, size_t n)
+{
+    assert(!in_callback && sdk_returned);
+    return strncmp(a, b, n);
+}
+
+static void fail_allocation(size_t size, uint32_t caps, const char *allocator)
+{
+    in_callback = true;
+    callback(size, caps, allocator);
+    in_callback = false;
+}
+
+esp_err_t heap_caps_register_failed_alloc_callback(esp_alloc_failed_hook_t fn)
+{
+    assert(callback == NULL && board_calls == 0 && room_calls == 0);
+    if (install_result == ESP_OK) {
+        callback = fn;
+    }
+    return install_result;
+}
+
+esp_err_t tab5_room_board_config(esp_openclaw_room_node_config_t *config)
+{
+    (void)config;
+    assert(callback != NULL || install_result != ESP_OK);
+    ++board_calls;
+    return ESP_OK;
+}
+
+esp_err_t esp_openclaw_room_node_start(const esp_openclaw_room_node_config_t *config)
+{
+    (void)config;
+    assert(board_calls == 1);
+    ++room_calls;
+    return ESP_OK;
+}
+
+size_t heap_caps_get_free_size(uint32_t caps)
+{
+    assert(!in_callback && !state_locked && sdk_returned && !cleanup_done);
+    assert(caps == 2052);
+    ++queries;
+    /* Neither heap queries nor logging may recapture after disarm. */
+    fail_allocation(9999, 99, "secret-allocator-canary");
+    return 30000;
+}
+
+size_t heap_caps_get_largest_free_block(uint32_t caps)
+{
+    assert(!in_callback && !state_locked && sdk_returned && !cleanup_done);
+    assert(caps == 2052);
+    ++queries;
+    return 4000;
+}
+
+void test_log(const char *tag, const char *format, ...)
+{
+    if (strcmp(tag, "tab5_alloc") != 0) {
+        return;
+    }
+    assert(!in_callback && !state_locked && !cleanup_done);
+    va_list args;
+    va_start(args, format);
+    int written = vsnprintf(record, sizeof(record), format, args);
+    va_end(args);
+    assert(written > 0 && (size_t)written < sizeof(record));
+    assert(strstr(record, "secret-allocator-canary") == NULL);
+    assert(strstr(record, "private-token-canary") == NULL);
+    if (strstr(record, "alloc_diag phase=") != NULL) {
+        assert(sdk_returned);
+        ++records;
+        fail_allocation(9999, 99, "secret-allocator-canary");
+    }
+}
+
+typedef void *esp_websocket_client_handle_t;
+typedef int esp_event_base_t;
+typedef struct {
+    const char *uri, *cert_pem, *cert_common_name;
+    bool disable_auto_reconnect, keep_alive_enable, skip_cert_common_name_check;
+    int network_timeout_ms, ping_interval_sec, pingpong_timeout_sec;
+    int keep_alive_idle, keep_alive_interval, keep_alive_count, task_prio, task_stack, buffer_size;
+    size_t cert_len;
+    void *user_context;
+} esp_websocket_client_config_t;
+typedef struct {
+    const char *role, *tls_cert_pem, *tls_common_name;
+    size_t tls_cert_len;
+    bool use_cert_bundle, skip_cert_common_name_check;
+} config_t;
+typedef struct {
+    esp_websocket_client_handle_t (*client_init)(const esp_websocket_client_config_t *);
+    esp_err_t (*register_events)(void *, int, void (*)(void *, int, int32_t, void *), void *);
+    esp_err_t (*client_start)(void *);
+} ops_t;
+typedef struct node {
+    config_t config;
+    struct { int kind; char *gateway_uri; } active_connect_source;
+    struct { char *gateway_uri; } persisted_session;
+    const ops_t *websocket_client_ops;
+    uint32_t next_transport_id, active_transport_id;
+    void *ws, *transport_ctx;
+    char *transport_gateway_uri;
+    bool client_started, transport_connected;
+} *esp_openclaw_node_handle_t;
+typedef struct { esp_openclaw_node_handle_t node; uint32_t transport_id; } esp_openclaw_node_transport_event_ctx_t;
+enum {
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_SAVED_SESSION,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_BOOTSTRAP_TOKEN,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_DEVICE_TOKEN,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_SHARED_TOKEN,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_PASSWORD,
+    ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NO_AUTH,
+};
+#define ESP_OPENCLAW_NODE_TAG "node"
+#define ESP_OPENCLAW_NODE_WS_PING_INTERVAL_SEC 20
+#define ESP_OPENCLAW_NODE_WS_PINGPONG_TIMEOUT_SEC 20
+#define ESP_OPENCLAW_NODE_TRANSPORT_TASK_PRIORITY 5
+#define ESP_OPENCLAW_NODE_TRANSPORT_TASK_STACK_SIZE 8192
+#define ESP_OPENCLAW_NODE_TRANSPORT_BUFFER_SIZE 2048
+#define WEBSOCKET_EVENT_ANY 0
+#define ESP_RETURN_ON_ERROR(call, tag, ...) do { esp_err_t e = (call); if (e) return e; } while (0)
+
+static void esp_openclaw_node_lock_state(esp_openclaw_node_handle_t node)
+{ (void)node; assert(!state_locked); state_locked = true; }
+static void esp_openclaw_node_unlock_state(esp_openclaw_node_handle_t node)
+{ (void)node; assert(state_locked); state_locked = false; }
+static void esp_openclaw_node_clear_session_wait_state_locked(esp_openclaw_node_handle_t node)
+{ (void)node; assert(state_locked); }
+static const char *esp_openclaw_node_trimmed_or_null(const char *s) { return s; }
+static char *esp_openclaw_node_duplicate_string(const char *s) { return strdup(s); }
+static esp_err_t esp_openclaw_node_validate_tls_preflight(const config_t *c, const char *u)
+{ (void)c; (void)u; return ESP_OK; }
+static void websocket_event_handler(void *a, int b, int32_t c, void *d)
+{ (void)a; (void)b; (void)c; (void)d; }
+
+static void esp_openclaw_node_cleanup_transport_instance(esp_openclaw_node_handle_t node, bool stop)
+{
+    assert(!stop && !state_locked);
+    if (starts != 0) {
+        assert(records == 1);
+    }
+    cleanup_done = true;
+    ++cleanups;
+    free(node->transport_gateway_uri);
+    free(node->transport_ctx);
+    node->transport_gateway_uri = NULL;
+    node->transport_ctx = NULL;
+}
+
+#include "transport_start_under_test.inc"
+
+static void *client_init(const esp_websocket_client_config_t *config)
+{
+    assert(!state_locked && config->disable_auto_reconnect);
+    assert(config->task_stack == ESP_OPENCLAW_NODE_TRANSPORT_TASK_STACK_SIZE);
+    if (strcmp(scenario, "init-failure") == 0) {
+        return NULL;
+    }
+    return (void *)1;
+}
+
+static esp_err_t register_events(void *ws, int event, void (*fn)(void *, int, int32_t, void *), void *ctx)
+{
+    (void)ws; (void)event; (void)fn; (void)ctx;
+    assert(!state_locked);
+    return strcmp(scenario, "register-failure") == 0 ? -77 : ESP_OK;
+}
+
+static esp_err_t client_start(void *ws)
+{
+    (void)ws;
+    assert(!state_locked);
+    ++starts;
+    if (concurrent) {
+        atomic_fetch_add(&concurrent_ready, 1);
+        while (atomic_load(&concurrent_ready) != 2) {
+            sched_yield();
+        }
+    }
+    if (strcmp(scenario, "exclusions") == 0) {
+        isr = true;
+        fail_allocation(8000, 9, "heap_caps_malloc");
+        isr = false;
+        TaskHandle_t saved = current_task;
+        current_task = (void *)99;
+        fail_allocation(8000, 9, "heap_caps_malloc");
+        current_task = saved;
+        fail_allocation(1234, 2052, "secret-allocator-canary");
+    } else if (strcmp(scenario, "uncaptured-failure") != 0 && strcmp(scenario, "success") != 0) {
+        fail_allocation(1234, 2052, "heap_caps_malloc");
+        fail_allocation(9000, 9, "heap_caps_calloc");
+    }
+    assert(queries == 0 && records == 0);
+    /* Model the SDK's own cleanup before returning its original result. */
+    sdk_returned = true;
+    return strcmp(scenario, "success") == 0 || strcmp(scenario, "captured-success") == 0 ? ESP_OK : -91;
+}
+
+static void run_start(const char *role)
+{
+    queries = records = starts = cleanups = 0;
+    sdk_returned = cleanup_done = false;
+    record[0] = '\0';
+    const ops_t ops = {client_init, register_events, client_start};
+    struct node node = {
+        .config.role = role, .websocket_client_ops = &ops,
+        .active_connect_source = {
+            .kind = ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_DEVICE_TOKEN,
+            .gateway_uri = "ws://private-token-canary.invalid",
+        },
+    };
+    if (strcmp(scenario, "no-source") == 0) {
+        node.active_connect_source.kind = ESP_OPENCLAW_NODE_CONNECT_SOURCE_KIND_NONE;
+    }
+    esp_err_t result = esp_openclaw_node_start_transport_for_active_source(&node);
+    if (strcmp(scenario, "no-source") == 0 || strcmp(scenario, "init-failure") == 0 ||
+        strcmp(scenario, "register-failure") == 0) {
+        assert(result == (strcmp(scenario, "no-source") == 0 ? ESP_ERR_INVALID_STATE :
+                          strcmp(scenario, "init-failure") == 0 ? ESP_FAIL : -77));
+        assert(starts == 0 && records == 0 && queries == 0);
+        assert(cleanups == (unsigned)(strcmp(scenario, "register-failure") == 0));
+        return;
+    }
+    bool success = strcmp(scenario, "success") == 0 || strcmp(scenario, "captured-success") == 0;
+    bool captured = strcmp(scenario, "uncaptured-failure") != 0 && strcmp(scenario, "success") != 0;
+    assert(result == (success ? ESP_OK : -91));
+    assert(cleanups == (unsigned)!success && node.client_started == success);
+    assert(records == (unsigned)(captured || !success));
+    assert(queries == (captured ? 2U : 0U));
+    if (records) {
+        char expected[768];
+        snprintf(expected, sizeof(expected),
+                 "alloc_diag phase=after_sdk_return_before_owner_cleanup role=%u sdk_err=%d "
+                 "captured=%u requested=%u caps=%u allocator=%u origin=0 "
+                 "heap_sampled=%u free=%u largest=%u",
+                 strcmp(role, "node") == 0 ? 1U : 2U, result, (unsigned)captured,
+                 captured ? 1234U : 0U, captured ? 2052U : 0U,
+                 captured && strcmp(scenario, "exclusions") != 0 ? 1U : 0U,
+                 (unsigned)captured, captured ? 30000U : 0U, captured ? 4000U : 0U);
+        assert(strcmp(record, expected) == 0);
+    }
+    if (success) {
+        free(node.transport_gateway_uri);
+        free(node.transport_ctx);
+    }
+    unsigned before = records;
+    fail_allocation(8888, 99, "heap_caps_malloc");
+    esp_openclaw_node_transport_start_end(role, ESP_OK);
+    assert(records == before);
+}
+
+static void *concurrent_start(void *task)
+{
+    current_task = task;
+    scenario = "capture";
+    run_start(task == (void *)1 ? "node" : "operator");
+    return NULL;
+}
+
+int main(int argc, char **argv)
+{
+    assert(argc == 2);
+    scenario = argv[1];
+    if (strcmp(scenario, "install-failure") == 0) {
+        install_result = -88;
+    }
+    extern void app_main(void);
+    app_main();
+    assert(board_calls == 1 && room_calls == 1);
+    if (install_result != ESP_OK) {
+        assert(strcmp(record, "alloc_diag_install err=-88") == 0);
+        return 0;
+    }
+    fail_allocation(9999, 99, "heap_caps_malloc");
+    if (strcmp(scenario, "concurrent") == 0) {
+        concurrent = true;
+        pthread_t node, operator;
+        assert(pthread_create(&node, NULL, concurrent_start, (void *)1) == 0);
+        assert(pthread_create(&operator, NULL, concurrent_start, (void *)2) == 0);
+        assert(pthread_join(node, NULL) == 0 && pthread_join(operator, NULL) == 0);
+    } else if (strcmp(scenario, "rearm") == 0) {
+        scenario = "capture";
+        run_start("node");
+        scenario = "uncaptured-failure";
+        run_start("node");
+        scenario = "captured-success";
+        run_start("operator");
+    } else {
+        run_start("node");
+    }
+    return 0;
+}

--- a/scripts/tests/fixtures/test_tab5_camera_capture.c
+++ b/scripts/tests/fixtures/test_tab5_camera_capture.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -7,9 +8,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 
 #define ESP_OK 0
 #define ESP_FAIL -1
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_SIZE 0x104
 #define BSP_FAILURE 0x105
 #define TAG "camera-fixture"
 #define CAMERA_SENSOR_WIDTH 1280U
@@ -27,7 +33,8 @@
 #define V4L2_PIX_FMT_RGB565X 0x52424752U
 #define FRAME_SIZE (CAMERA_SENSOR_WIDTH * CAMERA_SENSOR_HEIGHT * 2U)
 enum { VIDIOC_G_FMT, VIDIOC_S_FMT, VIDIOC_REQBUFS, VIDIOC_QUERYBUF,
-       VIDIOC_QBUF, VIDIOC_STREAMON, VIDIOC_DQBUF, VIDIOC_STREAMOFF };
+       VIDIOC_QBUF, VIDIOC_STREAMON, VIDIOC_DQBUF, VIDIOC_STREAMOFF,
+       VIDIOC_S_DQBUF_TIMEOUT };
 typedef int esp_err_t;
 struct v4l2_format {
     uint32_t type;
@@ -40,6 +47,10 @@ struct v4l2_buffer {
 };
 typedef struct { char stage[40], domain[16]; int error; } record_t;
 static record_t records[2];
+typedef struct { char stage[40]; uint64_t elapsed_ms; } pipeline_record_t;
+static pipeline_record_t pipeline_records[10];
+static unsigned pipeline_count, timeout_sets;
+static uint64_t dequeue_timeout_ms;
 static unsigned record_count, log_count, bsp_calls, gfmt_calls, maps, unmaps;
 static unsigned closes, streamoffs, dequeues, initial_queues, requeues;
 static int64_t clock_us;
@@ -67,6 +78,17 @@ static void capture_log(const char *format, ...)
         assert(sscanf(line, "camera_capture_diag stage=%39s domain=%15s error=%d%n",
                       record->stage, record->domain, &record->error, &consumed) == 3);
         assert(line[consumed] == '\0');
+    } else if (strncmp(line, "camera_pipeline_diag ", 21) == 0) {
+        assert(pipeline_count < 10);
+        pipeline_record_t *record = &pipeline_records[pipeline_count++];
+        int consumed = 0;
+        assert(sscanf(line, "camera_pipeline_diag stage=%39s elapsed_ms=%" SCNu64 "%n",
+                      record->stage, &record->elapsed_ms, &consumed) == 2);
+        assert(line[consumed] == '\0');
+        if (strstr(record->stage, "_begin") != NULL) assert(record->elapsed_ms == 0);
+        for (unsigned i = 0; i + 1 < pipeline_count; ++i) {
+            assert(strcmp(record->stage, pipeline_records[i].stage) != 0);
+        }
     } else {
         memcpy(validation_detail, line, (size_t)length + 1);
     }
@@ -74,6 +96,7 @@ static void capture_log(const char *format, ...)
 }
 #define ESP_LOGE(tag, ...) do { (void)(tag); capture_log(__VA_ARGS__); } while (0)
 #define ESP_LOGI(tag, ...) do { (void)(tag); capture_log(__VA_ARGS__); } while (0)
+#define ESP_LOGW(tag, ...) do { (void)(tag); capture_log(__VA_ARGS__); } while (0)
 #define ESP_RETURN_ON_ERROR(call, tag, ...) do { \
     esp_err_t error = (call); \
     if (error != ESP_OK) { ESP_LOGE(tag, __VA_ARGS__); return error; } \
@@ -89,6 +112,7 @@ static esp_err_t bsp_camera_start(const void *config)
 static int camera_open(const char *path, int flags)
 {
     assert(strcmp(path, BSP_CAMERA_DEVICE) == 0 && flags == O_RDONLY);
+    dequeue_timeout_ms = UINT64_MAX;
     errno = EIO;
     return is("open") || is("open-cache") ? -1 : 7;
 }
@@ -96,6 +120,7 @@ static int camera_close(int fd)
 {
     assert(fd == 7);
     ++closes;
+    clock_us += 3000;
     errno = EBADF;
     return -1;
 }
@@ -120,20 +145,36 @@ static int camera_munmap(void *address, size_t length)
     assert(address == mapped[index] && live_mapping[index]);
     live_mapping[index] = false;
     ++unmaps;
+    clock_us += 2000;
     errno = EBADF;
     return -1;
 }
-static int camera_ioctl(int fd, int request, void *argument)
+static int camera_ioctl(int fd, int request, ...)
 {
+    va_list args;
+    va_start(args, request);
+    void *argument = va_arg(args, void *);
+    va_end(args);
     assert(fd == 7);
     errno = ESTALE;
     if (request == VIDIOC_STREAMOFF) {
         assert(*(int *)argument == V4L2_BUF_TYPE_VIDEO_CAPTURE);
         ++streamoffs;
+        clock_us += 1000;
         errno = EBADF;
         return -1;
     }
-    if (request == VIDIOC_G_FMT) {
+    if (request == VIDIOC_S_DQBUF_TIMEOUT) {
+        const struct timeval *timeout = argument;
+        assert(gfmt_calls == 0 && maps == 0 && initial_queues == 0);
+        ++timeout_sets;
+        if (is("timeout-setup")) {
+            errno = ENOTTY;
+            return -1;
+        }
+        assert(timeout->tv_sec == 2 && timeout->tv_usec == 0);
+        dequeue_timeout_ms = (uint64_t)timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
+    } else if (request == VIDIOC_G_FMT) {
         struct v4l2_format *format = argument;
         ++gfmt_calls;
         if ((gfmt_calls == 1 && is("gfmt")) || (gfmt_calls == 2 && is("gfmt-after"))) goto failure;
@@ -181,6 +222,14 @@ static int camera_ioctl(int fd, int request, void *argument)
     } else if (request == VIDIOC_DQBUF) {
         struct v4l2_buffer *buffer = argument;
         ++dequeues;
+        if (is("missing-frame") || (is("warmup-starved") && dequeues > 1)) {
+            /* Model the SDK's default infinite ready-semaphore wait without hanging the test. */
+            assert(dequeue_timeout_ms > 0 && dequeue_timeout_ms != UINT64_MAX);
+            clock_us += (int64_t)dequeue_timeout_ms * 1000;
+            errno = ETIMEDOUT;
+            return -1;
+        }
+        clock_us += is("warmup-max") ? 250000 : 1000;
         if (is("dqbuf")) goto failure;
         buffer->index = is("frame-index") ? 2 : (dequeues - 1) % 2;
         buffer->bytesused = is("frame-length") ? 1 : is("zero-bytesused") ? 0 : FRAME_SIZE;
@@ -194,9 +243,7 @@ failure:
 }
 static int64_t esp_timer_get_time(void)
 {
-    int64_t current = clock_us;
-    clock_us += 1000;
-    return current;
+    return clock_us;
 }
 #define open camera_open
 #define close camera_close
@@ -204,6 +251,186 @@ static int64_t esp_timer_get_time(void)
 #define munmap camera_munmap
 #define ioctl camera_ioctl
 #include "camera_capture_under_test.inc"
+
+/* Run the actual command owner with valid parameters and observable dependency boundaries. */
+typedef struct cJSON {
+    int kind, valueint;
+    double valuedouble;
+    const char *valuestring, *string;
+    struct cJSON *child, *next;
+} cJSON;
+static cJSON parameters, delay_parameter;
+static unsigned parameter_deletes, indicator_ends, releases, transforms, encodes;
+static bool lease_held, indicator_active;
+typedef void *esp_openclaw_node_handle_t;
+typedef struct { const char *code, *message; } esp_openclaw_node_error_t;
+static cJSON *cJSON_ParseWithLength(const char *text, size_t length)
+{
+    assert(length == 2 && strcmp(text, "{}") == 0);
+    parameters = (cJSON){.kind = 1};
+    if (is("warmup-max") || is("warmup-starved")) {
+        delay_parameter = (cJSON){.kind = 2, .valueint = 10000, .valuedouble = 10000,
+                                 .string = "delayMs"};
+        parameters.child = &delay_parameter;
+    }
+    return &parameters;
+}
+static cJSON *cJSON_GetObjectItemCaseSensitive(const cJSON *object, const char *name)
+{
+    assert(object == &parameters);
+    return strcmp(name, "delayMs") == 0 ? parameters.child : NULL;
+}
+static bool cJSON_IsObject(const cJSON *item) { return item != NULL && item->kind == 1; }
+static bool cJSON_IsNumber(const cJSON *item) { return item != NULL && item->kind == 2; }
+static bool cJSON_IsString(const cJSON *item) { return item != NULL && item->kind == 3; }
+static void cJSON_Delete(cJSON *item) { assert(item == &parameters); ++parameter_deletes; }
+static bool esp_openclaw_room_node_try_acquire_camera(void)
+{
+    assert(!lease_held);
+    lease_held = true;
+    return true;
+}
+static esp_err_t esp_openclaw_room_node_camera_indicator_begin(void)
+{
+    assert(lease_held && !indicator_active);
+    indicator_active = true;
+    return ESP_OK;
+}
+static void esp_openclaw_room_node_camera_indicator_end(void)
+{
+    assert(indicator_active && lease_held && closes == 1);
+    indicator_active = false;
+    ++indicator_ends;
+    clock_us += 2000;
+}
+static void esp_openclaw_room_node_release_camera(void)
+{
+    assert(lease_held && !indicator_active);
+    lease_held = false;
+    ++releases;
+    clock_us += 3000;
+}
+typedef struct {
+    uint8_t *data;
+    size_t data_size;
+    uint32_t width, height;
+} camera_transformed_frame_t;
+static esp_err_t transform_camera_frame(const camera_frame_t *camera, int width,
+                                        camera_transformed_frame_t *output)
+{
+    assert(camera->fd == 7 && camera->frame.index < 2 && width == 1024);
+    assert(lease_held && indicator_active && unmaps == 0);
+    ++transforms;
+    clock_us += 7000;
+    if (is("transform-failure")) return ESP_FAIL;
+    *output = (camera_transformed_frame_t){.width = 800, .height = 800, .data_size = 800 * 800 * 3};
+    output->data = malloc(output->data_size);
+    assert(output->data != NULL);
+    return ESP_OK;
+}
+static void heap_caps_free(void *memory) { free(memory); }
+typedef struct {
+    int width, height, src_type, subsampling;
+    uint8_t quality;
+    bool task_enable;
+} jpeg_enc_config_t;
+typedef void *jpeg_enc_handle_t;
+typedef int jpeg_error_t;
+#define DEFAULT_JPEG_ENC_CONFIG() ((jpeg_enc_config_t){0})
+#define JPEG_PIXEL_FORMAT_RGB888 1
+#define JPEG_SUBSAMPLE_420 2
+#define JPEG_ERR_OK 0
+static int encoder_token;
+static jpeg_error_t jpeg_enc_open(const jpeg_enc_config_t *config, jpeg_enc_handle_t *encoder)
+{
+    assert(config->width == 800 && config->height == 800 && !config->task_enable);
+    assert(config->src_type == JPEG_PIXEL_FORMAT_RGB888 && config->subsampling == JPEG_SUBSAMPLE_420);
+    *encoder = &encoder_token;
+    return JPEG_ERR_OK;
+}
+static jpeg_error_t jpeg_enc_process(jpeg_enc_handle_t encoder, const uint8_t *input,
+                                    int input_size, uint8_t *output, int capacity, int *size)
+{
+    assert(encoder == &encoder_token && input != NULL && output != NULL);
+    assert(input_size == 800 * 800 * 3 && capacity == input_size + 1024);
+    assert(lease_held && indicator_active && unmaps == 0);
+    ++encodes;
+    clock_us += 2000;
+    if (is("encode-failure")) return -1;
+    *size = is("quality-retry") && encodes < 3 ? 740 * 1024 + 1 : 32;
+    memset(output, 0, (size_t)*size);
+    return JPEG_ERR_OK;
+}
+static void jpeg_enc_close(jpeg_enc_handle_t encoder) { assert(encoder == &encoder_token); }
+static int mbedtls_base64_encode(unsigned char *output, size_t capacity, size_t *written,
+                                const unsigned char *input, size_t length)
+{
+    assert(!lease_held && !indicator_active && input != NULL && length == 32 && capacity >= 4);
+    memcpy(output, "AAAA", 4);
+    *written = 4;
+    return 0;
+}
+#include "camera_handler_under_test.inc"
+
+static const pipeline_record_t *pipeline(const char *stage)
+{
+    for (unsigned i = 0; i < pipeline_count; ++i) {
+        if (strcmp(pipeline_records[i].stage, stage) == 0) return &pipeline_records[i];
+    }
+    return NULL;
+}
+static void run_handler(void)
+{
+    char *output = NULL;
+    esp_openclaw_node_error_t error = {0};
+    esp_err_t result = camera_snap(NULL, NULL, "{}", 2, &output, &error);
+    bool capture_failed = is("missing-frame") || is("warmup-starved") || is("timeout-setup");
+    bool failed = capture_failed || is("transform-failure") || is("encode-failure");
+    assert(result == (failed ? ESP_FAIL : ESP_OK));
+    assert(!lease_held && !indicator_active && releases == 1 && indicator_ends == 1);
+    assert(parameter_deletes == 1 && closes == 1 && streamoffs == 1 && maps == unmaps);
+    assert(timeout_sets == 1);
+    assert(pipeline("cleanup_begin") != NULL && pipeline("cleanup_end") != NULL);
+    assert(pipeline("cleanup_end")->elapsed_ms == (is("timeout-setup") ? 4U : 8U));
+    assert(pipeline("release_begin") != NULL && pipeline("release_end")->elapsed_ms == 5);
+    if (capture_failed) {
+        assert(transforms == 0 && encodes == 0 && output == NULL);
+        assert(strcmp(error.code, "UNAVAILABLE") == 0);
+        const record_t *failure = &records[record_count - 1];
+        assert(strcmp(failure->domain, "errno") == 0);
+        assert(failure->error == (is("timeout-setup") ? ENOTTY : ETIMEDOUT));
+        assert(pipeline("capture_complete") == NULL && pipeline("transform_begin") == NULL);
+        if (is("timeout-setup")) {
+            assert(dequeues == 0 && gfmt_calls == 0 && maps == 0 && initial_queues == 0);
+            assert(strcmp(failure->stage, "dqbuf_timeout_setup") == 0);
+            assert(pipeline("dqbuf_first_return") == NULL);
+        } else {
+            assert(strcmp(failure->stage, "dqbuf") == 0);
+            assert(dequeues == (is("warmup-starved") ? 2U : 1U));
+            assert(requeues == (is("warmup-starved") ? 1U : 0U));
+            assert(pipeline("dqbuf_first_return")->elapsed_ms == (is("warmup-starved") ? 1U : 2000U));
+        }
+    } else {
+        assert(transforms == 1);
+        assert(pipeline("capture_complete")->elapsed_ms == (is("warmup-max") ? 10000U : 1U));
+        assert(dequeues == (is("warmup-max") ? 40U : 1U) && requeues + 1 == dequeues);
+        assert(pipeline("transform_end")->elapsed_ms == 7);
+        if (is("transform-failure")) {
+            assert(encodes == 0 && pipeline("encode_begin") == NULL);
+            assert(strcmp(error.code, "UNAVAILABLE") == 0 && output == NULL);
+        } else {
+            assert(encodes == (is("quality-retry") ? 3U : 1U));
+            assert(pipeline("encode_end")->elapsed_ms == 2U * encodes);
+            assert(pipeline_count == 10);
+            if (is("encode-failure")) {
+                assert(strcmp(error.code, "INTERNAL") == 0 && output == NULL);
+            } else {
+                assert(output != NULL && strstr(output, "\"width\":800,\"height\":800") != NULL);
+            }
+        }
+    }
+    free(output);
+}
 
 typedef struct {
     const char *scenario, *stage, *domain;
@@ -248,6 +475,11 @@ int main(int argc, char **argv)
     assert(setrlimit(RLIMIT_CORE, &no_core) == 0);
     assert(argc == 2);
     scenario = argv[1];
+    if (strncmp(scenario, "handler-", 8) == 0) {
+        scenario += 8;
+        run_handler();
+        return 0;
+    }
     errno = EDOM;
     camera_frame_t camera = {.fd = -1};
     int delay = is("delayed") ? 20 : is("requeue") ? 10 : 0;
@@ -260,7 +492,7 @@ int main(int argc, char **argv)
             is("negotiated-format") || is("negotiated-stride") ||
             is("buffer-length") || is("frame-length");
         assert(record_count == test->marker_count + 1);
-        assert(log_count == record_count + (detail ? 1U : 0U));
+        assert(log_count == record_count + pipeline_count + (detail ? 1U : 0U));
         if (is("default-size")) assert(strstr(validation_detail, "640x720") != NULL);
         if (is("negotiated-size")) assert(strstr(validation_detail, "1280x480") != NULL);
         if (is("negotiated-format")) assert(strstr(validation_detail, "fourcc=0x00000000") != NULL);
@@ -287,7 +519,7 @@ int main(int argc, char **argv)
         assert(camera.width == CAMERA_SENSOR_WIDTH && camera.height == CAMERA_SENSOR_HEIGHT);
         assert(camera.stride == CAMERA_SENSOR_WIDTH * 2);
         assert(camera.format == (is("rgb565x") ? V4L2_PIX_FMT_RGB565X : V4L2_PIX_FMT_RGB565));
-        assert(record_count == 1 && log_count == 1);
+        assert(record_count == 1 && log_count == 1 + pipeline_count);
         assert_marker();
         assert(maps == 2 && unmaps == 0 && closes == 0 && streamoffs == 0);
         assert(dequeues == (is("delayed") ? 20U : 1U));
@@ -297,11 +529,14 @@ int main(int argc, char **argv)
     }
     if (cache_case) {
         unsigned expected_starts = is("bsp-retry") ? 2 : 1;
+        unsigned expected_timeout_sets = is("success-cache") ? 2 : 1;
         scenario = "success";
         record_count = log_count = gfmt_calls = maps = unmaps = closes = 0;
         streamoffs = dequeues = initial_queues = requeues = 0;
+        pipeline_count = 0;
         assert(capture_rgb565_frame(0, &camera) == ESP_OK);
         assert(bsp_calls == expected_starts && record_count == 1);
+        assert(timeout_sets == expected_timeout_sets);
         assert_marker();
         close_camera_frame(&camera);
         assert(unmaps == 2 && closes == 1);

--- a/scripts/tests/fixtures/test_tab5_camera_format.c
+++ b/scripts/tests/fixtures/test_tab5_camera_format.c
@@ -1,0 +1,139 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Host-only type/log boundaries for the complete, hash-checked upstream mapper. */
+typedef int esp_err_t;
+typedef int cam_ctlr_color_t;
+typedef int isp_color_t;
+typedef int esp_cam_sensor_output_format_t;
+enum { ESP_OK, ESP_ERR_INVALID_ARG, ESP_ERR_NOT_SUPPORTED };
+enum {
+    CAM_CTLR_COLOR_RAW8, CAM_CTLR_COLOR_RAW10, CAM_CTLR_COLOR_RAW12,
+    CAM_CTLR_COLOR_RGB565, CAM_CTLR_COLOR_RGB888, CAM_CTLR_COLOR_YUV420,
+    CAM_CTLR_COLOR_YUV422, CAM_CTLR_COLOR_YUV422_UYVY, CAM_CTLR_COLOR_GRAY8
+};
+enum {
+    ISP_COLOR_RAW8, ISP_COLOR_RAW10, ISP_COLOR_RAW12, ISP_COLOR_RGB565,
+    ISP_COLOR_RGB888, ISP_COLOR_YUV420, ISP_COLOR_YUV422
+};
+enum {
+    ESP_CAM_SENSOR_PIXFORMAT_RGB565_LE, ESP_CAM_SENSOR_PIXFORMAT_RGB565_BE,
+    ESP_CAM_SENSOR_PIXFORMAT_YUV422_UYVY, ESP_CAM_SENSOR_PIXFORMAT_YUV422_YUYV,
+    ESP_CAM_SENSOR_PIXFORMAT_YUV420, ESP_CAM_SENSOR_PIXFORMAT_RGB888,
+    ESP_CAM_SENSOR_PIXFORMAT_RGB444, ESP_CAM_SENSOR_PIXFORMAT_RGB555,
+    ESP_CAM_SENSOR_PIXFORMAT_BGR888, ESP_CAM_SENSOR_PIXFORMAT_RAW8,
+    ESP_CAM_SENSOR_PIXFORMAT_RAW10, ESP_CAM_SENSOR_PIXFORMAT_RAW12,
+    ESP_CAM_SENSOR_PIXFORMAT_GRAYSCALE
+};
+enum {
+    V4L2_PIX_FMT_SBGGR8 = 100, V4L2_PIX_FMT_SBGGR10, V4L2_PIX_FMT_SBGGR12,
+    V4L2_PIX_FMT_RGB565, V4L2_PIX_FMT_RGB565X, V4L2_PIX_FMT_RGB24,
+    V4L2_PIX_FMT_YUV420, V4L2_PIX_FMT_UYVY, V4L2_PIX_FMT_VYUY,
+    V4L2_PIX_FMT_YUYV, V4L2_PIX_FMT_YVYU, V4L2_PIX_FMT_GREY
+};
+typedef struct {
+    bool isp_bypass_required;
+    isp_color_t isp_input_fmt;
+    isp_color_t isp_output_fmt;
+    uint8_t isp_bpp;
+    cam_ctlr_color_t csi_input_fmt;
+    cam_ctlr_color_t csi_output_fmt;
+} esp_video_csi_isp_in_out_format_t;
+
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+#define ESP_IDF_VERSION_VAL(major, minor, patch) (((major) << 16) | ((minor) << 8) | (patch))
+#define ESP_VIDEO_CSI_DEVICE_CONV_FORMAT 0
+#define CONFIG_ESP_VIDEO_ENABLE_ISP_VIDEO_DEVICE 1
+#define ESP_LOGD(tag, ...) ((void)(tag))
+#define ESP_LOGI(tag, ...) ((void)(tag))
+#define ESP_LOGE(tag, ...) ((void)(tag))
+#define ESP_RETURN_ON_FALSE(condition, result, ...) do { if (!(condition)) return (result); } while (0)
+
+static bool esp_video_isp_video_device_is_raw_bypass(void)
+{
+    return true;
+}
+
+#include "camera_mapper_under_test.inc"
+
+#define CHECK(condition, message) do { \
+    if (!(condition)) { fprintf(stderr, "%s\n", message); return 1; } \
+} while (0)
+
+static int processing(void)
+{
+    const struct {
+        uint32_t output;
+        cam_ctlr_color_t csi;
+        isp_color_t isp;
+        uint8_t bpp;
+    } cases[] = {
+        {V4L2_PIX_FMT_RGB565, CAM_CTLR_COLOR_RGB565, ISP_COLOR_RGB565, 16},
+        {V4L2_PIX_FMT_RGB24, CAM_CTLR_COLOR_RGB888, ISP_COLOR_RGB888, 24},
+        {V4L2_PIX_FMT_YUV420, CAM_CTLR_COLOR_YUV420, ISP_COLOR_YUV420, 12},
+    };
+    for (size_t i = 0; i < ARRAY_SIZE(cases); ++i) {
+        for (int raw10 = 0; raw10 <= 1; ++raw10) {
+            esp_video_csi_isp_in_out_format_t format = {0};
+            int sensor = raw10 ? ESP_CAM_SENSOR_PIXFORMAT_RAW10 : ESP_CAM_SENSOR_PIXFORMAT_RAW8;
+            CHECK(esp_video_csi_check_format(sensor, cases[i].output, &format) == ESP_OK,
+                  "supported processing format rejected");
+            CHECK(!format.isp_bypass_required, "ISP processing was bypassed");
+            CHECK(format.isp_input_fmt == (raw10 ? ISP_COLOR_RAW10 : ISP_COLOR_RAW8),
+                  "ISP sensor input changed");
+            CHECK(format.isp_output_fmt == cases[i].isp, "ISP output changed");
+            CHECK(isp_color_to_bpp(format.isp_output_fmt) == cases[i].bpp, "output bit depth changed");
+            CHECK(format.csi_output_fmt == cases[i].csi, "CSI output changed");
+            CHECK(format.csi_input_fmt == cases[i].csi, "post-ISP CSI input mismatch");
+            CHECK(format.csi_input_fmt == format.csi_output_fmt, "early-P4 CSI conversion requested");
+        }
+    }
+    return 0;
+}
+
+static int bypass(void)
+{
+    const int sensors[] = {ESP_CAM_SENSOR_PIXFORMAT_RAW8, ESP_CAM_SENSOR_PIXFORMAT_RAW10};
+    const uint32_t pixels[] = {V4L2_PIX_FMT_SBGGR8, V4L2_PIX_FMT_SBGGR10};
+    const int colors[] = {CAM_CTLR_COLOR_RAW8, CAM_CTLR_COLOR_RAW10};
+    for (size_t i = 0; i < ARRAY_SIZE(sensors); ++i) {
+        for (int use_default = 0; use_default <= 1; ++use_default) {
+            esp_video_csi_isp_in_out_format_t format = {0};
+            CHECK(esp_video_csi_check_format(sensors[i], use_default ? 0 : pixels[i], &format) == ESP_OK,
+                  "raw bypass rejected");
+            CHECK(format.isp_bypass_required, "raw bypass changed");
+            CHECK(format.csi_input_fmt == colors[i] && format.csi_output_fmt == colors[i],
+                  "raw CSI passthrough changed");
+            CHECK(format.isp_input_fmt == format.isp_output_fmt, "raw ISP passthrough changed");
+            CHECK(format.isp_bpp == (i ? 10 : 8), "raw bypass bit depth changed");
+        }
+    }
+    return 0;
+}
+
+static int unsupported(void)
+{
+    esp_video_csi_isp_in_out_format_t format = {0};
+    CHECK(esp_video_csi_check_format(ESP_CAM_SENSOR_PIXFORMAT_RAW8, UINT32_MAX, &format)
+          == ESP_ERR_NOT_SUPPORTED, "unknown output accepted");
+    CHECK(esp_video_csi_check_format(ESP_CAM_SENSOR_PIXFORMAT_RAW12, V4L2_PIX_FMT_RGB565, &format)
+          == ESP_ERR_NOT_SUPPORTED, "unsupported raw12 conversion accepted");
+    CHECK(esp_video_csi_check_format(ESP_CAM_SENSOR_PIXFORMAT_RAW8, V4L2_PIX_FMT_YUYV, &format)
+          == ESP_ERR_NOT_SUPPORTED, "unsupported old-chip output accepted");
+    CHECK(esp_video_csi_check_format(-1, V4L2_PIX_FMT_RGB565, &format)
+          == ESP_ERR_NOT_SUPPORTED, "unknown sensor accepted");
+    CHECK(esp_video_csi_check_format(ESP_CAM_SENSOR_PIXFORMAT_RAW8, V4L2_PIX_FMT_RGB565, NULL)
+          == ESP_ERR_INVALID_ARG, "null output accepted");
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2) return 2;
+    if (strcmp(argv[1], "processing") == 0) return processing();
+    if (strcmp(argv[1], "bypass") == 0) return bypass();
+    if (strcmp(argv[1], "unsupported") == 0) return unsupported();
+    return 2;
+}

--- a/scripts/tests/fixtures/test_tab5_camera_transform.c
+++ b/scripts/tests/fixtures/test_tab5_camera_transform.c
@@ -1,0 +1,191 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+
+typedef int esp_err_t;
+enum { ESP_OK, ESP_ERR_INVALID_STATE, ESP_ERR_NOT_SUPPORTED,
+       ESP_ERR_INVALID_SIZE, ESP_ERR_NO_MEM, PPA_FAILURE };
+enum { MALLOC_CAP_SPIRAM = 1, PPA_SRM_COLOR_MODE_RGB565,
+       PPA_SRM_COLOR_MODE_RGB888, PPA_TRANS_MODE_BLOCKING };
+typedef enum {
+    PPA_SRM_ROTATION_ANGLE_0, PPA_SRM_ROTATION_ANGLE_90,
+    PPA_SRM_ROTATION_ANGLE_180, PPA_SRM_ROTATION_ANGLE_270,
+} ppa_srm_rotation_angle_t;
+typedef struct {
+    void *buffer;
+    size_t buffer_size;
+    uint32_t pic_w, pic_h, block_w, block_h;
+    int srm_cm;
+} picture_t;
+typedef struct {
+    picture_t in, out;
+    ppa_srm_rotation_angle_t rotation_angle;
+    float scale_x, scale_y;
+    int mode;
+} ppa_srm_oper_config_t;
+typedef struct {
+    uint32_t width, height;
+    void *buffers[2];
+    struct { unsigned index; } frame;
+} camera_frame_t;
+
+static int test_rotation;
+#define BSP_CAMERA_ROTATION test_rotation
+#define TAG "camera-transform-fixture"
+#define ESP_LOGE(tag, ...) ((void)(tag))
+#define ESP_RETURN_ON_FALSE(condition, error, tag, ...) do { \
+    if (!(condition)) return (error); \
+} while (0)
+#define ESP_RETURN_ON_ERROR(call, tag, ...) do { \
+    esp_err_t error = (call); \
+    if (error != ESP_OK) return error; \
+} while (0)
+
+static void *camera_ppa_srm = (void *)&test_rotation;
+static size_t camera_ppa_alignment = 64;
+static void *allocation;
+static size_t allocation_bytes;
+static unsigned allocations, frees, ppa_calls;
+static uint32_t written_width, written_height;
+static bool fail_allocation, fail_ppa;
+
+static void *heap_caps_aligned_calloc(size_t alignment, size_t count, size_t size, int caps)
+{
+    assert(allocation == NULL && count == 1 && caps == MALLOC_CAP_SPIRAM);
+    assert(alignment == camera_ppa_alignment && size % alignment == 0);
+    ++allocations;
+    if (fail_allocation) return NULL;
+    allocation = aligned_alloc(alignment, size);
+    assert(allocation != NULL && (uintptr_t)allocation % 16 == 0);
+    allocation_bytes = size;
+    memset(allocation, 0, size);
+    return allocation;
+}
+
+static void heap_caps_free(void *buffer)
+{
+    assert(buffer != NULL && buffer == allocation);
+    ++frees;
+    free(buffer);
+    allocation = NULL;
+}
+
+static esp_err_t ppa_do_scale_rotate_mirror(void *client, const ppa_srm_oper_config_t *config)
+{
+    assert(client == camera_ppa_srm && config->mode == PPA_TRANS_MODE_BLOCKING);
+    assert(config->in.srm_cm == PPA_SRM_COLOR_MODE_RGB565);
+    assert(config->out.srm_cm == PPA_SRM_COLOR_MODE_RGB888);
+    assert(config->out.buffer == allocation && config->out.buffer_size == allocation_bytes);
+    assert(config->in.block_w == config->in.pic_w && config->in.block_h == config->in.pic_h);
+    ++ppa_calls;
+    if (fail_ppa) return PPA_FAILURE;
+
+    /* Pinned PPA hardware truncates each scale to four fractional bits. */
+    unsigned x_sixteenths = (unsigned)(config->scale_x * 16);
+    unsigned y_sixteenths = (unsigned)(config->scale_y * 16);
+    assert(x_sixteenths >= 1 && x_sixteenths <= 16);
+    assert(y_sixteenths >= 1 && y_sixteenths <= 16);
+    written_width = config->in.block_w * x_sixteenths / 16;
+    written_height = config->in.block_h * y_sixteenths / 16;
+    if (config->rotation_angle == PPA_SRM_ROTATION_ANGLE_90 ||
+        config->rotation_angle == PPA_SRM_ROTATION_ANGLE_270) {
+        uint32_t swap = written_width;
+        written_width = written_height;
+        written_height = swap;
+    }
+    assert(written_width <= config->out.pic_w && written_height <= config->out.pic_h);
+    assert((size_t)config->out.pic_w * config->out.pic_h * 3 <= allocation_bytes);
+    uint8_t *output = config->out.buffer;
+    for (uint32_t y = 0; y < written_height; ++y) {
+        memset(output + (size_t)y * config->out.pic_w * 3, 0xa5, written_width * 3);
+    }
+    return ESP_OK;
+}
+
+#include "camera_transform_under_test.inc"
+
+typedef struct {
+    int rotation, max_width;
+    uint32_t input_width, input_height, output_width, output_height;
+    esp_err_t result;
+} geometry_case_t;
+
+static void check_geometry(geometry_case_t test)
+{
+    allocations = frees = ppa_calls = 0;
+    written_width = written_height = 0;
+    allocation_bytes = 0;
+    test_rotation = test.rotation;
+    uint8_t input;
+    camera_frame_t camera = {
+        .width = test.input_width, .height = test.input_height,
+        .buffers = {&input, NULL}, .frame.index = 0,
+    };
+    camera_transformed_frame_t transformed;
+    memset(&transformed, 0x55, sizeof(transformed));
+    esp_err_t result = transform_camera_frame(&camera, test.max_width, &transformed);
+    assert(result == test.result);
+    if (result != ESP_OK) {
+        assert(transformed.data == NULL && transformed.data_size == 0);
+        assert(transformed.width == 0 && transformed.height == 0 && allocation == NULL);
+        if (fail_allocation) assert(allocations == 1 && ppa_calls == 0 && frees == 0);
+        else if (fail_ppa) assert(allocations == 1 && ppa_calls == 1 && frees == 1);
+        else assert(allocations == 0 && ppa_calls == 0 && frees == 0);
+        return;
+    }
+    if (transformed.width != written_width || transformed.height != written_height) {
+        fprintf(stderr, "packed image %ux%u differs from PPA-written extent %ux%u\n",
+                transformed.width, transformed.height, written_width, written_height);
+        abort();
+    }
+    assert(transformed.width == test.output_width && transformed.height == test.output_height);
+    assert(transformed.width <= (uint32_t)test.max_width);
+    assert(transformed.data_size == (size_t)test.output_width * test.output_height * 3);
+    assert(transformed.data_size <= CAMERA_MAX_PIXELS * 3U);
+    assert(allocations == 1 && ppa_calls == 1 && frees == 0);
+    /* JPEG receives exactly packed RGB888, never an unwritten margin or allocation tail. */
+    for (size_t i = 0; i < transformed.data_size; ++i) assert(transformed.data[i] == 0xa5);
+    for (size_t i = transformed.data_size; i < allocation_bytes; ++i) assert(transformed.data[i] == 0);
+    heap_caps_free(transformed.data);
+    assert(frees == 1);
+}
+
+int main(int argc, char **argv)
+{
+    struct rlimit core_limit = {0, 0};
+    assert(setrlimit(RLIMIT_CORE, &core_limit) == 0);
+    assert(argc == 2);
+    geometry_case_t requested = {90, 640, 1280, 720, 630, 1120, ESP_OK};
+    if (strcmp(argv[1], "requested-640") == 0) {
+        check_geometry(requested);
+    } else if (strcmp(argv[1], "geometry") == 0) {
+        const geometry_case_t cases[] = {
+            {270, 640, 1280, 720, 630, 1120, ESP_OK},
+            {90, 720, 1280, 720, 720, 1280, ESP_OK},
+            {270, 2048, 1280, 720, 720, 1280, ESP_OK},
+            {0, 1280, 1280, 720, 1280, 720, ESP_OK},
+            {180, 640, 1280, 720, 640, 360, ESP_OK},
+            {90, 64, 1280, 720, 45, 80, ESP_OK},
+            {0, 80, 1280, 720, 80, 45, ESP_OK},
+            {0, 64, 1280, 720, 0, 0, ESP_ERR_INVALID_SIZE},
+            {90, 629, 1280, 720, 585, 1040, ESP_OK},
+            {90, 640, 2048, 1024, 0, 0, ESP_ERR_NOT_SUPPORTED},
+            {90, 640, 1280, 0, 0, 0, ESP_ERR_NOT_SUPPORTED},
+        };
+        for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) check_geometry(cases[i]);
+    } else if (strcmp(argv[1], "allocation-failure") == 0) {
+        fail_allocation = true;
+        requested.result = ESP_ERR_NO_MEM;
+        check_geometry(requested);
+    } else {
+        assert(strcmp(argv[1], "ppa-failure") == 0);
+        fail_ppa = true;
+        requested.result = PPA_FAILURE;
+        check_geometry(requested);
+    }
+    return 0;
+}

--- a/scripts/tests/test_nvs_diagnostics.py
+++ b/scripts/tests/test_nvs_diagnostics.py
@@ -104,6 +104,7 @@ class NvsDiagnosticsTests(unittest.TestCase):
                         "-o", str(cls.root / "partition")], check=True)
         node = ROOT / "components/esp-openclaw-node"
         subprocess.run([os.environ.get("CC", "cc"), "-std=c11", "-D_POSIX_C_SOURCE=200809L",
+                        "-pthread", "-Dprintf=host_diagnostic_printf",
                         *common, "-I", str(node / "private_include"),
                         str(node / "src/esp_openclaw_node_persisted_session.c"),
                         str(FIXTURES / "test_nvs_session.c"),
@@ -117,6 +118,10 @@ class NvsDiagnosticsTests(unittest.TestCase):
 
     def test_session_original_errors_presence_clear_and_canary_privacy(self):
         subprocess.run([str(self.root / "session")], check=True)
+
+    def test_runtime_session_record_does_not_split_stdout_log(self):
+        subprocess.run([str(self.root / "session"), "--stdio-contention"],
+                       check=True, timeout=15)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_package_firmware.py
+++ b/scripts/tests/test_package_firmware.py
@@ -21,6 +21,8 @@ from test_idf_tab5_compat import fixture_profile, seed_sdk
 import idf_tab5_compat as compat
 from test_tab5_sdio_diagnostics import HAS_MANAGER, component_fixture
 import tab5_sdio_diagnostics as sdio
+from test_tab5_camera_compat import camera_fixture, seed_camera_sdk, write_object
+import tab5_camera_compat as camera
 
 SPEC = importlib.util.spec_from_file_location("package_firmware", SCRIPT)
 firmware = importlib.util.module_from_spec(SPEC)
@@ -135,11 +137,13 @@ class FirmwareBundleTests(unittest.TestCase):
         (self.build / "project_description.json").write_text(json.dumps(self.description))
         (self.build / "flasher_args.json").write_text(json.dumps(self.flash))
 
-    def package(self, nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False):
+    def package(self, nvs_diagnostics=False, sdio_diagnostics=False, sdio_psram_rx=False,
+                camera_compat=False):
         self.write_metadata()
         return firmware.package_firmware(
             self.project, self.build, self.output, self.description["target"],
             self.provenance, self.dependencies, nvs_diagnostics, sdio_diagnostics, sdio_psram_rx,
+            camera_compat,
         )
 
     def test_relocated_bundle_preserves_every_image_and_original_inputs(self):
@@ -486,6 +490,76 @@ class FirmwareBundleTests(unittest.TestCase):
             self.assertEqual(len(expected["patches"]), 2)
             self.assertEqual(expected["patched_source_sha256"],
                              firmware.sha256(component / sdio.SOURCE_PATH))
+
+    @unittest.skipUnless(HAS_MANAGER, "actual component hashing runs in the IDF environment")
+    def test_camera_metadata_is_additive_and_revalidates_final_component_and_object(self):
+        self.configure_tab5()
+        self.config += "CONFIG_SPIRAM=y\nCONFIG_SOC_SDMMC_PSRAM_DMA_CAPABLE=y\n"
+        self.config += "".join(f"{k}={v}\n" for k, v in camera.PROFILE.items())
+        base = seed_camera_sdk(self.idf)
+        self.write_metadata()
+        with fixture_profile(base), component_fixture(
+                self.project, self.build, self.dependencies) as sdio_component, camera_fixture(
+                self.project, self.build, self.idf, self.dependencies) as camera_component:
+            expected_sdk = compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            expected_sdio = sdio.apply_component_patch(
+                self.project, sdio_component, self.build, self.dependencies, psram_rx=True)
+            camera.apply_component_patch(
+                self.project, camera_component, self.build, self.idf, self.dependencies)
+            with self.assertRaises(FileNotFoundError):
+                self.package(True, True, True, True)
+            self.assertFalse(self.output.exists())
+            source = camera_component / camera.SOURCE_PATH
+            write_object(self.build, source)
+            with self.assertRaises(ValueError):
+                self.package(True, True, True)
+            other = camera_component / "other.c"
+            original = other.read_bytes()
+            other.write_bytes(original + b"/* after-build tamper */\n")
+            with self.assertRaises(ValueError):
+                self.package(True, True, True, True)
+            self.assertFalse(self.output.exists())
+            other.write_bytes(original)
+            self.package(True, True, True, True)
+            manifest = json.loads((self.output / "manifest.json").read_text())
+            self.assertEqual(manifest["component_compatibility_patch"], expected_sdio)
+            for key, value in expected_sdk.items():
+                self.assertEqual(manifest["idf"][key], value)
+            self.assertEqual(manifest["camera_compatibility_patch"], camera.verify_component_patch(
+                self.project, camera_component, self.build, self.idf, self.dependencies))
+            self.assertEqual(manifest["camera_compatibility_patch"]["patched_source_sha256"],
+                             firmware.sha256(source))
+
+    def test_camera_profile_does_not_enable_itself_on_other_builds(self):
+        with self.assertRaises(ValueError):
+            self.package(camera_compat=True)
+        self.assertFalse(self.output.exists())
+        self.configure_tab5()
+        with self.assertRaises(ValueError):
+            self.package(camera_compat=True)
+        self.assertFalse(self.output.exists())
+
+    @unittest.skipUnless(HAS_MANAGER, "actual component hashing runs in the IDF environment")
+    def test_unpatched_rev3_packages_but_camera_patch_profile_rejects_it(self):
+        self.configure_tab5()
+        self.config += (
+            "CONFIG_ESP32P4_REV_MIN_FULL=300\nCONFIG_ESP32P4_REV_MAX_FULL=399\n"
+            "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=n\n"
+        )
+        self.description.update(min_rev="300", max_rev="399")
+        base = seed_camera_sdk(self.idf)
+        self.write_metadata()
+        with fixture_profile(base), camera_fixture(
+                self.project, self.build, self.idf, self.dependencies) as component:
+            compat.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+            before = {p: p.read_bytes() for p in component.rglob("*") if p.is_file()}
+            with self.assertRaisesRegex(ValueError, "unchanged early-P4 Tab5 profile"):
+                self.package(nvs_diagnostics=True, camera_compat=True)
+            self.assertFalse(self.output.exists())
+            self.package(nvs_diagnostics=True)
+            manifest = json.loads((self.output / "manifest.json").read_text())
+            self.assertNotIn("camera_compatibility_patch", manifest)
+            self.assertEqual({p: p.read_bytes() for p in before}, before)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_tab5_allocation_diagnostics.py
+++ b/scripts/tests/test_tab5_allocation_diagnostics.py
@@ -1,0 +1,167 @@
+"""Execute the Tab5 callback and real transport-start owner with bounded SDK stubs."""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+NODE = ROOT / "components/esp-openclaw-node"
+MAIN = ROOT / "examples/m5stack-tab5-room-node/main/main.c"
+FIXTURE = Path(__file__).parent / "fixtures/test_tab5_allocation_diagnostics.c"
+HEADERS = {
+    "esp_err.h": """#pragma once
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_FAIL -1
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERROR_CHECK(call) do { if ((call) != ESP_OK) abort(); } while (0)
+""",
+    "esp_attr.h": "#pragma once\n#define IRAM_ATTR\n#define DRAM_ATTR\n",
+    "esp_heap_caps.h": """#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+typedef void (*esp_alloc_failed_hook_t)(size_t, uint32_t, const char *);
+esp_err_t heap_caps_register_failed_alloc_callback(esp_alloc_failed_hook_t);
+size_t heap_caps_get_free_size(uint32_t);
+size_t heap_caps_get_largest_free_block(uint32_t);
+""",
+    "esp_log.h": """#pragma once
+void test_log(const char *, const char *, ...) __attribute__((format(printf, 2, 3)));
+#define ESP_LOGI(tag, ...) test_log(tag, __VA_ARGS__)
+#define ESP_LOGE(tag, ...) test_log(tag, __VA_ARGS__)
+""",
+    "freertos/FreeRTOS.h": """#pragma once
+typedef void *TaskHandle_t;
+int xPortInIsrContext(void);
+""",
+    "freertos/task.h": """#pragma once
+#include "freertos/FreeRTOS.h"
+TaskHandle_t xTaskGetCurrentTaskHandle(void);
+""",
+    "esp_openclaw_room_node.h": """#pragma once
+#include <stdlib.h>
+#include "esp_err.h"
+typedef struct { int unused; } esp_openclaw_room_node_config_t;
+esp_err_t esp_openclaw_room_node_start(const esp_openclaw_room_node_config_t *);
+""",
+    "tab5_room_board.h": """#pragma once
+#include "esp_openclaw_room_node.h"
+esp_err_t tab5_room_board_config(esp_openclaw_room_node_config_t *);
+""",
+    "forbid_alloc.h": """#include <stddef.h>
+void *test_forbidden_malloc(size_t);
+void *test_forbidden_calloc(size_t, size_t);
+void *test_forbidden_realloc(void *, size_t);
+int test_allocator_strncmp(const char *, const char *, size_t);
+#define malloc test_forbidden_malloc
+#define calloc test_forbidden_calloc
+#define realloc test_forbidden_realloc
+#define strncmp test_allocator_strncmp
+""",
+}
+
+
+class AllocationDiagnosticsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        temporary = tempfile.TemporaryDirectory(prefix="tab5-allocation-test-")
+        cls.addClassCleanup(temporary.cleanup)
+        directory = Path(temporary.name)
+        for name, content in HEADERS.items():
+            path = directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        transport = (NODE / "src/esp_openclaw_node_transport.c").read_text()
+        start = transport.index("esp_err_t esp_openclaw_node_start_transport_for_active_source(")
+        end = transport.index("\nvoid esp_openclaw_node_send_challenge_kick_ping(", start)
+        (directory / "transport_start_under_test.inc").write_text(transport[start:end])
+        start = transport.index("__attribute__((weak)) void esp_openclaw_node_transport_start_begin(")
+        end = transport.index("\nstatic void websocket_event_handler(", start)
+        (directory / "default_hooks.c").write_text(
+            '#include "esp_openclaw_node_transport_diag.h"\n' + transport[start:end]
+        )
+        common = [
+            os.environ.get("CC", "cc"), "-std=c11", "-D_POSIX_C_SOURCE=200809L",
+            "-Wall", "-Wextra", "-Werror", "-pthread",
+            "-fsanitize=address,undefined", "-fno-sanitize-recover=all",
+            "-I", str(directory), "-I", str(NODE / "private_include"),
+        ]
+        subprocess.run([
+            *common, "-include", str(directory / "forbid_alloc.h"), "-c",
+            os.environ.get("TAB5_ALLOCATION_MAIN", str(MAIN)), "-o", str(directory / "tab5.o"),
+        ], check=True, timeout=60)
+        cls.binary = directory / "allocation-test"
+        subprocess.run([
+            *common, str(FIXTURE), str(directory / "tab5.o"),
+            str(directory / "default_hooks.c"), "-o", str(cls.binary),
+        ], check=True, timeout=60)
+        # Link defaults independently, as non-Tab5 applications do.
+        (directory / "noop.c").write_text(
+            '#include "esp_openclaw_node_transport_diag.h"\n'
+            'int main(void) { esp_openclaw_node_transport_start_begin("node"); '
+            'esp_openclaw_node_transport_start_end("node", ESP_FAIL); return 0; }\n'
+        )
+        cls.noop = directory / "noop"
+        subprocess.run([
+            *common, str(directory / "noop.c"), str(directory / "default_hooks.c"),
+            "-o", str(cls.noop),
+        ], check=True, timeout=60)
+
+    def run_case(self, scenario):
+        result = subprocess.run(
+            [str(self.binary), scenario], capture_output=True, text=True, timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_first_capture_and_post_return_heap_phase(self):
+        self.run_case("capture")
+
+    def test_success_after_capture_and_failure_without_capture(self):
+        for scenario in ("captured-success", "uncaptured-failure", "success"):
+            with self.subTest(scenario=scenario):
+                self.run_case(scenario)
+
+    def test_isr_unrelated_task_unknown_allocator_and_disarm(self):
+        self.run_case("exclusions")
+
+    def test_role_isolation_and_concurrent_first_capture(self):
+        self.run_case("concurrent")
+
+    def test_rearming_and_original_transport_error_cleanup(self):
+        self.run_case("rearm")
+        for scenario in ("init-failure", "register-failure", "no-source"):
+            with self.subTest(scenario=scenario):
+                self.run_case(scenario)
+
+    def test_registration_before_board_and_nonfatal_registration_failure(self):
+        self.run_case("install-failure")
+
+    def test_other_boards_link_default_noop_hooks(self):
+        subprocess.run([str(self.noop)], check=True, timeout=20)
+        for binary, weak in ((self.binary, False), (self.noop, True)):
+            symbols = subprocess.run(
+                ["nm", "-m" if sys.platform == "darwin" else "-g", str(binary)],
+                check=True, capture_output=True, text=True, timeout=20,
+            ).stdout.splitlines()
+            for hook in (
+                "esp_openclaw_node_transport_start_begin",
+                "esp_openclaw_node_transport_start_end",
+            ):
+                name = "_" + hook if sys.platform == "darwin" else hook
+                matches = [line for line in symbols if line.split()[-1:] == [name]]
+                self.assertEqual(len(matches), 1, symbols)
+                if sys.platform == "darwin":
+                    self.assertIn("external", matches[0])
+                    self.assertEqual("weak external" in matches[0], weak, matches[0])
+                else:
+                    self.assertEqual(matches[0].split()[-2], "W" if weak else "T")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_tab5_camera_compat.py
+++ b/scripts/tests/test_tab5_camera_compat.py
@@ -1,8 +1,9 @@
 """Exercise exact component guards and the real upstream camera format mapper."""
 
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 import copy
 import difflib
+import io
 import json
 import os
 from pathlib import Path
@@ -130,6 +131,63 @@ class CameraPatchTests(unittest.TestCase):
     def verify(self, **options):
         return camera.verify_component_patch(
             self.project, self.component, self.build, self.idf, self.dependencies, **options)
+
+    def assert_cli_refusal(self, code, canary):
+        (self.project / "dependencies.lock").write_text(json.dumps(self.dependencies))
+        before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}
+        sdk_before = sdk.git(self.idf, "diff")
+        sdk_status = sdk.git(self.idf, "status", "--porcelain=v1")
+        stdout, stderr = io.StringIO(), io.StringIO()
+        arguments = [
+            "tab5_camera_compat.py", "--project-path", str(self.project),
+            "--component-path", str(self.component), "--build-path", str(self.build),
+            "--idf-path", str(self.idf),
+        ]
+        with patch.object(sys, "argv", arguments), redirect_stdout(stdout), redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as result:
+                camera.main()
+        self.assertEqual(result.exception.code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn(f"guard={code}", stderr.getvalue())
+        for value in (canary, str(self.root), "Traceback"):
+            self.assertNotIn(value, stdout.getvalue() + stderr.getvalue())
+        self.assertEqual(
+            {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}, before)
+        self.assertEqual(sdk.git(self.idf, "diff"), sdk_before)
+        self.assertEqual(sdk.git(self.idf, "status", "--porcelain=v1"), sdk_status)
+
+    def test_cli_classifies_real_camera_and_sdk_guards_before_apply(self):
+        canary = "synthetic-private-value-must-not-print"
+        self.dependencies["dependencies"][camera.COMPONENT]["version"] = canary
+        self.assert_cli_refusal("component_identity", canary)
+        self.dependencies["dependencies"][camera.COMPONENT]["version"] = camera.VERSION
+        config = self.config.read_text()
+        self.config.write_text(config.replace('CONFIG_IDF_TARGET="esp32p4"',
+                                              f'CONFIG_IDF_TARGET="{canary}"'))
+        self.assert_cli_refusal("early_p4_profile", canary)
+        self.config.write_text(config)
+        for module, name, code in (
+            (camera, "MANIFEST_SHA256", "component_manifest"),
+            (camera, "SDK_SOURCE_SHA256", "sdk_csi_contract"),
+            (sdk, "BASE_COMMIT", "sdk_base"),
+            (sdk, "PATCH_SHA256", "sdk_patch_bytes"),
+            (sdk, "ORIGINAL_SHA256", "sdk_base_source"),
+            (sdk, "PATCHED_SHA256", "sdk_patch_state"),
+        ):
+            with self.subTest(code=code), patch.object(module, name, canary):
+                self.assert_cli_refusal(code, canary)
+
+    def test_cli_unknown_errors_have_a_fixed_nonleaking_fallback(self):
+        canary = "synthetic-private-value-must-not-print"
+        for error in (
+            ValueError(canary),
+            ValueError("Build must compile exactly one camera format mapper " + canary),
+            OSError(5, canary, str(self.root / canary)),
+            subprocess.CalledProcessError(1, [canary], output=canary, stderr=canary),
+        ):
+            with self.subTest(error=type(error).__name__), patch.object(
+                    camera, "apply_component_patch", side_effect=error):
+                self.assert_cli_refusal("unclassified", canary)
 
     def test_exact_application_idempotence_integrity_markers_and_metadata(self):
         before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}

--- a/scripts/tests/test_tab5_camera_compat.py
+++ b/scripts/tests/test_tab5_camera_compat.py
@@ -67,10 +67,12 @@ def camera_fixture(project, build, idf, dependencies):
     patched_hash = directory_hash(component)
     source.write_bytes(ORIGINAL)
     patch_file = build / "camera-fixture.patch"
-    patch_file.write_text("".join(difflib.unified_diff(
-        ORIGINAL.decode().splitlines(keepends=True), PATCHED.decode().splitlines(keepends=True),
-        fromfile="a/" + camera.SOURCE_PATH, tofile="b/" + camera.SOURCE_PATH,
-    )))
+    patch_file.write_text(
+        f"diff --git a/{camera.SOURCE_PATH} b/{camera.SOURCE_PATH}\n"
+        + "".join(difflib.unified_diff(
+            ORIGINAL.decode().splitlines(keepends=True), PATCHED.decode().splitlines(keepends=True),
+            fromfile="a/" + camera.SOURCE_PATH, tofile="b/" + camera.SOURCE_PATH,
+        )))
     commands_file = build / "compile_commands.json"
     commands = json.loads(commands_file.read_text()) if commands_file.exists() else []
     commands.append({
@@ -190,6 +192,13 @@ class CameraPatchTests(unittest.TestCase):
                 self.assert_cli_refusal("unclassified", canary)
 
     def test_exact_application_idempotence_integrity_markers_and_metadata(self):
+        tracked = self.root / "tracked.txt"
+        tracked.write_text("Original caller-owned file.\n")
+        sdk.git(self.root, "add", "tracked.txt")
+        sdk.git(self.root, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.com",
+                "-c", "commit.gpgsign=false", "commit", "-qm", "Caller-owned file")
+        tracked.write_text("Preserve this caller edit.\n")
+        root_before = sdk.git(self.root, "diff", "--binary")
         before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}
         sdk_before = sdk.git(self.idf, "diff")
         expected = self.apply()
@@ -199,12 +208,46 @@ class CameraPatchTests(unittest.TestCase):
             if path != self.source:
                 self.assertEqual(path.read_bytes(), data)
         self.assertEqual(sdk.git(self.idf, "diff"), sdk_before)
+        self.assertEqual(sdk.git(self.root, "diff", "--binary"), root_before)
         output = write_object(self.build, self.source)
         verified = self.verify()
         self.assertEqual(verified["sdk_base_commit"], self.base)
         self.assertEqual(verified["patched_component_hash"], directory_hash(self.component))
         self.assertEqual(verified["patched_source_sha256"], camera.digest(PATCHED))
         self.assertEqual(verified["compiled_object"]["sha256"], camera.digest(output.read_bytes()))
+
+    def test_standalone_application_preserves_bytes_and_idempotence(self):
+        (self.root / ".git").rename(self.root / "saved-git-metadata")
+        before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}
+        sdk_before = sdk.git(self.idf, "diff")
+        result = self.apply()
+        self.assertEqual(self.apply(), result)
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+        for path, data in before.items():
+            if path != self.source:
+                self.assertEqual(path.read_bytes(), data)
+        self.assertEqual(sdk.git(self.idf, "diff"), sdk_before)
+
+    def test_cli_rejects_invalid_owner_config_instead_of_standalone_fallback(self):
+        canary = "synthetic-private-value-must-not-print"
+        (self.root / ".git/config").write_text(f"[invalid\n{canary}\n")
+        self.assert_cli_refusal("component_worktree", canary)
+
+    def test_cli_rejects_bare_repository_instead_of_standalone_fallback(self):
+        (self.root / ".git").rename(self.root / "saved-git-metadata")
+        sdk.git(self.root, "init", "--bare", "-q")
+        self.assert_cli_refusal("component_worktree", "synthetic-private-value-must-not-print")
+
+    def test_cli_rejects_broken_git_marker_instead_of_standalone_fallback(self):
+        (self.root / ".git").rename(self.root / "saved-git-metadata")
+        (self.root / ".git").mkdir()
+        self.assert_cli_refusal("component_worktree", "synthetic-private-value-must-not-print")
+
+    def test_cli_requires_component_containment_in_discovered_worktree(self):
+        outside = self.root / "other-worktree"
+        outside.mkdir()
+        sdk.git(self.root, "config", "core.worktree", str(outside))
+        self.assert_cli_refusal("component_worktree_path", "synthetic-private-value-must-not-print")
 
     def test_verification_never_mutates_and_requires_native_current_object(self):
         with self.assertRaises(ValueError):

--- a/scripts/tests/test_tab5_camera_compat.py
+++ b/scripts/tests/test_tab5_camera_compat.py
@@ -1,0 +1,327 @@
+"""Exercise exact component guards and the real upstream camera format mapper."""
+
+from contextlib import contextmanager
+import copy
+import difflib
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from test_idf_tab5_compat import fixture_profile, seed_sdk
+from test_tab5_sdio_diagnostics import HAS_MANAGER, directory_hash, REGISTRY_SOURCE
+import idf_tab5_compat as sdk
+import tab5_camera_compat as camera
+
+
+ORIGINAL = b"/* Synthetic camera component, not a pipeline simulation. */\nint original;\n"
+PATCHED = ORIGINAL.replace(b"original", b"patched")
+SDK_SOURCE = b"/* Synthetic pinned SDK CSI contract fixture. */\n"
+OBJECT_PATH = "esp-idf/esp_video/CMakeFiles/esp_video.dir/src/device/esp_video_csi_format.c.obj"
+
+
+def seed_camera_sdk(idf):
+    seed_sdk(idf)
+    source = idf / camera.SDK_SOURCE
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(SDK_SOURCE)
+    sdk.git(idf, "add", ".")
+    sdk.git(idf, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.com",
+            "-c", "commit.gpgsign=false", "commit", "-qm", "CSI contract fixture")
+    return sdk.git(idf, "rev-parse", "HEAD").decode().strip()
+
+
+def write_object(build, source):
+    output = build / OBJECT_PATH
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(b"\x7fELF\x01\x01" + b"\x00" * 10 + b"\x01\x00\xf3\x00fixture-object")
+    stamp = max(output.stat().st_mtime_ns, source.stat().st_mtime_ns + 1)
+    os.utime(output, ns=(stamp, stamp))
+    return output
+
+
+@contextmanager
+def camera_fixture(project, build, idf, dependencies):
+    component = project / "managed_components/espressif__esp_video"
+    source = component / camera.SOURCE_PATH
+    source.parent.mkdir(parents=True)
+    source.write_bytes(ORIGINAL)
+    (component / "other.c").write_text("/* Unrelated component source. */\n")
+    manifest = component / "idf_component.yml"
+    manifest.write_text(json.dumps({
+        "version": camera.VERSION,
+        "repository": "git://github.com/espressif/esp-video-components.git",
+        "repository_info": {"commit_sha": camera.REVISION, "path": "esp_video"},
+        "dependencies": {"idf": ">=5.4"},
+    }))
+    original_hash = directory_hash(component)
+    (component / ".component_hash").write_text(original_hash)
+    source.write_bytes(PATCHED)
+    patched_hash = directory_hash(component)
+    source.write_bytes(ORIGINAL)
+    patch_file = build / "camera-fixture.patch"
+    patch_file.write_text("".join(difflib.unified_diff(
+        ORIGINAL.decode().splitlines(keepends=True), PATCHED.decode().splitlines(keepends=True),
+        fromfile="a/" + camera.SOURCE_PATH, tofile="b/" + camera.SOURCE_PATH,
+    )))
+    commands_file = build / "compile_commands.json"
+    commands = json.loads(commands_file.read_text()) if commands_file.exists() else []
+    commands.append({
+        "directory": str(build), "file": str(source),
+        "arguments": ["riscv32-esp-elf-gcc", "-o", OBJECT_PATH, "-c", str(source)],
+    })
+    commands_file.write_text(json.dumps(commands))
+    dependencies["target"] = "esp32p4"
+    dependencies.setdefault("dependencies", {})[camera.COMPONENT] = {
+        "version": camera.VERSION, "component_hash": original_hash,
+        "source": copy.deepcopy(REGISTRY_SOURCE),
+    }
+    with patch.multiple(
+        camera, COMPONENT_HASH=original_hash, PATCHED_COMPONENT_HASH=patched_hash,
+        MANIFEST_SHA256=camera.digest(manifest.read_bytes()),
+        ORIGINAL_SHA256=camera.digest(ORIGINAL), PATCHED_SHA256=camera.digest(PATCHED),
+        PATCH_PATH=patch_file, PATCH_SHA256=camera.digest(patch_file.read_bytes()),
+        SDK_SOURCE_SHA256=camera.digest(SDK_SOURCE),
+        BASE_COMMIT=sdk.git(idf, "rev-parse", "HEAD").decode().strip(),
+    ):
+        yield component
+
+
+@unittest.skipUnless(HAS_MANAGER, "requires the real IDF component-manager environment")
+class CameraPatchTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="camera-compat-test-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name).resolve()
+        self.project = self.root / "examples/m5stack-tab5-room-node"
+        self.build = self.project / "build"
+        self.build.mkdir(parents=True)
+        self.idf = self.root / "idf"
+        self.idf.mkdir()
+        self.enterContext(patch.dict(os.environ, {
+            "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_NOSYSTEM": "1",
+        }))
+        for root in (self.root, self.idf):
+            sdk.git(root, "init", "-q")
+        self.base = seed_camera_sdk(self.idf)
+        self.enterContext(fixture_profile(self.base))
+        sdk.apply_sdk_patch(self.idf, nvs_diagnostics=True)
+        self.dependencies = {}
+        self.component = self.enterContext(camera_fixture(
+            self.project, self.build, self.idf, self.dependencies))
+        self.source = self.component / camera.SOURCE_PATH
+        self.config = self.project / "sdkconfig"
+        self.config.write_text("".join(f"{k}={v}\n" for k, v in camera.PROFILE.items()))
+        (self.build / "project_description.json").write_text(json.dumps({
+            "idf_path": str(self.idf), "project_path": str(self.project),
+            "build_dir": str(self.build), "target": "esp32p4", "config_file": str(self.config),
+        }))
+
+    def apply(self):
+        return camera.apply_component_patch(
+            self.project, self.component, self.build, self.idf, self.dependencies)
+
+    def verify(self, **options):
+        return camera.verify_component_patch(
+            self.project, self.component, self.build, self.idf, self.dependencies, **options)
+
+    def test_exact_application_idempotence_integrity_markers_and_metadata(self):
+        before = {p: p.read_bytes() for p in self.component.rglob("*") if p.is_file()}
+        sdk_before = sdk.git(self.idf, "diff")
+        expected = self.apply()
+        self.assertEqual(self.apply(), expected)
+        self.assertEqual(self.source.read_bytes(), PATCHED)
+        for path, data in before.items():
+            if path != self.source:
+                self.assertEqual(path.read_bytes(), data)
+        self.assertEqual(sdk.git(self.idf, "diff"), sdk_before)
+        output = write_object(self.build, self.source)
+        verified = self.verify()
+        self.assertEqual(verified["sdk_base_commit"], self.base)
+        self.assertEqual(verified["patched_component_hash"], directory_hash(self.component))
+        self.assertEqual(verified["patched_source_sha256"], camera.digest(PATCHED))
+        self.assertEqual(verified["compiled_object"]["sha256"], camera.digest(output.read_bytes()))
+
+    def test_verification_never_mutates_and_requires_native_current_object(self):
+        with self.assertRaises(ValueError):
+            self.verify()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.assertFalse(self.verify(patched=False, compiled=False)["modified"])
+        self.apply()
+        with self.assertRaises(FileNotFoundError):
+            self.verify()
+        output = write_object(self.build, self.source)
+        output.write_bytes(b"not-an-ELF")
+        with self.assertRaises(ValueError):
+            self.verify()
+        write_object(self.build, self.source)
+        os.utime(output, ns=(1, 1))
+        with self.assertRaises(ValueError):
+            self.verify()
+        write_object(self.build, self.source)
+        with self.assertRaises(ValueError):
+            self.verify(patched=False)
+
+    def test_wrong_sdk_or_tampered_contract_refuses_before_mutation(self):
+        for module, key in ((sdk, "BASE_COMMIT"), (camera, "SDK_SOURCE_SHA256")):
+            with self.subTest(key=key), patch.object(module, key, "0" * 64):
+                with self.assertRaises(ValueError):
+                    self.apply()
+                self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        (self.idf / camera.SDK_SOURCE).write_bytes(SDK_SOURCE + b"/* tampered */\n")
+        with self.assertRaises(ValueError):
+            self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_wrong_profile_lock_and_registry_key_fail_closed(self):
+        original = copy.deepcopy(self.dependencies)
+        for key, value in (("version", "2.4.0"), ("component_hash", "0" * 64),
+                           ("source", {"type": "service", "service_url": REGISTRY_SOURCE["registry_url"]})):
+            with self.subTest(key=key):
+                self.dependencies = copy.deepcopy(original)
+                self.dependencies["dependencies"][camera.COMPONENT][key] = value
+                with self.assertRaises(ValueError):
+                    self.apply()
+        self.dependencies = original
+        before = self.config.read_text()
+        for key in camera.PROFILE:
+            self.config.write_text(before.replace(f"{key}={camera.PROFILE[key]}", f"{key}=unexpected"))
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_patch_manifest_and_component_tampering_are_not_idempotence(self):
+        for name in ("PATCH_SHA256", "MANIFEST_SHA256"):
+            with self.subTest(name=name), patch.object(camera, name, "0" * 64):
+                with self.assertRaises(ValueError):
+                    self.apply()
+                self.assertEqual(self.source.read_bytes(), ORIGINAL)
+        self.apply()
+        write_object(self.build, self.source)
+        other = self.component / "other.c"
+        other.write_text("/* Changed after the build. */\n")
+        with self.assertRaises(ValueError):
+            self.verify()
+        with self.assertRaises(ValueError):
+            self.apply()
+        (self.component / ".component_hash").write_text(camera.PATCHED_COMPONENT_HASH)
+        with self.assertRaises(ValueError):
+            self.verify()
+
+    def test_native_compile_path_cannot_select_another_mapper(self):
+        path = self.build / "compile_commands.json"
+        original = json.loads(path.read_text())
+        wrong = self.build / Path(camera.SOURCE_PATH).name
+        wrong.write_bytes(ORIGINAL)
+        wrong_arguments = original[0]["arguments"][:-1] + [str(wrong)]
+        for commands in ([], original * 2, [{**original[0], "file": str(wrong)}],
+                         [{**original[0], "arguments": wrong_arguments}]):
+            path.write_text(json.dumps(commands))
+            with self.subTest(count=len(commands)), self.assertRaises(ValueError):
+                self.apply()
+        self.assertEqual(self.source.read_bytes(), ORIGINAL)
+
+    def test_native_command_string_resolves_the_same_source_and_output(self):
+        path = self.build / "compile_commands.json"
+        commands = json.loads(path.read_text())
+        commands[0]["command"] = shlex.join(commands[0].pop("arguments"))
+        path.write_text(json.dumps(commands))
+        self.apply()
+        write_object(self.build, self.source)
+        self.assertEqual(self.verify()["compiled_object"]["path"], OBJECT_PATH)
+
+    def test_symlink_and_post_build_source_changes_are_rejected(self):
+        link = self.component / "alias.c"
+        link.symlink_to(self.source)
+        with self.assertRaises(ValueError):
+            self.apply()
+        link.unlink()
+        self.apply()
+        write_object(self.build, self.source)
+        self.source.write_bytes(PATCHED + b"/* unexpected */\n")
+        with self.assertRaises(ValueError):
+            self.verify()
+
+
+class ActualMapperTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        component = Path(os.environ.get(
+            "ESP_VIDEO_COMPONENT_DIR", "managed_components/espressif__esp_video"))
+        source = component / camera.SOURCE_PATH
+        if not source.is_file():
+            raise unittest.SkipTest("requires the configured esp_video 2.4.1 source")
+        data = source.read_bytes()
+        source_hash = camera.digest(data)
+        if source_hash not in (camera.ORIGINAL_SHA256, camera.PATCHED_SHA256):
+            raise AssertionError("mapper fixture requires the pinned original or patched source")
+        temporary = tempfile.TemporaryDirectory(prefix="camera-mapper-test-")
+        cls.addClassCleanup(temporary.cleanup)
+        cls.root = Path(temporary.name)
+        original = cls.root / "original" / camera.SOURCE_PATH
+        original.parent.mkdir(parents=True)
+        original.write_bytes(data)
+        if source_hash == camera.PATCHED_SHA256:
+            subprocess.run(["git", "apply", "--reverse", str(camera.PATCH_PATH)],
+                           cwd=cls.root / "original", check=True)
+        if camera.digest(original.read_bytes()) != camera.ORIGINAL_SHA256:
+            raise AssertionError("original mapper reconstruction differs")
+        repaired = cls.root / "patched" / camera.SOURCE_PATH
+        repaired.parent.mkdir(parents=True)
+        repaired.write_bytes(original.read_bytes())
+        subprocess.run(["git", "apply", str(camera.PATCH_PATH)], cwd=cls.root / "patched", check=True)
+        if camera.digest(repaired.read_bytes()) != camera.PATCHED_SHA256:
+            raise AssertionError("patched mapper differs")
+        cls.binaries = {}
+        for name, path in (("original", original), ("patched", repaired)):
+            # Keep the complete upstream implementation; replace only its SDK includes.
+            include = cls.root / name / "camera_mapper_under_test.inc"
+            include.write_text("".join(
+                line for line in path.read_text().splitlines(keepends=True)
+                if not line.startswith("#include ")
+            ))
+            for version in ("0x050505", "0x060000"):
+                output = cls.root / f"{name}-{version}"
+                subprocess.run([
+                    os.environ.get("CC", "cc"), "-std=c11", "-Wall", "-Wextra", "-Werror",
+                    "-Wno-sign-compare", f"-DESP_IDF_VERSION={version}",
+                    "-I", str(include.parent),
+                    str(Path(__file__).parent / "fixtures/test_tab5_camera_format.c"),
+                    "-o", str(output),
+                ], check=True)
+                cls.binaries[name, version] = output
+
+    def run_case(self, name, case, version="0x050505"):
+        return subprocess.run([str(self.binaries[name, version]), case],
+                              capture_output=True, text=True)
+
+    def test_processing_is_red_on_original_and_green_on_repaired_mapper(self):
+        original = self.run_case("original", "processing")
+        self.assertEqual(original.returncode, 1, original.stdout + original.stderr)
+        self.assertIn("post-ISP CSI input mismatch", original.stderr)
+        repaired = self.run_case("patched", "processing")
+        self.assertEqual(repaired.returncode, 0, repaired.stdout + repaired.stderr)
+
+    def test_raw_bypass_and_unsupported_formats_are_unchanged(self):
+        for name in ("original", "patched"):
+            for case in ("bypass", "unsupported"):
+                with self.subTest(name=name, case=case):
+                    result = self.run_case(name, case)
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_existing_six_point_zero_mapping_is_unchanged(self):
+        for name in ("original", "patched"):
+            for case in ("processing", "bypass", "unsupported"):
+                with self.subTest(name=name, case=case):
+                    result = self.run_case(name, case, "0x060000")
+                    self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_tab5_camera_diagnostics.py
+++ b/scripts/tests/test_tab5_camera_diagnostics.py
@@ -23,6 +23,9 @@ class CameraCaptureDiagnosticsTests(unittest.TestCase):
         cls.addClassCleanup(temporary.cleanup)
         directory = Path(temporary.name)
         (directory / "camera_capture_under_test.inc").write_text(source[start:end])
+        handler_start = source.index("static esp_err_t camera_snap(")
+        handler_end = source.index("\nstatic esp_err_t storage_metrics(", handler_start)
+        (directory / "camera_handler_under_test.inc").write_text(source[handler_start:handler_end])
         cls.binary = directory / "camera-capture"
         subprocess.run([
             os.environ.get("CC", "cc"), "-std=c11", "-Wall", "-Wextra", "-Werror",
@@ -54,6 +57,19 @@ class CameraCaptureDiagnosticsTests(unittest.TestCase):
         for scenario in ("bsp-retry", "open-cache", "success-cache"):
             with self.subTest(scenario=scenario):
                 self.run_case(scenario)
+
+    def test_missing_frame_and_timeout_setup_fail_closed(self):
+        for scenario in ("missing-frame", "timeout-setup"):
+            with self.subTest(scenario=scenario):
+                self.run_case("handler-" + scenario)
+
+    def test_warmup_and_handler_stage_cleanup(self):
+        for scenario in (
+            "success", "warmup-max", "warmup-starved", "transform-failure",
+            "encode-failure", "quality-retry",
+        ):
+            with self.subTest(scenario=scenario):
+                self.run_case("handler-" + scenario)
 
 
 class CameraTransformTests(unittest.TestCase):

--- a/scripts/tests/test_tab5_camera_diagnostics.py
+++ b/scripts/tests/test_tab5_camera_diagnostics.py
@@ -1,4 +1,4 @@
-"""Execute the real capture owner against bounded V4L2 and logging stubs."""
+"""Execute the real capture and transform owners against bounded SDK stubs."""
 
 import os
 from pathlib import Path
@@ -10,6 +10,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 SOURCE = ROOT / "examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c"
 FIXTURE = Path(__file__).parent / "fixtures/test_tab5_camera_capture.c"
+TRANSFORM_FIXTURE = Path(__file__).parent / "fixtures/test_tab5_camera_transform.c"
 
 
 class CameraCaptureDiagnosticsTests(unittest.TestCase):
@@ -51,6 +52,44 @@ class CameraCaptureDiagnosticsTests(unittest.TestCase):
 
     def test_existing_initialization_cache_policy(self):
         for scenario in ("bsp-retry", "open-cache", "success-cache"):
+            with self.subTest(scenario=scenario):
+                self.run_case(scenario)
+
+
+class CameraTransformTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source = Path(os.environ.get("TAB5_CAMERA_SOURCE", SOURCE)).read_text()
+        start = source.index("typedef struct {\n    uint8_t *data;\n    size_t data_size;")
+        end = source.index("\nstatic esp_err_t camera_snap(", start)
+        constants = "\n".join(
+            line for line in source.splitlines() if line.startswith("#define CAMERA_")
+        )
+        temporary = tempfile.TemporaryDirectory(prefix="tab5-camera-transform-")
+        cls.addClassCleanup(temporary.cleanup)
+        directory = Path(temporary.name)
+        (directory / "camera_transform_under_test.inc").write_text(
+            constants + "\n" + source[start:end]
+        )
+        cls.binary = directory / "camera-transform"
+        subprocess.run([
+            os.environ.get("CC", "cc"), "-std=c11", "-Wall", "-Wextra", "-Werror",
+            "-fsanitize=address,undefined", "-fno-sanitize-recover=all",
+            "-I", str(directory), str(TRANSFORM_FIXTURE), "-o", str(cls.binary),
+        ], check=True)
+
+    def run_case(self, scenario):
+        result = subprocess.run([str(self.binary), scenario], capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_requested_640_matches_written_extent(self):
+        self.run_case("requested-640")
+
+    def test_native_minimum_scale_rotations_and_size_bounds(self):
+        self.run_case("geometry")
+
+    def test_allocation_and_ppa_failure_cleanup(self):
+        for scenario in ("allocation-failure", "ppa-failure"):
             with self.subTest(scenario=scenario):
                 self.run_case(scenario)
 


### PR DESCRIPTION
## Problem

Tab5 capture leaves ESP Video's ready-buffer wait at its default
`portMAX_DELAY`. The existing `delayMs` deadline is checked only after a
successful dequeue, so it does not bound a missing frame.

A recent camera attempt produced `dqbuf_begin` without later completion
evidence. That observation does not establish where it stalled; this change
addresses the independently verified unbounded ready-buffer wait and adds
stage timing without claiming an incident root cause.

Stacked on https://github.com/openclaw/esp-openclaw-node/pull/52.

## Changes

- Set a two-second per-dequeue timeout on every open through the existing
  `VIDIOC_S_DQBUF_TIMEOUT` ioctl. Fail closed through the existing capture
  cleanup path if configuration fails.
- Preserve warm-up/requeue semantics, capture formats, geometry, allocation
  policy, privacy indicator, and camera/Talk ownership. A missing frame fails
  without retry, including during warm-up.
- Add at most ten fixed-field INFO records for first dequeue return, selected
  capture, transform, encode, cleanup, and release. No per-frame trace or
  request identity; a region returning is not proof of success or sensor
  power-off.
- Extend the existing actual-source capture/handler fixture and document the
  finite wait and remaining blocking boundaries.

## Validation

- Original source compiles with the final fixture, then fails both intended
  regressions: the missing-frame wait remains infinite, and timeout setup is
  unchecked.
- Eight focused test methods pass with ASan/UBSan and
  `-Wall -Wextra -Werror`. Coverage includes setup failure, missing frames,
  partial cleanup, repeated open, zero/ten-second virtual warm-up, starvation,
  bounded stage records, transform/encode failures, and actual-handler release.
  Existing transform geometry tests also pass.
- Actionlint and `git diff --check` pass. No workflow change.
- Fresh scoped P2 autoreview and independent source-delta review found no
  actionable P0-P2 findings on the frozen four-file change.
- All five native CI jobs passed on head
  `33748b8c5b43db4f1c494677e75313f07c217969`:
  https://github.com/openclaw/esp-openclaw-node/actions/runs/34519194614.
- The verified Tab5 firmware was compiled from synthetic merge
  `14f511933af6fceaa0923b4a3457283eb4de36f5` (app version `14f5119`).
  Its parents and tree match the reviewed base/head. Artifact `10169253664`
  matches GitHub's SHA256
  `16f4d1d1f8e9bd7f8a323fe9c7e2c334470288888c087ad852e4343b94c9dc97`;
  all 11 internal checksums, 10 manifest file entries, and four offset-mapped
  images passed verification. The images do not overlap NVS, PHY, or storage.
- SDK `362a1776ec212788fda95f75b733bfdde3a0c394` with the existing tracked
  patches, component patch provenance, generated configuration, resolved
  dependency lock, and partition table match the previously verified PR52
  bundle. The post-Ninja camera-source verifier and strong-symbol link checks
  passed in CI. These checks do not establish reproducible builds or new
  hardware qualification.

## Bounded Physical Observations

- The exact `14f5119` image was flashed with four writes and four independent
  readbacks passing. Runtime identity and `device.info` confirmed this image.
- In the first keyless camera trial, all ten pipeline records were observed.
  First dequeue returned in 41 ms; selected capture was reported at 508 ms,
  transform at 119 ms, encode at 482 ms, cleanup at 2 ms, and release at 15 ms.
  These records show the instrumented regions returned, not that a valid
  JPEG reached the caller or that sensor power-off was verified.
- The camera RPC failed with `DISCONNECTED` after 10,816 ms. Same-node
  connection reconciliation was recorded immediately before the failure;
  host cleanup sent SIGTERM afterward. This ordering does not establish the
  disconnect's cause. No JPEG was delivered, and Canvas was not dispatched.
  No assertion, panic, or additional reset was observed beyond the single
  controlled boot.
- A second metadata-diagnostic attempt stopped at the test harness's
  `initial-drain-not-empty` guard, before Gateway startup or any RPC. It did
  not reach the camera. This was a harness preflight stop, not an additional
  firmware fault or camera qualification result.

## Limits

Two seconds is a policy allowance, not a measured maximum first-frame
latency. Setup, post-wait preprocessing, PPA, JPEG, logging, and cleanup can
still block; this is not a whole-command or Gateway timeout guarantee.

No dependency, SDK patch, format, allocator, retry, reset, or Gateway change.
Host fixtures do not prove actual sensor timing, PPA/JPEG output, teardown,
or media quality. The bounded physical observations above do not establish
successful camera delivery, image quality, or a resolved disconnect cause.
Voice remains inconclusive; no successful voice qualification is claimed.
Further physical qualification remains separate from source landing.

## Maintainer Disposition

Accept the two-second per-dequeue policy and its existing failure cleanup:
a camera that needs longer for a frame will now return the existing unavailable
result, including during warm-up. Keeping an indefinitely blocked dequeue is
not the selected default. This accepts that compatibility tradeoff; it does
not claim fresh/upgraded-device latency coverage or physical missing-frame
recovery. The actual-owner tests and exact-head native CI support the bounded
implementation, while the limitations above remain open.

Land after https://github.com/openclaw/esp-openclaw-node/pull/52 with a merge
commit and verified cumulative tree. Preserve accepted predecessor repairs.
No release, whole-request timing guarantee or successful voice qualification
is implied.
