### PR TITLE
fix(ci): pin Tab5 to qualified ESP-IDF image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           - name: m5stack-tab5-room-node
             path: examples/m5stack-tab5-room-node
             target: esp32p4
+            # Keep the image qualified with the exact Tab5 SDK patches.
+            idf_version: release-v5.5@sha256:b05ef8f0e05ba8128668fce03a5798ea175ca94829d6bc4cf15f744895fd8482
 
     name: ${{ matrix.name }} (${{ matrix.target }})
     steps:
@@ -75,7 +77,7 @@ jobs:
       - name: Build
         uses: espressif/esp-idf-ci-action@v1
         with:
-          esp_idf_version: release-v5.5
+          esp_idf_version: ${{ matrix.idf_version || 'release-v5.5' }}
           target: ${{ matrix.target }}
           path: ${{ matrix.path }}
           command: |
@@ -104,7 +106,7 @@ jobs:
                 --pr-head-sha "${{ github.event.pull_request.head.sha }}" \
                 --run-id "${{ github.run_id }}" \
                 --run-attempt "${{ github.run_attempt }}" \
-                --idf-image "espressif/idf:release-v5.5" \
+                --idf-image "espressif/idf:${{ matrix.idf_version || 'release-v5.5' }}" \
                 $nvs_diagnostics
             fi
 


### PR DESCRIPTION
## Problem

The moving `espressif/idf:release-v5.5` image no longer supplies the SDK base
required by the reviewed Tab5 compatibility patches. The
[main build after PR42](https://github.com/openclaw/esp-openclaw-node/actions/runs/34675798457)
pulled image digest
`sha256:5976da28fd46671f66d8f96908e166f99bc34d1fc24f516ead9a8fbef9bdc109`
and correctly refused before compilation:
`SDK compatibility patch refused: SDK is not at the approved compatibility-patch base`.

## Change

- Pin only the Tab5 matrix row to
  `release-v5.5@sha256:b05ef8f0e05ba8128668fce03a5798ea175ca94829d6bc4cf15f744895fd8482`,
  the image used by the retained successful build with SDK
  `362a1776ec212788fda95f75b733bfdde3a0c394`.
- Use the same selected version in the action input and the complete
  `espressif/idf:` image reference passed to firmware packaging.
- Keep the other four lanes on `release-v5.5`. The action, SDK guards, vendor
  patches, application configuration, and manual-only release workflow are
  unchanged.

This restores the previously qualified build input; it is not an SDK upgrade
or a guard bypass.

## Validation

- Actionlint and `git diff --check` passed.
- Parsed-YAML validation confirmed exactly five lanes, only one image override,
  identical action/provenance selections, and no other workflow-field changes.
- The registry returned HTTP200 for the pinned image index. Its bytes and
  `Docker-Content-Digest` matched the requested digest, with a Linux amd64
  descriptor present. This was a metadata-only check, not a new image pull.
- Fresh focused autoreview through P2 found no actionable issues.
- Independent source and implementation reviews cleared the same frozen diff.
- All five native CI jobs passed in
  [run 34700508207](https://github.com/openclaw/esp-openclaw-node/actions/runs/34700508207)
  for head `0144f89c09dc48e33332edb709be5b99a5ec38e4` and test merge
  `bd4b4f8722700989de7f6873993477b7f3f296f8`. CodeQL also passed.
  The component test-app job includes compilation; this does not claim its
  target-only Unity tests ran on hardware.
- No local SDK build, Docker-layer download, hardware test, provider call, or
  release was performed for this repair.

The existing SDK plus tracked compatibility/diagnostic patches remain
explicitly identified in firmware provenance. Broader hardware, encrypted
media, camera color, and successful end-to-end voice qualification are not
claimed by this CI repair.
