### PR TITLE
fix(tab5): align camera RGB order with JPEG encoder

### DIFF
--- a/examples/m5stack-tab5-room-node/README.md
+++ b/examples/m5stack-tab5-room-node/README.md
@@ -376,6 +376,11 @@ PPA output pitch use the same dimensions, while the allocation retains its
 cache-line alignment. This geometry correction does not qualify color,
 exposure, warm-up or the complete camera pipeline.
 
+PPA's RGB888 memory order is B,G,R, while `esp_new_jpeg` expects R,G,B.
+The camera transform swaps red and blue for that encoder boundary. This
+corrects channel ordering; it does not establish the cause of an observed
+color cast or qualify sensor exposure and white balance.
+
 ### Media stage diagnostics
 
 The capture owner emits one `camera_capture_diag` failure with a fixed `stage`,

--- a/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
+++ b/examples/m5stack-tab5-room-node/components/tab5_room_board/tab5_room_board.c
@@ -1021,6 +1021,8 @@ static esp_err_t transform_camera_frame(
         .rotation_angle = rotation,
         .scale_x = scale,
         .scale_y = scale,
+        /* PPA RGB888 is B,G,R in memory; esp_new_jpeg expects R,G,B. */
+        .rgb_swap = true,
         .mode = PPA_TRANS_MODE_BLOCKING,
     };
     esp_err_t result = ppa_do_scale_rotate_mirror(camera_ppa_srm, &config);

--- a/scripts/tests/fixtures/test_tab5_camera_capture.c
+++ b/scripts/tests/fixtures/test_tab5_camera_capture.c
@@ -14,8 +14,10 @@
 #define ESP_FAIL -1
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERR_INVALID_STATE 0x103
 #define ESP_ERR_NO_MEM 0x101
 #define ESP_ERR_INVALID_SIZE 0x104
+#define ESP_ERR_NOT_SUPPORTED 0x106
 #define BSP_FAILURE 0x105
 #define TAG "camera-fixture"
 #define CAMERA_SENSOR_WIDTH 1280U
@@ -100,6 +102,9 @@ static void capture_log(const char *format, ...)
 #define ESP_RETURN_ON_ERROR(call, tag, ...) do { \
     esp_err_t error = (call); \
     if (error != ESP_OK) { ESP_LOGE(tag, __VA_ARGS__); return error; } \
+} while (0)
+#define ESP_RETURN_ON_FALSE(condition, error, tag, ...) do { \
+    if (!(condition)) return (error); \
 } while (0)
 
 static esp_err_t bsp_camera_start(const void *config)
@@ -310,25 +315,95 @@ static void esp_openclaw_room_node_release_camera(void)
     ++releases;
     clock_us += 3000;
 }
+enum { MALLOC_CAP_SPIRAM = 1, PPA_SRM_COLOR_MODE_RGB565,
+       PPA_SRM_COLOR_MODE_RGB888, PPA_TRANS_MODE_BLOCKING };
+typedef enum {
+    PPA_SRM_ROTATION_ANGLE_0, PPA_SRM_ROTATION_ANGLE_90,
+    PPA_SRM_ROTATION_ANGLE_180, PPA_SRM_ROTATION_ANGLE_270,
+} ppa_srm_rotation_angle_t;
 typedef struct {
-    uint8_t *data;
-    size_t data_size;
-    uint32_t width, height;
-} camera_transformed_frame_t;
-static esp_err_t transform_camera_frame(const camera_frame_t *camera, int width,
-                                        camera_transformed_frame_t *output)
+    void *buffer;
+    size_t buffer_size;
+    uint32_t pic_w, pic_h, block_w, block_h;
+    int srm_cm;
+} picture_t;
+typedef struct {
+    picture_t in, out;
+    ppa_srm_rotation_angle_t rotation_angle;
+    float scale_x, scale_y;
+    bool rgb_swap;
+    int mode;
+} ppa_srm_oper_config_t;
+#define BSP_CAMERA_ROTATION 0
+static int ppa_token;
+static void *camera_ppa_srm = &ppa_token;
+static size_t camera_ppa_alignment = 64;
+static void *transform_allocation;
+static unsigned transform_allocations, transform_frees;
+typedef struct {
+    const char *name;
+    uint16_t rgb565;
+    uint8_t rgb888[3];
+} color_case_t;
+static const color_case_t colors[] = {
+    {"color-red", 0xf800, {255, 0, 0}},
+    {"color-green", 0x07e0, {0, 255, 0}},
+    {"color-blue", 0x001f, {0, 0, 255}},
+    {"color-gray", 0x8410, {132, 130, 132}},
+};
+static const color_case_t *color_case;
+static void *heap_caps_aligned_calloc(size_t alignment, size_t count, size_t size, int caps)
 {
-    assert(camera->fd == 7 && camera->frame.index < 2 && width == 1024);
+    assert(alignment == 64 && count == 1 && size % alignment == 0 && caps == MALLOC_CAP_SPIRAM);
+    assert(transform_allocation == NULL);
+    transform_allocation = aligned_alloc(alignment, size);
+    assert(transform_allocation != NULL);
+    memset(transform_allocation, 0, size);
+    ++transform_allocations;
+    return transform_allocation;
+}
+static void heap_caps_free(void *memory)
+{
+    assert(memory != NULL && memory == transform_allocation);
+    free(memory);
+    transform_allocation = NULL;
+    ++transform_frees;
+}
+static const char *esp_err_to_name(esp_err_t error) { (void)error; return "synthetic-ppa-error"; }
+static esp_err_t ppa_do_scale_rotate_mirror(void *client, const ppa_srm_oper_config_t *config)
+{
+    assert(client == camera_ppa_srm && config->mode == PPA_TRANS_MODE_BLOCKING);
+    assert(config->in.srm_cm == PPA_SRM_COLOR_MODE_RGB565);
+    assert(config->out.srm_cm == PPA_SRM_COLOR_MODE_RGB888);
+    assert(config->rotation_angle == PPA_SRM_ROTATION_ANGLE_0);
+    assert(config->out.pic_w == 960 && config->out.pic_h == 540);
+    assert(config->out.buffer == transform_allocation);
     assert(lease_held && indicator_active && unmaps == 0);
     ++transforms;
     clock_us += 7000;
     if (is("transform-failure")) return ESP_FAIL;
-    *output = (camera_transformed_frame_t){.width = 800, .height = 800, .data_size = 800 * 800 * 3};
-    output->data = malloc(output->data_size);
-    assert(output->data != NULL);
+
+    const uint8_t *source = config->in.buffer;
+    uint16_t pixel = (uint16_t)source[0] | ((uint16_t)source[1] << 8);
+    uint8_t r5 = (pixel >> 11) & 31, g6 = (pixel >> 5) & 63, b5 = pixel & 31;
+    uint8_t r = (r5 << 3) | (r5 >> 2), g = (g6 << 2) | (g6 >> 4), b = (b5 << 3) | (b5 >> 2);
+    /* Model input R/B swap, then the pinned PPA's B,G,R output memory order. */
+    if (config->rgb_swap) {
+        uint8_t swap = r;
+        r = b;
+        b = swap;
+    }
+    uint8_t *output = config->out.buffer;
+    size_t size = (size_t)config->out.pic_w * config->out.pic_h * 3;
+    assert(size <= config->out.buffer_size);
+    for (size_t i = 0; i < size; i += 3) {
+        output[i] = b;
+        output[i + 1] = g;
+        output[i + 2] = r;
+    }
     return ESP_OK;
 }
-static void heap_caps_free(void *memory) { free(memory); }
+#include "camera_transform_under_test.inc"
 typedef struct {
     int width, height, src_type, subsampling;
     uint8_t quality;
@@ -343,7 +418,7 @@ typedef int jpeg_error_t;
 static int encoder_token;
 static jpeg_error_t jpeg_enc_open(const jpeg_enc_config_t *config, jpeg_enc_handle_t *encoder)
 {
-    assert(config->width == 800 && config->height == 800 && !config->task_enable);
+    assert(config->width == 960 && config->height == 540 && !config->task_enable);
     assert(config->src_type == JPEG_PIXEL_FORMAT_RGB888 && config->subsampling == JPEG_SUBSAMPLE_420);
     *encoder = &encoder_token;
     return JPEG_ERR_OK;
@@ -352,8 +427,18 @@ static jpeg_error_t jpeg_enc_process(jpeg_enc_handle_t encoder, const uint8_t *i
                                     int input_size, uint8_t *output, int capacity, int *size)
 {
     assert(encoder == &encoder_token && input != NULL && output != NULL);
-    assert(input_size == 800 * 800 * 3 && capacity == input_size + 1024);
+    assert(input == transform_allocation && input_size == 960 * 540 * 3 && capacity == input_size + 1024);
     assert(lease_held && indicator_active && unmaps == 0);
+    if (color_case != NULL) {
+        for (int i = 0; i < input_size; i += 3) {
+            if (memcmp(input + i, color_case->rgb888, 3) != 0) {
+                fprintf(stderr, "JPEG RGB888 ingress for %s: got %u,%u,%u, expected %u,%u,%u\n",
+                        color_case->name, input[i], input[i + 1], input[i + 2],
+                        color_case->rgb888[0], color_case->rgb888[1], color_case->rgb888[2]);
+                abort();
+            }
+        }
+    }
     ++encodes;
     clock_us += 2000;
     if (is("encode-failure")) return -1;
@@ -381,6 +466,18 @@ static const pipeline_record_t *pipeline(const char *stage)
 }
 static void run_handler(void)
 {
+    for (size_t i = 0; i < sizeof(colors) / sizeof(colors[0]); ++i) {
+        if (is(colors[i].name)) color_case = &colors[i];
+    }
+    if (color_case != NULL) {
+        /* Uniform frames keep color-order proof independent of resampling. */
+        for (size_t i = 0; i < sizeof(mapped) / sizeof(mapped[0]); ++i) {
+            for (size_t j = 0; j < sizeof(mapped[i]); j += 2) {
+                mapped[i][j] = (uint8_t)color_case->rgb565;
+                mapped[i][j + 1] = color_case->rgb565 >> 8;
+            }
+        }
+    }
     char *output = NULL;
     esp_openclaw_node_error_t error = {0};
     esp_err_t result = camera_snap(NULL, NULL, "{}", 2, &output, &error);
@@ -389,6 +486,7 @@ static void run_handler(void)
     assert(result == (failed ? ESP_FAIL : ESP_OK));
     assert(!lease_held && !indicator_active && releases == 1 && indicator_ends == 1);
     assert(parameter_deletes == 1 && closes == 1 && streamoffs == 1 && maps == unmaps);
+    assert(transform_allocation == NULL && transform_allocations == transform_frees);
     assert(timeout_sets == 1);
     assert(pipeline("cleanup_begin") != NULL && pipeline("cleanup_end") != NULL);
     assert(pipeline("cleanup_end")->elapsed_ms == (is("timeout-setup") ? 4U : 8U));
@@ -425,7 +523,7 @@ static void run_handler(void)
             if (is("encode-failure")) {
                 assert(strcmp(error.code, "INTERNAL") == 0 && output == NULL);
             } else {
-                assert(output != NULL && strstr(output, "\"width\":800,\"height\":800") != NULL);
+                assert(output != NULL && strstr(output, "\"width\":960,\"height\":540") != NULL);
             }
         }
     }

--- a/scripts/tests/fixtures/test_tab5_camera_transform.c
+++ b/scripts/tests/fixtures/test_tab5_camera_transform.c
@@ -25,6 +25,7 @@ typedef struct {
     picture_t in, out;
     ppa_srm_rotation_angle_t rotation_angle;
     float scale_x, scale_y;
+    bool rgb_swap;
     int mode;
 } ppa_srm_oper_config_t;
 typedef struct {

--- a/scripts/tests/test_tab5_camera_diagnostics.py
+++ b/scripts/tests/test_tab5_camera_diagnostics.py
@@ -26,6 +26,13 @@ class CameraCaptureDiagnosticsTests(unittest.TestCase):
         handler_start = source.index("static esp_err_t camera_snap(")
         handler_end = source.index("\nstatic esp_err_t storage_metrics(", handler_start)
         (directory / "camera_handler_under_test.inc").write_text(source[handler_start:handler_end])
+        transform_start = source.index("typedef struct {\n    uint8_t *data;\n    size_t data_size;")
+        constants = "\n".join(
+            line for line in source.splitlines() if line.startswith("#define CAMERA_")
+        )
+        (directory / "camera_transform_under_test.inc").write_text(
+            constants + "\n" + source[transform_start:handler_start]
+        )
         cls.binary = directory / "camera-capture"
         subprocess.run([
             os.environ.get("CC", "cc"), "-std=c11", "-Wall", "-Wextra", "-Werror",
@@ -70,6 +77,11 @@ class CameraCaptureDiagnosticsTests(unittest.TestCase):
         ):
             with self.subTest(scenario=scenario):
                 self.run_case("handler-" + scenario)
+
+    def test_rgb565_colors_reach_jpeg_as_rgb888(self):
+        for color in ("red", "green", "blue", "gray"):
+            with self.subTest(color=color):
+                self.run_case("handler-color-" + color)
 
 
 class CameraTransformTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

The Tab5 camera passes PPA RGB888 output directly to `esp_new_jpeg`. The pinned
PPA pixel layout is B,G,R in memory, while the encoder's RGB888 input contract
is R,G,B. Without a channel swap, red and blue reach the encoder reversed.

## Changes

- Enable PPA's existing input RGB channel-swap option at the camera transform.
- Keep ISP, white balance, rotation, quantized geometry, allocation, ownership,
  quality policy, SDK and dependencies unchanged in this PR's unique delta.
- Extend the existing actual-source fixture through `camera_snap`,
  `transform_camera_frame`, and the JPEG process boundary with independent
  red, green, blue and gray vectors.
- Document the byte-order boundary without claiming a fix for observed color
  cast or physical color accuracy.

The pinned SDK contracts are in
[color_types.h](https://github.com/espressif/esp-idf/blob/362a1776ec212788fda95f75b733bfdde3a0c394/components/hal/include/hal/color_types.h#L185)
and
[ppa.h](https://github.com/espressif/esp-idf/blob/362a1776ec212788fda95f75b733bfdde3a0c394/components/esp_driver_ppa/include/driver/ppa.h#L180).
The reviewed encoder contract is `espressif/esp_new_jpeg` 1.0.2.

## Validation

- Original production source compiled against the new fixture, then failed
  specifically on reversed red and blue at JPEG ingress; green and gray passed.
- All nine focused camera test methods passed again after current-main
  integration, with ASan/UBSan and warnings-as-errors. Coverage includes the
  existing geometry, warm-up, lifetime and failure-cleanup cases.
- The original semantic delta passed P2 autoreview and independent source
  review. The ancestry-only integration preserves that exact five-file delta.
- Diff whitespace and privacy checks passed.
- All five native jobs passed on the integrated head:
  https://github.com/openclaw/esp-openclaw-node/actions/runs/34754017538.
- All three CodeQL analyses passed:
  https://github.com/openclaw/esp-openclaw-node/actions/runs/34754016230.
  No extra workflow was dispatched.
- The Tab5 firmware archive was downloaded once and verified against its
  GitHub SHA256 and byte count. All 11 checksum records, ten manifest file
  records and four offset-mapped images passed verification. The image ranges
  do not overlap NVS, PHY initialization or storage partitions.

## Current-Main Integration

Originally stacked on https://github.com/openclaw/esp-openclaw-node/pull/55,
this PR now targets `main`. Signed merge commit
`e517b141cdd80ec3f979aefcfe4ca02a129d2f25` preserves the original signed head
`4f87df7d5b381b4d9f3b1a79364caff2c86dca11` and incorporates main
`f3f7719a9d2d75763c1645dcd758b61189c8e872`.

The candidate tree `a369f7a33734ca2d59e60205753b7d597fedcb13` exactly matches
current main plus the unchanged reviewed patch. GitHub's synthetic merge
`8f63e61a4f9fb0adf7f6dfac83dd44d5b9df79c6` has the same tree and the expected
main/head parents.

The archive identifies compiled source
`8f63e61a4f9fb0adf7f6dfac83dd44d5b9df79c6`, app version `8f63e61`, and the
qualified ESP-IDF image with the existing tracked patches. Firmware artifact
`10316388299` is 2,899,804 bytes, SHA256
`815a8f1ed89d6381a69a4c548c8577d793cd0e3d26fd6d01f1832cacf3999848`.
Symbols are retained in the same run but were not downloaded.

## Qualification

On September 13, 2026, candidate
`8f63e61a4f9fb0adf7f6dfac83dd44d5b9df79c6` was flashed to an M5Stack Tab5:
all four programmed images were verified, and a clean ESP32-P4 v1.3 boot
reached `app_main`. Both node and operator roles reconnected using saved
sessions. `device.info` confirmed the Tab5 and app version `8f63e61`; one
`camera.snap` RPC succeeded and returned a JPEG that decoded successfully.
The bounded run ended with its owned resources closed.

The inspected image was dark and nearly uniform, without an identifiable
scene. This proves a working capture/encode/RPC path, not optical RGB
calibration or usable scene quality. Physical color accuracy, exposure,
white balance and orientation remain unqualified. The cause of the dark
frame and previously observed color cast remains unknown. Voice qualification
is still pending; no successful voice exchange is claimed.

The owner has explicitly approved landing this narrow, source-contract-backed
channel-order correction with those optical limitations, releasing the draft
hold. The production delta remains one option and its explanatory comment;
the PPA/JPEG boundaries in the color fixtures are modeled, not physical color
measurements. No orientation, exposure or white-balance repair is included.
Landing is by merge commit to preserve the original signed series. No release,
OTA, secure-provisioning or other-device work is included.
